### PR TITLE
Setting the placement target when opening the context menu.

### DIFF
--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -631,7 +631,7 @@ namespace OxyPlot.Wpf
                 {
                     // TODO: why is the data context not passed to the context menu??
                     this.ContextMenu.DataContext = this.DataContext;
-
+                    this.ContextMenu.PlacementTarget = this;
                     this.ContextMenu.Visibility = Visibility.Visible;
                     this.ContextMenu.IsOpen = true;
                 }


### PR DESCRIPTION
The PlacementTarget Property is always null on the context menu of the plot view, which is probably not intended.
