### PR TITLE
Fix .NET 3.5 builds

### DIFF
--- a/Source/Examples/ExampleLibrary/ExampleLibrary_NET35.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary_NET35.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.XML" />
   </ItemGroup>

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -15,8 +15,6 @@ namespace ExampleLibrary
     using System.IO;
     using System.Reflection;
     using System.Threading;
-    using System.Threading.Tasks;
-    using System.Xml;
     using System.Xml.Serialization;
 
     using OxyPlot;

--- a/Source/OxyPlot/OxyPlot_NET35.csproj
+++ b/Source/OxyPlot/OxyPlot_NET35.csproj
@@ -104,7 +104,7 @@
     <Compile Include="Rendering\Utilities\Decimator.cs" />
     <Compile Include="Rendering\Utilities\SutherlandHodgmanClipping.cs" />
     <Compile Include="Rendering\Utilities\CohenSutherlandClipping.cs" />
-    <Compile Include="Rendering\OxyPenLineJoin.cs" />
+    <Compile Include="Rendering\LineJoin.cs" />
     <Compile Include="Rendering\HorizontalAlignment.cs" />
     <Compile Include="Rendering\VerticalAlignment.cs" />
     <Compile Include="Rendering\OxyColor.cs" />


### PR DESCRIPTION
.NET 3.5 builds were broken once again.

Would be great to have them back in the NuGet package, by the way :-)
