### PR TITLE
Update LineSeries.cs

### DIFF
--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -351,7 +351,7 @@ namespace OxyPlot.Series
         public override void Render(IRenderContext rc, PlotModel model)
         {
             var actualPoints = this.ActualPoints;
-            if (actualPoints.Count == 0)
+            if (actualPoints == null || actualPoints.Count == 0)
             {
                 return;
             }


### PR DESCRIPTION
Prevent null reference with MVVM binding values, example:
<OxyPlot:LineSeries ItemsSource="{Binding MyIEnumerableValueCollection}"  />
