### PR TITLE
Fix view not updating when Model is changed.

### DIFF
--- a/Source/OxyPlot.XamarinFormsIOS/PlotViewRenderer.cs
+++ b/Source/OxyPlot.XamarinFormsIOS/PlotViewRenderer.cs
@@ -60,6 +60,7 @@ namespace OxyPlot.XamarinFormsIOS
             if (e.PropertyName == XamarinForms.PlotView.ModelProperty.PropertyName)
             {
                 this.Control.Model = Element.Model;
+                this.Control.SetNeedsLayout();
             }
 
             if (e.PropertyName == XamarinForms.PlotView.ControllerProperty.PropertyName)


### PR DESCRIPTION
Consider the following binding

```
plotView.SetBinding(PlotView.ModelProperty, "PlotModel");
```

This updates the model when the property is changed in the ViewModel. However these changes are not reflected in the View. When adding `SetNeedsLayout` after the Model is set in the code. The changes now reflects in the UI.
