### PR TITLE
Issue #227 - Fixed floating point noise accumulation in axis marks

### DIFF
--- a/Source/OxyPlot.Tests/Axes/AxisUtilitiesTests.cs
+++ b/Source/OxyPlot.Tests/Axes/AxisUtilitiesTests.cs
@@ -102,6 +102,19 @@ namespace OxyPlot.Tests
                 var values = Axis.CreateTickValues(0, Math.PI * 2, Math.PI);
                 CollectionAssert.AreEqual(new[] { 0, Math.PI, Math.PI * 2 }, values);
             }
+
+            /// <summary>
+            /// Ensures tick values are not including floating point error to such an extent that it would show up when printed 
+            /// </summary>
+            [Test]
+            public void FloatingPointAccumulation()
+            {
+                var values = Axis.CreateTickValues(0.58666699999999994, 0.9233, 0.05);
+                foreach (var val in values)
+                {
+                    Assert.LessOrEqual(string.Format("{0:}", val).Length, 4);
+                }
+            }
         }
     }
 }

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -654,17 +654,22 @@ namespace OxyPlot.Axes
             var startValue = Math.Round(from / step) * step;
             var numberOfValues = Math.Max((int)((to - from) / step), 1);
             var epsilon = step * 1e-3 * Math.Sign(step);
-            var values = new List<double>(numberOfValues);
-            var i = 0;
+            var values = new List<double>(numberOfValues);            
             var lastValue = startValue;
 
-            while (startValue + (step * i) <= to + epsilon && i < maxTicks)
+            for (int k = 0; k < maxTicks; k++)
             {
-                lastValue = startValue + (step * i++);
+                lastValue = startValue + (step * k);
+
+                // If we hit the maximum value before reaching the max number of ticks, exit
+                if (lastValue > to + epsilon)
+                {
+                    break;
+                }
 
                 // try to get rid of numerical noise
                 var v = Math.Round(lastValue / step, 14) * step;
-                values.Add(v);                
+                values.Add(v);
             }
 
             return values;


### PR DESCRIPTION
Just to recap, there were cases in which axis labels would have way too many decimal places (e.g. "0.900000000000001").  I changed the label generation code to multiply by the step size instead of repeatedly adding to avoid round-off error accumulation.  I tested this against the code put up by the original bug reporter as well as some cases I was running into and it seems to fix the problem nicely.
