### PR TITLE
Possible fix for issue #301: The plot labels placed strangely for some specific axis angles

### DIFF
--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -749,7 +749,7 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
-        [Example("Wrong label placement for category axis when Angle = 45")]
+        [Example("#301: Wrong label placement for category axis when Angle = 45 (closed)")]
         public static PlotModel LabelPlacementCategoryAxisWhenAxisAngleIs45()
         {
             var plotModel1 = new PlotModel { Title = "Wrong label placement for category axis when Angle = 45", Subtitle = "The labels should not be clipped. Click on text annotation to change tha angle." };

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -375,19 +375,23 @@ namespace OxyPlot.Axes
                 {
                     case AxisPosition.Left:
                         pt = new ScreenPoint(axisPosition + a1 - axis.AxisTickToLabelDistance, transformedValue);
-                        ha = axis.Angle >= -90 && axis.Angle < 90 ? HorizontalAlignment.Right : HorizontalAlignment.Left;
+                        this.GetRotatedAlignments(axis.Angle, -90, out ha, out va);
+
                         break;
                     case AxisPosition.Right:
                         pt = new ScreenPoint(axisPosition + a1 + axis.AxisTickToLabelDistance, transformedValue);
-                        ha = axis.Angle >= -90 && axis.Angle < 90 ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+                        this.GetRotatedAlignments(axis.Angle, 90, out ha, out va);
+
                         break;
                     case AxisPosition.Top:
                         pt = new ScreenPoint(transformedValue, axisPosition + a1 - axis.AxisTickToLabelDistance);
-                        ha = axis.Angle >= 0 ? HorizontalAlignment.Right : HorizontalAlignment.Left;
+                        this.GetRotatedAlignments(axis.Angle, 0, out ha, out va);
+
                         break;
                     case AxisPosition.Bottom:
                         pt = new ScreenPoint(transformedValue, axisPosition + a1 + axis.AxisTickToLabelDistance);
-                        ha = axis.Angle >= 0 ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+                        this.GetRotatedAlignments(axis.Angle, -180, out ha, out va);
+
                         break;
                 }
 
@@ -582,6 +586,50 @@ namespace OxyPlot.Axes
             if (this.MinorTickPen != null)
             {
                 this.RenderContext.DrawLineSegments(minorTickSegments, this.MinorTickPen);
+            }
+        }
+
+        /// <summary>
+        /// Gets the alignments given the specified rotation angle.
+        /// </summary>
+        /// <param name="angle">The angle.</param>
+        /// <param name="axisAngle">The axis angle, the original angle belongs to.</param>
+        /// <param name="ha">Horizontal alignment.</param>
+        /// <param name="va">Vertical alignment.</param>
+        private void GetRotatedAlignments(
+            double angle,
+            double axisAngle,
+            out HorizontalAlignment ha,
+            out VerticalAlignment va)
+        {
+            const double AngleTolerance = 10;
+
+            double flippedAxisAngle = ((axisAngle + 360) % 360) - 180;
+
+            ha = angle >= Math.Min(axisAngle, flippedAxisAngle) && angle < Math.Max(axisAngle, flippedAxisAngle) ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+            va = VerticalAlignment.Middle;
+
+            // If the angle of axis is flipped - flip the horizontal alignment
+            if (axisAngle < 0)
+            {
+                ha = (HorizontalAlignment)((int)ha * -1);
+            }
+
+            // If the angle almost the same as axisAngle - set horizontal alignment to Center
+            if (Math.Abs(angle - flippedAxisAngle) < AngleTolerance || Math.Abs(angle - axisAngle) < AngleTolerance)
+            {
+                ha = HorizontalAlignment.Center;
+            }
+
+            // And vertical alignment according to whether it is near to axisAngle or flippedAxisAngle
+            if (Math.Abs(angle - axisAngle) < AngleTolerance)
+            {
+                va = VerticalAlignment.Bottom;
+            }
+
+            if (Math.Abs(angle - flippedAxisAngle) < AngleTolerance)
+            {
+                va = VerticalAlignment.Top;
             }
         }
     }

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -219,52 +219,6 @@ namespace OxyPlot.Axes
         }
 
         /// <summary>
-        /// Gets the alignments given the specified rotation angle.
-        /// </summary>
-        /// <param name="angle">The angle.</param>
-        /// <param name="defaultHorizontalAlignment">The default horizontal alignment.</param>
-        /// <param name="defaultVerticalAlignment">The default vertical alignment.</param>
-        /// <param name="ha">The rotated horizontal alignment.</param>
-        /// <param name="va">The rotated vertical alignment.</param>
-        protected virtual void GetRotatedAlignments(
-            double angle,
-            HorizontalAlignment defaultHorizontalAlignment,
-            VerticalAlignment defaultVerticalAlignment,
-            out HorizontalAlignment ha,
-            out VerticalAlignment va)
-        {
-            ha = defaultHorizontalAlignment;
-            va = defaultVerticalAlignment;
-
-            Debug.Assert(angle <= 180 && angle >= -180, "Axis angle should be in the interval [-180,180] degrees.");
-
-            if (angle > -45 && angle < 45)
-            {
-                return;
-            }
-
-            if (angle > 135 || angle < -135)
-            {
-                ha = (HorizontalAlignment)(-(int)defaultHorizontalAlignment);
-                va = (VerticalAlignment)(-(int)defaultVerticalAlignment);
-                return;
-            }
-
-            if (angle > 45)
-            {
-                ha = (HorizontalAlignment)((int)defaultVerticalAlignment);
-                va = (VerticalAlignment)(-(int)defaultHorizontalAlignment);
-                return;
-            }
-
-            if (angle < -45)
-            {
-                ha = (HorizontalAlignment)(-(int)defaultVerticalAlignment);
-                va = (VerticalAlignment)((int)defaultHorizontalAlignment);
-            }
-        }
-
-        /// <summary>
         /// Renders the axis title.
         /// </summary>
         /// <param name="axis">The axis.</param>
@@ -421,39 +375,19 @@ namespace OxyPlot.Axes
                 {
                     case AxisPosition.Left:
                         pt = new ScreenPoint(axisPosition + a1 - axis.AxisTickToLabelDistance, transformedValue);
-                        this.GetRotatedAlignments(
-                            axis.Angle,
-                            HorizontalAlignment.Right,
-                            VerticalAlignment.Middle,
-                            out ha,
-                            out va);
+                        ha = axis.Angle >= -90 && axis.Angle < 90 ? HorizontalAlignment.Right : HorizontalAlignment.Left;
                         break;
                     case AxisPosition.Right:
                         pt = new ScreenPoint(axisPosition + a1 + axis.AxisTickToLabelDistance, transformedValue);
-                        this.GetRotatedAlignments(
-                            axis.Angle,
-                            HorizontalAlignment.Left,
-                            VerticalAlignment.Middle,
-                            out ha,
-                            out va);
+                        ha = axis.Angle >= -90 && axis.Angle < 90 ? HorizontalAlignment.Left : HorizontalAlignment.Right;
                         break;
                     case AxisPosition.Top:
                         pt = new ScreenPoint(transformedValue, axisPosition + a1 - axis.AxisTickToLabelDistance);
-                        this.GetRotatedAlignments(
-                            axis.Angle,
-                            HorizontalAlignment.Center,
-                            VerticalAlignment.Bottom,
-                            out ha,
-                            out va);
+                        ha = axis.Angle >= 0 ? HorizontalAlignment.Right : HorizontalAlignment.Left;
                         break;
                     case AxisPosition.Bottom:
                         pt = new ScreenPoint(transformedValue, axisPosition + a1 + axis.AxisTickToLabelDistance);
-                        this.GetRotatedAlignments(
-                            axis.Angle,
-                            HorizontalAlignment.Center,
-                            VerticalAlignment.Top,
-                            out ha,
-                            out va);
+                        ha = axis.Angle >= 0 ? HorizontalAlignment.Left : HorizontalAlignment.Right;
                         break;
                 }
 


### PR DESCRIPTION
Issue: https://github.com/oxyplot/oxyplot/issues/301

The horizontal alignment is kept the same as `Center`. I don't think it is ever needed to be something else, isn't it?