### PR TITLE
Custom colors for scatters

### DIFF
--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -415,7 +415,7 @@ namespace OxyPlot.Series
                         this.MarkerType,
                         this.MarkerOutline,
                         groupSizes[group.Key],
-                        this.MarkerFill.Equals(OxyColors.Automatic) ? color : this.MarkerFill,
+                        this.MarkerFill.GetActualColor(color),
                         markerIsStrokedOnly ? color : this.MarkerStroke,
                         this.MarkerStrokeThickness,
                         this.BinSize,

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -415,7 +415,7 @@ namespace OxyPlot.Series
                         this.MarkerType,
                         this.MarkerOutline,
                         groupSizes[group.Key],
-                        color,
+                        this.MarkerFill.Equals(OxyColors.Automatic) ? color : this.MarkerFill,
                         markerIsStrokedOnly ? color : this.MarkerStroke,
                         this.MarkerStrokeThickness,
                         this.BinSize,


### PR DESCRIPTION
If MarkerFill color is set (i.e. not default OxyColors.Automatic), then fill scatters with MarkerFill.

https://github.com/oxyplot/oxyplot/issues/271