### PR TITLE
Issue #336: Fixed multitouch instability

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@ Benoit Blanchon <>
 br
 brantheman
 Brannon King
+Caleb Clarke <thealmightybob@users.noreply.github.com>
 darrelbrown
 David Laundav <davelaundav@gmail.com>
 David Wong <dvkwong0@gmail.com>

--- a/Source/Examples/Xamarin.iOS/ExampleBrowser/Info.plist
+++ b/Source/Examples/Xamarin.iOS/ExampleBrowser/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.3.0</string>
 	<key>MinimumOSVersion</key>
-	<string>5.0</string>
+	<string>5.2</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
@@ -36,5 +36,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string></string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
 </dict>
 </plist>

--- a/Source/OxyPlot.MonoTouch/PlotView.cs
+++ b/Source/OxyPlot.MonoTouch/PlotView.cs
@@ -11,6 +11,9 @@ namespace OxyPlot.MonoTouch
 {
     using global::MonoTouch.Foundation;
     using global::MonoTouch.UIKit;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using OxyPlot;
 
     /// <summary>
@@ -28,7 +31,18 @@ namespace OxyPlot.MonoTouch
         /// The default plot controller.
         /// </summary>
         private IPlotController defaultController;
-               
+
+        /// <summary>
+        /// Up to 2 touches being currently tracked in a pan/zoom.
+        /// </summary>
+        private List<UITouch> activeTouches = new List<UITouch>();
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis
+        /// </summary>
+        private const double threshold = 20d;
+
+
         /// <summary>
         /// Initializes a new instance of the <see cref="OxyPlot.XamarinIOS.PlotView"/> class.
         /// </summary>
@@ -286,11 +300,24 @@ namespace OxyPlot.MonoTouch
         /// <param name="evt">The event arguments.</param>
         public override void TouchesBegan(NSSet touches, UIEvent evt)
         {
-            base.TouchesBegan(touches, evt);
-            var touch = touches.AnyObject as UITouch;
-            if (touch != null)
+            if (this.activeTouches.Count >= 2)
             {
-                this.ActualController.HandleTouchStarted(this, touch.ToTouchEventArgs(this));
+                // we already have two touches
+                return;
+            }
+
+            // Grab 1-2 touches to track
+            var newTouches = touches.ToArray<UITouch>();
+            var firstTouch = !this.activeTouches.Any();
+
+            activeTouches.AddRange(newTouches.Take(2 - this.activeTouches.Count));
+
+            if (firstTouch)
+            {
+                // HandleTouchStarted initializes the entire multitouch gesture,
+                // with the first touch used for panning.
+                //
+                ActualController.HandleTouchStarted(this, this.activeTouches.First().ToTouchEventArgs(this));
             }
         }
 
@@ -301,33 +328,31 @@ namespace OxyPlot.MonoTouch
         /// <param name="evt">The event arguments.</param>
         public override void TouchesMoved(NSSet touches, UIEvent evt)
         {
-            // it seems to be easier to handle touch events here than using UIPanGesturRecognizer and UIPinchGestureRecognizer
-            base.TouchesMoved(touches, evt);
-
-            // convert the touch points to an array
-            var ta = touches.ToArray<UITouch>();
-
-            if (ta.Length > 0)
+            if (activeTouches.Count > 0)
             {
                 // get current and previous location of the first touch point
-                var t1 = ta[0];
+                var t1 = this.activeTouches.First();
                 var l1 = t1.LocationInView(this).ToScreenPoint();
-                var pl1 = t1.PreviousLocationInView(this).ToScreenPoint();
+                var pl1 = t1.Phase == UITouchPhase.Moved ? t1.PreviousLocationInView(this).ToScreenPoint() : l1;
+
                 var l = l1;
                 var t = l1 - pl1;
                 var s = new ScreenVector(1, 1);
-                if (ta.Length > 1)
+
+                if (activeTouches.Count > 1)
                 {
                     // get current and previous location of the second touch point
-                    var t2 = ta[1];
+                    var t2 = this.activeTouches.ElementAt(1);
                     var l2 = t2.LocationInView(this).ToScreenPoint();
-                    var pl2 = t2.PreviousLocationInView(this).ToScreenPoint();
+                    var pl2 = t2.Phase == UITouchPhase.Moved ? t2.PreviousLocationInView(this).ToScreenPoint() : l2;
+
                     var d = l1 - l2;
                     var pd = pl1 - pl2;
+
                     if (!this.KeepAspectRatioWhenPinching)
                     {
-                        var scalex = System.Math.Abs(pd.X) > 0 ? System.Math.Abs(d.X / pd.X) : 1;
-                        var scaley = System.Math.Abs(pd.Y) > 0 ? System.Math.Abs(d.Y / pd.Y) : 1;
+                        var scalex = Math.Abs(pd.X) > PlotView.threshold && Math.Abs(d.X) > PlotView.threshold ? Math.Abs(d.X / pd.X) : 1;
+                        var scaley = Math.Abs(pd.Y) > PlotView.threshold && Math.Abs(d.Y) > PlotView.threshold ? Math.Abs(d.Y / pd.Y) : 1;
                         s = new ScreenVector(scalex, scaley);
                     }
                     else
@@ -349,11 +374,29 @@ namespace OxyPlot.MonoTouch
         /// <param name="evt">The event arguments.</param>
         public override void TouchesEnded(NSSet touches, UIEvent evt)
         {
-            base.TouchesEnded(touches, evt);
-            var touch = touches.AnyObject as UITouch;
-            if (touch != null)
+            // We already have the only two touches we care about, so ignore the params
+            //
+            var secondTouch = this.activeTouches.ElementAtOrDefault(1);
+
+            if (secondTouch != null && secondTouch.Phase == UITouchPhase.Ended)
             {
-                this.ActualController.HandleTouchCompleted(this, touch.ToTouchEventArgs(this));
+                this.activeTouches.Remove(secondTouch);
+            }
+
+            var firstTouch = this.activeTouches.FirstOrDefault();
+
+            if (firstTouch != null && firstTouch.Phase == UITouchPhase.Ended)
+            {
+                this.activeTouches.Remove(firstTouch);
+
+                ActualController.HandleTouchCompleted(this, firstTouch.ToTouchEventArgs(this));
+
+                if (secondTouch != null && secondTouch.Phase != UITouchPhase.Ended)
+                {
+                    // Restart with the former-secondary touch now promoted to primary touch (congratulations!)
+                    //
+                    ActualController.HandleTouchStarted(this, secondTouch.ToTouchEventArgs(this));
+                }
             }
         }
 
@@ -364,9 +407,10 @@ namespace OxyPlot.MonoTouch
         /// <param name="evt">The event arguments.</param>
         public override void TouchesCancelled(NSSet touches, UIEvent evt)
         {
-            base.TouchesCancelled(touches, evt);
-            var touch = touches.AnyObject as UITouch;
-            if (touch != null)
+            // TODO: Is it possible for one touch to be canceled while others remain in play?
+
+            var touch = this.activeTouches.FirstOrDefault();
+            if (touch != null && touch.Phase == UITouchPhase.Cancelled)
             {
                 this.ActualController.HandleTouchCompleted(this, touch.ToTouchEventArgs(this));
             }

--- a/Source/OxyPlot.Xamarin.iOS/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PlotView.cs
@@ -10,9 +10,10 @@
 namespace OxyPlot.Xamarin.iOS
 {
     using Foundation;
-
     using OxyPlot;
-
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using UIKit;
 
     /// <summary>
@@ -30,6 +31,17 @@ namespace OxyPlot.Xamarin.iOS
         /// The default plot controller.
         /// </summary>
         private IPlotController defaultController;
+
+        /// <summary>
+        /// Up to 2 touches being currently tracked in a pan/zoom.
+        /// </summary>
+        private List<UITouch> activeTouches = new List<UITouch>();
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis
+        /// </summary>
+        private const double threshold = 20d;
+
                
         /// <summary>
         /// Initializes a new instance of the <see cref="OxyPlot.Xamarin.iOS.PlotView"/> class.
@@ -288,11 +300,24 @@ namespace OxyPlot.Xamarin.iOS
         /// <param name="evt">The event arguments.</param>
         public override void TouchesBegan(NSSet touches, UIEvent evt)
         {
-            base.TouchesBegan(touches, evt);
-            var touch = touches.AnyObject as UITouch;
-            if (touch != null)
+            if (this.activeTouches.Count >= 2)
             {
-                this.ActualController.HandleTouchStarted(this, touch.ToTouchEventArgs(this));
+                // we already have two touches
+                return;
+            }
+
+            // Grab 1-2 touches to track
+            var newTouches = touches.ToArray<UITouch>();
+            var firstTouch = !this.activeTouches.Any();
+
+            activeTouches.AddRange(newTouches.Take(2 - this.activeTouches.Count));
+
+            if (firstTouch)
+            {
+                // HandleTouchStarted initializes the entire multitouch gesture,
+                // with the first touch used for panning.
+                //
+                ActualController.HandleTouchStarted(this, this.activeTouches.First().ToTouchEventArgs(this));
             }
         }
 
@@ -303,33 +328,31 @@ namespace OxyPlot.Xamarin.iOS
         /// <param name="evt">The event arguments.</param>
         public override void TouchesMoved(NSSet touches, UIEvent evt)
         {
-            // it seems to be easier to handle touch events here than using UIPanGesturRecognizer and UIPinchGestureRecognizer
-            base.TouchesMoved(touches, evt);
-
-            // convert the touch points to an array
-            var ta = touches.ToArray<UITouch>();
-
-            if (ta.Length > 0)
+            if (activeTouches.Count > 0)
             {
                 // get current and previous location of the first touch point
-                var t1 = ta[0];
+                var t1 = this.activeTouches.First();
                 var l1 = t1.LocationInView(this).ToScreenPoint();
-                var pl1 = t1.PreviousLocationInView(this).ToScreenPoint();
+                var pl1 = t1.Phase == UITouchPhase.Moved ? t1.PreviousLocationInView(this).ToScreenPoint() : l1;
+
                 var l = l1;
                 var t = l1 - pl1;
                 var s = new ScreenVector(1, 1);
-                if (ta.Length > 1)
+
+                if (activeTouches.Count > 1)
                 {
                     // get current and previous location of the second touch point
-                    var t2 = ta[1];
+                    var t2 = this.activeTouches.ElementAt(1);
                     var l2 = t2.LocationInView(this).ToScreenPoint();
-                    var pl2 = t2.PreviousLocationInView(this).ToScreenPoint();
+                    var pl2 = t2.Phase == UITouchPhase.Moved ? t2.PreviousLocationInView(this).ToScreenPoint() : l2;
+
                     var d = l1 - l2;
                     var pd = pl1 - pl2;
+
                     if (!this.KeepAspectRatioWhenPinching)
                     {
-                        var scalex = System.Math.Abs(pd.X) > 0 ? System.Math.Abs(d.X / pd.X) : 1;
-                        var scaley = System.Math.Abs(pd.Y) > 0 ? System.Math.Abs(d.Y / pd.Y) : 1;
+                        var scalex = Math.Abs(pd.X) > PlotView.threshold && Math.Abs(d.X) > PlotView.threshold ? Math.Abs(d.X / pd.X) : 1;
+                        var scaley = Math.Abs(pd.Y) > PlotView.threshold && Math.Abs(d.Y) > PlotView.threshold ? Math.Abs(d.Y / pd.Y) : 1;
                         s = new ScreenVector(scalex, scaley);
                     }
                     else
@@ -351,11 +374,29 @@ namespace OxyPlot.Xamarin.iOS
         /// <param name="evt">The event arguments.</param>
         public override void TouchesEnded(NSSet touches, UIEvent evt)
         {
-            base.TouchesEnded(touches, evt);
-            var touch = touches.AnyObject as UITouch;
-            if (touch != null)
+            // We already have the only two touches we care about, so ignore the params
+            //
+            var secondTouch = this.activeTouches.ElementAtOrDefault(1);
+
+            if (secondTouch != null && secondTouch.Phase == UITouchPhase.Ended)
             {
-                this.ActualController.HandleTouchCompleted(this, touch.ToTouchEventArgs(this));
+                this.activeTouches.Remove(secondTouch);
+            }
+
+            var firstTouch = this.activeTouches.FirstOrDefault();
+
+            if (firstTouch != null && firstTouch.Phase == UITouchPhase.Ended)
+            {
+                this.activeTouches.Remove(firstTouch);
+
+                ActualController.HandleTouchCompleted(this, firstTouch.ToTouchEventArgs(this));
+
+                if (secondTouch != null && secondTouch.Phase != UITouchPhase.Ended)
+                {
+                    // Restart with the former-secondary touch now promoted to primary touch (congratulations!)
+                    //
+                    ActualController.HandleTouchStarted(this, secondTouch.ToTouchEventArgs(this));
+                }
             }
         }
 
@@ -366,9 +407,10 @@ namespace OxyPlot.Xamarin.iOS
         /// <param name="evt">The event arguments.</param>
         public override void TouchesCancelled(NSSet touches, UIEvent evt)
         {
-            base.TouchesCancelled(touches, evt);
-            var touch = touches.AnyObject as UITouch;
-            if (touch != null)
+            // TODO: Is it possible for one touch to be canceled while others remain in play?
+
+            var touch = this.activeTouches.FirstOrDefault();
+            if (touch != null && touch.Phase == UITouchPhase.Cancelled)
             {
                 this.ActualController.HandleTouchCompleted(this, touch.ToTouchEventArgs(this));
             }


### PR DESCRIPTION
Was mixing up fingers, switching modes mid-gesture, and creating a duplicate touch manipulator.

Also added a threshold to make it easier to zoom in only the X or Y direction without the graph going crazy (because it thought you were trying to zoom to/from near zero along the other axis, instead of trying not to zoom at all). Threshold is currently a constant... it could be a configurable property, but then might need a better name.

(also updated the Xamarin.iOS\ExampleBrowser deployment target as required by Xamarin Unified?)