### PR TITLE
Issue #338: Attaching/detaching PlotView/Model in Model setter.

### DIFF
--- a/Source/OxyPlot.MonoTouch/PlotView.cs
+++ b/Source/OxyPlot.MonoTouch/PlotView.cs
@@ -105,7 +105,24 @@ namespace OxyPlot.MonoTouch
             {
                 if (this.model != value)
                 {
-                    this.model = value;
+                    if (this.model != null)
+                    {
+                        ((IPlotModel)this.model).AttachPlotView(null);
+                        this.model = null;
+                    }
+
+                    if (value != null)
+                    {
+                        if (value.PlotView != null)
+                        {
+                            throw new InvalidOperationException(
+                                "This PlotModel is already in use by some other PlotView control.");
+                        }
+
+                        ((IPlotModel)value).AttachPlotView(this);
+                        this.model = value;
+                    }
+
                     this.InvalidatePlot();
                 }
             }

--- a/Source/OxyPlot.Xamarin.Android/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Android/PlotView.cs
@@ -116,8 +116,25 @@ namespace OxyPlot.Xamarin.Android
             {
                 if (this.model != value)
                 {
-                    this.model = value;
-                    this.InvalidatePlot(true);
+                    if (this.model != null)
+                    {
+                        ((IPlotModel)this.model).AttachPlotView(null);
+                        this.model = null;
+                    }
+
+                    if (value != null)
+                    {
+                        if (value.PlotView != null)
+                        {
+                            throw new InvalidOperationException(
+                                "This PlotModel is already in use by some other PlotView control.");
+                        }
+
+                        ((IPlotModel)value).AttachPlotView(this);
+                        this.model = value;
+                    }
+
+                    this.InvalidatePlot();
                 }
             }
         }

--- a/Source/OxyPlot.Xamarin.iOS/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PlotView.cs
@@ -105,7 +105,24 @@ namespace OxyPlot.Xamarin.iOS
             {
                 if (this.model != value)
                 {
-                    this.model = value;
+                    if (this.model != null)
+                    {
+                        ((IPlotModel)this.model).AttachPlotView(null);
+                        this.model = null;
+                    }
+
+                    if (value != null)
+                    {
+                        if (value.PlotView != null)
+                        {
+                            throw new InvalidOperationException(
+                                "This PlotModel is already in use by some other PlotView control.");
+                        }
+
+                        ((IPlotModel)value).AttachPlotView(this);
+                        this.model = value;
+                    }
+
                     this.InvalidatePlot();
                 }
             }


### PR DESCRIPTION
Added to iOS/Android the same logic as other platforms have in OnModelChanged.
(kept to setters since the separate OnModelChanged isn't required here like it is on the DependencyProperty-based implementations, but it could easily be refactored for consistency)

Should also address issue #288.

Warning: I do not have an Android license, so am unable to test that. I am merely trusting that it works there since the same logic is tested on all the other platforms and isn't really platform-specific. (and I have seen this issue discussed in Xamarin's Android forums)