### PR TITLE
Draw legend line with custom pattern #356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - XamlExporter background (#233)
 - .NET 3.5 build (#229)
 - Support WinPhone 8.1 in core NuGet package (#161)
+- Draw legend line with custom pattern (#356)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -55,6 +55,7 @@ Patrice Marin <patrice.marin@thomsonreuters.com>
 Philippe AURIOU <p.auriou@live.fr>
 Piotr Warzocha <pw@piootr.pl>
 Senen Fernandez <senenf@gmail.com>
+Shun-ichi Goto <shunichi.goto@gmail.com>
 Stefan Rado <oxyplot@sradonia.net>
 Taldoras <taldoras@googlemail.com>
 thepretender	

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -873,5 +873,35 @@ namespace ExampleLibrary
             plotModel1.Series.Add(new LineSeries { Title = "LS2" });
             return plotModel1;
         }
+
+        [Example("#356 Draw legend line with custom pattern")]
+        public static PlotModel LegendWithCustomPattern()
+        {
+            var plotModel1 = new PlotModel
+            {
+                Title = "Draw legend line with custom pattern",
+            };
+            var solid = new LineSeries
+            {
+                Title = "Solid",
+                LineStyle = LineStyle.Solid
+                // without dashes
+            };
+            var custom = new LineSeries
+            {
+                Title = "Custom",
+                LineStyle = LineStyle.Solid,
+                // dashd-dot pattern
+                Dashes = new[] {10.0, 2.0, 4.0, 2.0},
+            };
+            solid.Points.Add(new DataPoint(0, 2));
+            solid.Points.Add(new DataPoint(100, 1));
+            custom.Points.Add(new DataPoint(0, 3));
+            custom.Points.Add(new DataPoint(100, 2));
+            plotModel1.Series.Add(solid);
+            plotModel1.Series.Add(custom);
+            plotModel1.LegendSymbolLength = 100; // wide enough to see pattern
+            return plotModel1;
+        }
     }
 }

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -365,7 +365,7 @@ namespace OxyPlot.Series
                 pts,
                 this.GetSelectableColor(this.ActualColor),
                 this.StrokeThickness,
-                this.ActualLineStyle.GetDashArray());
+                this.ActualDashArray);
             var midpt = new ScreenPoint(xmid, ymid);
             rc.DrawMarker(
                 legendBox,


### PR DESCRIPTION
By this fix, LineSeries draw the line in legend with specified pattern in Dashes.
Before this, Dashes is not used in legend at all.

A sample is also added to see the change.