### PR TITLE
iOS gesture recognizer and zoom options

### DIFF
--- a/Source/OxyPlot.MonoTouch/OxyPlot.MonoTouch.csproj
+++ b/Source/OxyPlot.MonoTouch/OxyPlot.MonoTouch.csproj
@@ -39,6 +39,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <Compile Include="MonoTouchRenderContext.cs" />
+    <Compile Include="PanZoomGestureRecognizer.cs" />
     <Compile Include="PlotView.cs" />
     <Compile Include="ExportExtensions.cs" />
     <Compile Include="ConverterExtensions.cs" />

--- a/Source/OxyPlot.MonoTouch/PanZoomGestureRecognizer.cs
+++ b/Source/OxyPlot.MonoTouch/PanZoomGestureRecognizer.cs
@@ -1,0 +1,192 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PanZoomGestureRecognizer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Recognizes drag/pinch multitouch gestures and translates them into pan/zoom information.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.MonoTouch
+{
+    using global::MonoTouch.Foundation;
+    using global::MonoTouch.UIKit;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Recognizes drag/pinch multitouch gestures and translates them into pan/zoom information.
+    /// </summary>
+    public class PanZoomGestureRecognizer : UIGestureRecognizer
+    {
+        /// <summary>
+        /// Up to 2 touches being currently tracked in a pan/zoom.
+        /// </summary>
+        private List<UITouch> activeTouches = new List<UITouch>();
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis.
+        /// (only applies if KeepAspectRatioWhenPinching == false)
+        /// </summary>
+        public double ZoomThreshold { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PlotView"/> keeps the aspect ratio when pinching.
+        /// </summary>
+        /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
+        public bool KeepAspectRatioWhenPinching { get; set; }
+
+        /// <summary>
+        /// The current calculated pan/zoom changes
+        /// </summary>
+        public OxyTouchEventArgs TouchEventArgs { get; set; }
+
+
+        public PanZoomGestureRecognizer()
+        {
+            ZoomThreshold = 20d;
+        }
+
+
+        /// <summary>
+        /// Called when a touch gesture begins.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesBegan(NSSet touches, UIEvent evt)
+        {
+            base.TouchesBegan(touches, evt);
+
+            if (this.activeTouches.Count >= 2)
+            {
+                // we already have two touches
+                return;
+            }
+
+            // Grab 1-2 touches to track
+            var newTouches = touches.ToArray<UITouch>();
+            var firstTouch = !this.activeTouches.Any();
+
+            activeTouches.AddRange(newTouches.Take(2 - this.activeTouches.Count));
+
+            if (firstTouch)
+            {
+                // HandleTouchStarted initializes the entire multitouch gesture,
+                // with the first touch used for panning.
+                //
+                TouchEventArgs = this.activeTouches.First().ToTouchEventArgs(this.View);
+            }
+        }
+
+        /// <summary>
+        /// Called when a touch gesture is moving.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesMoved(NSSet touches, UIEvent evt)
+        {
+            base.TouchesMoved(touches, evt);
+
+            if (activeTouches.Any(touch => touch.Phase == UITouchPhase.Moved))
+            {
+                // get current and previous location of the first touch point
+                var t1 = this.activeTouches.First();
+                var l1 = t1.LocationInView(this.View).ToScreenPoint();
+                var pl1 = t1.Phase == UITouchPhase.Moved ? t1.PreviousLocationInView(this.View).ToScreenPoint() : l1;
+
+                var l = l1;
+                var t = l1 - pl1;
+                var s = new ScreenVector(1, 1);
+
+                if (activeTouches.Count > 1)
+                {
+                    // get current and previous location of the second touch point
+                    var t2 = this.activeTouches.ElementAt(1);
+                    var l2 = t2.LocationInView(this.View).ToScreenPoint();
+                    var pl2 = t2.Phase == UITouchPhase.Moved ? t2.PreviousLocationInView(this.View).ToScreenPoint() : l2;
+
+                    var d = l1 - l2;
+                    var pd = pl1 - pl2;
+
+                    if (!this.KeepAspectRatioWhenPinching)
+                    {
+                        var scalex = CalculateScaleFactor(d.X, pd.X);
+                        var scaley = CalculateScaleFactor(d.Y, pd.Y);
+                        s = new ScreenVector(scalex, scaley);
+                    }
+                    else
+                    {
+                        var scale = pd.Length > 0 ? d.Length / pd.Length : 1;
+                        s = new ScreenVector(scale, scale);
+                    }
+                }
+
+                var e = new OxyTouchEventArgs { Position = l, DeltaTranslation = t, DeltaScale = s };
+                this.TouchEventArgs = e;
+                this.State = UIGestureRecognizerState.Changed;
+            }
+        }
+
+        /// <summary>
+        /// Called when a touch gesture ends.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesEnded(NSSet touches, UIEvent evt)
+        {
+            base.TouchesEnded(touches, evt);
+
+            // We already have the only two touches we care about, so ignore the params
+            //
+            var secondTouch = this.activeTouches.ElementAtOrDefault(1);
+
+            if (secondTouch != null && secondTouch.Phase == UITouchPhase.Ended)
+            {
+                this.activeTouches.Remove(secondTouch);
+            }
+
+            var firstTouch = this.activeTouches.FirstOrDefault();
+
+            if (firstTouch != null && firstTouch.Phase == UITouchPhase.Ended)
+            {
+                this.activeTouches.Remove(firstTouch);
+
+                if (!this.activeTouches.Any())
+                {
+                    TouchEventArgs = firstTouch.ToTouchEventArgs(this.View);
+                    State = UIGestureRecognizerState.Ended;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when a touch gesture is cancelled.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesCancelled(NSSet touches, UIEvent evt)
+        {
+            base.TouchesCancelled(touches, evt);
+
+            // TODO: Is it possible for one touch to be canceled while others remain in play?
+
+            var touch = this.activeTouches.FirstOrDefault();
+            if (touch != null && touch.Phase == UITouchPhase.Cancelled)
+            {
+                TouchEventArgs = touch.ToTouchEventArgs(this.View);
+                State = UIGestureRecognizerState.Cancelled;
+            }
+        }
+
+
+        private double CalculateScaleFactor(double distance, double previousDistance)
+        {
+            return Math.Abs(previousDistance) > this.ZoomThreshold
+                && Math.Abs(distance) > this.ZoomThreshold
+                ? Math.Abs(distance / previousDistance)
+                : 1;
+        }
+    }
+}

--- a/Source/OxyPlot.MonoTouch/PanZoomGestureRecognizer.cs
+++ b/Source/OxyPlot.MonoTouch/PanZoomGestureRecognizer.cs
@@ -33,7 +33,7 @@ namespace OxyPlot.MonoTouch
         public double ZoomThreshold { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PlotView"/> keeps the aspect ratio when pinching.
+        /// Gets or sets a value indicating whether this <see cref="OxyPlot.MonoTouch.PanZoomGestureRecognizer"/> keeps the aspect ratio when pinching.
         /// </summary>
         /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
         public bool KeepAspectRatioWhenPinching { get; set; }

--- a/Source/OxyPlot.MonoTouch/PlotView.cs
+++ b/Source/OxyPlot.MonoTouch/PlotView.cs
@@ -219,6 +219,17 @@ namespace OxyPlot.MonoTouch
         }
 
         /// <summary>
+        /// If <c>true</c>, and KeepAspectRatioWhenPinching is <c>false</c>, a zoom-out gesture
+        /// can turn into a zoom-in gesture if the fingers cross. Setting to <c>false</c> will
+        /// instead simply stop the zoom at that point.
+        /// </summary>
+        public bool AllowPinchPastZero
+        {
+            get { return this.panZoomGesture.AllowPinchPastZero; }
+            set { this.panZoomGesture.AllowPinchPastZero = value; }
+        }
+
+        /// <summary>
         /// Hides the tracker.
         /// </summary>
         public void HideTracker()

--- a/Source/OxyPlot.MonoTouch/PlotView.cs
+++ b/Source/OxyPlot.MonoTouch/PlotView.cs
@@ -32,15 +32,8 @@ namespace OxyPlot.MonoTouch
         /// </summary>
         private IPlotController defaultController;
 
-        /// <summary>
-        /// Up to 2 touches being currently tracked in a pan/zoom.
-        /// </summary>
-        private List<UITouch> activeTouches = new List<UITouch>();
 
-        /// <summary>
-        /// How far apart touch points must be on a certain axis to enable scaling that axis
-        /// </summary>
-        private const double threshold = 20d;
+        private PanZoomGestureRecognizer panZoomGesture = new PanZoomGestureRecognizer();
 
 
         /// <summary>
@@ -88,6 +81,13 @@ namespace OxyPlot.MonoTouch
             this.MultipleTouchEnabled = true;
             this.BackgroundColor = UIColor.White;
             this.KeepAspectRatioWhenPinching = true;
+
+            this.panZoomGesture.AddTarget(() =>
+            {
+                HandlePanZoomGesture();
+            });
+
+            this.AddGestureRecognizer(this.panZoomGesture);
         }
 
         /// <summary>
@@ -202,7 +202,21 @@ namespace OxyPlot.MonoTouch
         /// Gets or sets a value indicating whether this <see cref="OxyPlot.MonoTouch.PlotView"/> keeps the aspect ratio when pinching.
         /// </summary>
         /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
-        public bool KeepAspectRatioWhenPinching { get; set; }
+        public bool KeepAspectRatioWhenPinching
+        {
+            get { return this.panZoomGesture.KeepAspectRatioWhenPinching; }
+            set { this.panZoomGesture.KeepAspectRatioWhenPinching = value; }
+        }
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis.
+        /// (only applies if KeepAspectRatioWhenPinching == false)
+        /// </summary>
+        public double ZoomThreshold
+        {
+            get { return this.panZoomGesture.ZoomThreshold; }
+            set { this.panZoomGesture.ZoomThreshold = value; }
+        }
 
         /// <summary>
         /// Hides the tracker.
@@ -310,126 +324,21 @@ namespace OxyPlot.MonoTouch
             }
         }
 
-        /// <summary>
-        /// Called when a touch gesture begins.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesBegan(NSSet touches, UIEvent evt)
+
+        private void HandlePanZoomGesture()
         {
-            if (this.activeTouches.Count >= 2)
+            switch (panZoomGesture.State)
             {
-                // we already have two touches
-                return;
-            }
-
-            // Grab 1-2 touches to track
-            var newTouches = touches.ToArray<UITouch>();
-            var firstTouch = !this.activeTouches.Any();
-
-            activeTouches.AddRange(newTouches.Take(2 - this.activeTouches.Count));
-
-            if (firstTouch)
-            {
-                // HandleTouchStarted initializes the entire multitouch gesture,
-                // with the first touch used for panning.
-                //
-                ActualController.HandleTouchStarted(this, this.activeTouches.First().ToTouchEventArgs(this));
-            }
-        }
-
-        /// <summary>
-        /// Called when a touch gesture is moving.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesMoved(NSSet touches, UIEvent evt)
-        {
-            if (activeTouches.Count > 0)
-            {
-                // get current and previous location of the first touch point
-                var t1 = this.activeTouches.First();
-                var l1 = t1.LocationInView(this).ToScreenPoint();
-                var pl1 = t1.Phase == UITouchPhase.Moved ? t1.PreviousLocationInView(this).ToScreenPoint() : l1;
-
-                var l = l1;
-                var t = l1 - pl1;
-                var s = new ScreenVector(1, 1);
-
-                if (activeTouches.Count > 1)
-                {
-                    // get current and previous location of the second touch point
-                    var t2 = this.activeTouches.ElementAt(1);
-                    var l2 = t2.LocationInView(this).ToScreenPoint();
-                    var pl2 = t2.Phase == UITouchPhase.Moved ? t2.PreviousLocationInView(this).ToScreenPoint() : l2;
-
-                    var d = l1 - l2;
-                    var pd = pl1 - pl2;
-
-                    if (!this.KeepAspectRatioWhenPinching)
-                    {
-                        var scalex = Math.Abs(pd.X) > PlotView.threshold && Math.Abs(d.X) > PlotView.threshold ? Math.Abs(d.X / pd.X) : 1;
-                        var scaley = Math.Abs(pd.Y) > PlotView.threshold && Math.Abs(d.Y) > PlotView.threshold ? Math.Abs(d.Y / pd.Y) : 1;
-                        s = new ScreenVector(scalex, scaley);
-                    }
-                    else
-                    {
-                        var scale = pd.Length > 0 ? d.Length / pd.Length : 1;
-                        s = new ScreenVector(scale, scale);
-                    }
-                }
-
-                var e = new OxyTouchEventArgs { Position = l, DeltaTranslation = t, DeltaScale = s };
-                this.ActualController.HandleTouchDelta(this, e);
-            }
-        }
-
-        /// <summary>
-        /// Called when a touch gesture ends.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesEnded(NSSet touches, UIEvent evt)
-        {
-            // We already have the only two touches we care about, so ignore the params
-            //
-            var secondTouch = this.activeTouches.ElementAtOrDefault(1);
-
-            if (secondTouch != null && secondTouch.Phase == UITouchPhase.Ended)
-            {
-                this.activeTouches.Remove(secondTouch);
-            }
-
-            var firstTouch = this.activeTouches.FirstOrDefault();
-
-            if (firstTouch != null && firstTouch.Phase == UITouchPhase.Ended)
-            {
-                this.activeTouches.Remove(firstTouch);
-
-                ActualController.HandleTouchCompleted(this, firstTouch.ToTouchEventArgs(this));
-
-                if (secondTouch != null && secondTouch.Phase != UITouchPhase.Ended)
-                {
-                    // Restart with the former-secondary touch now promoted to primary touch (congratulations!)
-                    //
-                    ActualController.HandleTouchStarted(this, secondTouch.ToTouchEventArgs(this));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Called when a touch gesture is cancelled.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesCancelled(NSSet touches, UIEvent evt)
-        {
-            // TODO: Is it possible for one touch to be canceled while others remain in play?
-
-            var touch = this.activeTouches.FirstOrDefault();
-            if (touch != null && touch.Phase == UITouchPhase.Cancelled)
-            {
-                this.ActualController.HandleTouchCompleted(this, touch.ToTouchEventArgs(this));
+                case UIGestureRecognizerState.Began:
+                    ActualController.HandleTouchStarted(this, panZoomGesture.TouchEventArgs);
+                    break;
+                case UIGestureRecognizerState.Changed:
+                    ActualController.HandleTouchDelta(this, panZoomGesture.TouchEventArgs);
+                    break;
+                case UIGestureRecognizerState.Ended:
+                case UIGestureRecognizerState.Cancelled:
+                    ActualController.HandleTouchCompleted(this, panZoomGesture.TouchEventArgs);
+                    break;
             }
         }
     }

--- a/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.csproj
+++ b/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.csproj
@@ -38,6 +38,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PanZoomGestureRecognizer.cs" />
     <Compile Include="PlotView.cs" />
     <Compile Include="ExportExtensions.cs" />
     <Compile Include="ConverterExtensions.cs" />

--- a/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
@@ -1,0 +1,192 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PanZoomGestureRecognizer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Recognizes drag/pinch multitouch gestures and translates them into pan/zoom information.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Xamarin.iOS
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Foundation;
+    using UIKit;
+
+    /// <summary>
+    /// Recognizes drag/pinch multitouch gestures and translates them into pan/zoom information.
+    /// </summary>
+    public class PanZoomGestureRecognizer : UIGestureRecognizer
+    {
+        /// <summary>
+        /// Up to 2 touches being currently tracked in a pan/zoom.
+        /// </summary>
+        private List<UITouch> activeTouches = new List<UITouch>();
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis.
+        /// (only applies if KeepAspectRatioWhenPinching == false)
+        /// </summary>
+        public double ZoomThreshold { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PlotView"/> keeps the aspect ratio when pinching.
+        /// </summary>
+        /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
+        public bool KeepAspectRatioWhenPinching { get; set; }
+
+        /// <summary>
+        /// The current calculated pan/zoom changes
+        /// </summary>
+        public OxyTouchEventArgs TouchEventArgs { get; set; }
+
+
+        public PanZoomGestureRecognizer()
+        {
+            ZoomThreshold = 20d;
+        }
+
+
+        /// <summary>
+        /// Called when a touch gesture begins.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesBegan(NSSet touches, UIEvent evt)
+        {
+            base.TouchesBegan(touches, evt);
+
+            if (this.activeTouches.Count >= 2)
+            {
+                // we already have two touches
+                return;
+            }
+
+            // Grab 1-2 touches to track
+            var newTouches = touches.ToArray<UITouch>();
+            var firstTouch = !this.activeTouches.Any();
+
+            activeTouches.AddRange(newTouches.Take(2 - this.activeTouches.Count));
+
+            if (firstTouch)
+            {
+                // HandleTouchStarted initializes the entire multitouch gesture,
+                // with the first touch used for panning.
+                //
+                TouchEventArgs = this.activeTouches.First().ToTouchEventArgs(this.View);
+            }
+        }
+
+        /// <summary>
+        /// Called when a touch gesture is moving.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesMoved(NSSet touches, UIEvent evt)
+        {
+            base.TouchesMoved(touches, evt);
+
+            if (activeTouches.Any(touch => touch.Phase == UITouchPhase.Moved))
+            {
+                // get current and previous location of the first touch point
+                var t1 = this.activeTouches.First();
+                var l1 = t1.LocationInView(this.View).ToScreenPoint();
+                var pl1 = t1.Phase == UITouchPhase.Moved ? t1.PreviousLocationInView(this.View).ToScreenPoint() : l1;
+
+                var l = l1;
+                var t = l1 - pl1;
+                var s = new ScreenVector(1, 1);
+
+                if (activeTouches.Count > 1)
+                {
+                    // get current and previous location of the second touch point
+                    var t2 = this.activeTouches.ElementAt(1);
+                    var l2 = t2.LocationInView(this.View).ToScreenPoint();
+                    var pl2 = t2.Phase == UITouchPhase.Moved ? t2.PreviousLocationInView(this.View).ToScreenPoint() : l2;
+
+                    var d = l1 - l2;
+                    var pd = pl1 - pl2;
+
+                    if (!this.KeepAspectRatioWhenPinching)
+                    {
+                        var scalex = CalculateScaleFactor(d.X, pd.X);
+                        var scaley = CalculateScaleFactor(d.Y, pd.Y);
+                        s = new ScreenVector(scalex, scaley);
+                    }
+                    else
+                    {
+                        var scale = pd.Length > 0 ? d.Length / pd.Length : 1;
+                        s = new ScreenVector(scale, scale);
+                    }
+                }
+
+                var e = new OxyTouchEventArgs { Position = l, DeltaTranslation = t, DeltaScale = s };
+                this.TouchEventArgs = e;
+                this.State = UIGestureRecognizerState.Changed;
+            }
+        }
+
+        /// <summary>
+        /// Called when a touch gesture ends.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesEnded(NSSet touches, UIEvent evt)
+        {
+            base.TouchesEnded(touches, evt);
+
+            // We already have the only two touches we care about, so ignore the params
+            //
+            var secondTouch = this.activeTouches.ElementAtOrDefault(1);
+
+            if (secondTouch != null && secondTouch.Phase == UITouchPhase.Ended)
+            {
+                this.activeTouches.Remove(secondTouch);
+            }
+
+            var firstTouch = this.activeTouches.FirstOrDefault();
+
+            if (firstTouch != null && firstTouch.Phase == UITouchPhase.Ended)
+            {
+                this.activeTouches.Remove(firstTouch);
+
+                if (!this.activeTouches.Any())
+                {
+                    TouchEventArgs = firstTouch.ToTouchEventArgs(this.View);
+                    State = UIGestureRecognizerState.Ended;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when a touch gesture is cancelled.
+        /// </summary>
+        /// <param name="touches">The touches.</param>
+        /// <param name="evt">The event arguments.</param>
+        public override void TouchesCancelled(NSSet touches, UIEvent evt)
+        {
+            base.TouchesCancelled(touches, evt);
+
+            // TODO: Is it possible for one touch to be canceled while others remain in play?
+
+            var touch = this.activeTouches.FirstOrDefault();
+            if (touch != null && touch.Phase == UITouchPhase.Cancelled)
+            {
+                TouchEventArgs = touch.ToTouchEventArgs(this.View);
+                State = UIGestureRecognizerState.Cancelled;
+            }
+        }
+
+
+        private double CalculateScaleFactor(double distance, double previousDistance)
+        {
+            return Math.Abs(previousDistance) > this.ZoomThreshold
+                && Math.Abs(distance) > this.ZoomThreshold
+                ? Math.Abs(distance / previousDistance)
+                : 1;
+        }
+    }
+}

--- a/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
@@ -33,7 +33,7 @@ namespace OxyPlot.Xamarin.iOS
         public double ZoomThreshold { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PlotView"/> keeps the aspect ratio when pinching.
+        /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PanZoomGestureRecognizer"/> keeps the aspect ratio when pinching.
         /// </summary>
         /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
         public bool KeepAspectRatioWhenPinching { get; set; }

--- a/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
@@ -26,17 +26,29 @@ namespace OxyPlot.Xamarin.iOS
         /// </summary>
         private List<UITouch> activeTouches = new List<UITouch>();
 
-        /// <summary>
-        /// How far apart touch points must be on a certain axis to enable scaling that axis.
-        /// (only applies if KeepAspectRatioWhenPinching == false)
-        /// </summary>
-        public double ZoomThreshold { get; set; }
+        // Distance between touchpoints when the second touchpoint begins. Used to determine
+        // whether the touchpoints cross along a given axis during the zoom gesture.
+        //
+        private ScreenVector startingDistance = default(ScreenVector);
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PanZoomGestureRecognizer"/> keeps the aspect ratio when pinching.
         /// </summary>
         /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
         public bool KeepAspectRatioWhenPinching { get; set; }
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis.
+        /// (only applies if KeepAspectRatioWhenPinching is <c>false</c>)
+        /// </summary>
+        public double ZoomThreshold { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, and KeepAspectRatioWhenPinching is <c>false</c>, a zoom-out gesture
+        /// can turn into a zoom-in gesture if the fingers cross. Setting to <c>false</c> will
+        /// instead simply stop the zoom at that point.
+        /// </summary>
+        public bool AllowPinchPastZero { get; set; }
 
         /// <summary>
         /// The current calculated pan/zoom changes
@@ -46,7 +58,8 @@ namespace OxyPlot.Xamarin.iOS
 
         public PanZoomGestureRecognizer()
         {
-            ZoomThreshold = 20d;
+            this.ZoomThreshold = 20d;
+            this.AllowPinchPastZero = true;
         }
 
 
@@ -78,6 +91,8 @@ namespace OxyPlot.Xamarin.iOS
                 //
                 TouchEventArgs = this.activeTouches.First().ToTouchEventArgs(this.View);
             }
+
+            CalculateStartingDistance();
         }
 
         /// <summary>
@@ -112,6 +127,12 @@ namespace OxyPlot.Xamarin.iOS
 
                     if (!this.KeepAspectRatioWhenPinching)
                     {
+                        if (!this.AllowPinchPastZero)
+                        {
+                            // Don't allow fingers crossing in a zoom-out gesture to turn it back into a zoom-in gesture
+                            d = PreventCross(d);
+                        }
+
                         var scalex = CalculateScaleFactor(d.X, pd.X);
                         var scaley = CalculateScaleFactor(d.Y, pd.Y);
                         s = new ScreenVector(scalex, scaley);
@@ -187,6 +208,43 @@ namespace OxyPlot.Xamarin.iOS
                 && Math.Abs(distance) > this.ZoomThreshold
                 ? Math.Abs(distance / previousDistance)
                 : 1;
+        }
+
+        private void CalculateStartingDistance()
+        {
+            if (this.activeTouches.Count < 2)
+            {
+                this.startingDistance = default(ScreenVector);
+                return;
+            }
+
+            var loc1 = this.activeTouches.ElementAt(0).LocationInView(this.View).ToScreenPoint();
+            var loc2 = this.activeTouches.ElementAt(1).LocationInView(this.View).ToScreenPoint();
+
+            this.startingDistance = loc1 - loc2;
+        }
+
+        private ScreenVector PreventCross(ScreenVector currentDistance)
+        {
+            var x = currentDistance.X;
+            var y = currentDistance.Y;
+
+            if (DidDirectionChange(x, this.startingDistance.X))
+            {
+                x = 0;
+            }
+
+            if (DidDirectionChange(y, this.startingDistance.Y))
+            {
+                y = 0;
+            }
+
+            return new ScreenVector(x, y);
+        }
+
+        private static bool DidDirectionChange(double current, double original)
+        {
+            return ((current >= 0) != (original >= 0));
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.iOS/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PlotView.cs
@@ -216,6 +216,16 @@ namespace OxyPlot.Xamarin.iOS
             set { this.panZoomGesture.ZoomThreshold = value; }
         }
 
+        /// <summary>
+        /// If <c>true</c>, and KeepAspectRatioWhenPinching is <c>false</c>, a zoom-out gesture
+        /// can turn into a zoom-in gesture if the fingers cross. Setting to <c>false</c> will
+        /// instead simply stop the zoom at that point.
+        /// </summary>
+        public bool AllowPinchPastZero
+        {
+            get { return this.panZoomGesture.AllowPinchPastZero; }
+            set { this.panZoomGesture.AllowPinchPastZero = value; }
+        }
 
         /// <summary>
         /// Hides the tracker.

--- a/Source/OxyPlot.Xamarin.iOS/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PlotView.cs
@@ -32,16 +32,7 @@ namespace OxyPlot.Xamarin.iOS
         /// </summary>
         private IPlotController defaultController;
 
-        /// <summary>
-        /// Up to 2 touches being currently tracked in a pan/zoom.
-        /// </summary>
-        private List<UITouch> activeTouches = new List<UITouch>();
-
-        /// <summary>
-        /// How far apart touch points must be on a certain axis to enable scaling that axis
-        /// </summary>
-        private const double threshold = 20d;
-
+        private PanZoomGestureRecognizer panZoomGesture = new PanZoomGestureRecognizer();
                
         /// <summary>
         /// Initializes a new instance of the <see cref="OxyPlot.Xamarin.iOS.PlotView"/> class.
@@ -88,6 +79,13 @@ namespace OxyPlot.Xamarin.iOS
             this.MultipleTouchEnabled = true;
             this.BackgroundColor = UIColor.White;
             this.KeepAspectRatioWhenPinching = true;
+
+            this.panZoomGesture.AddTarget(() =>
+            {
+                HandlePanZoomGesture();
+            });
+
+            this.AddGestureRecognizer(this.panZoomGesture);
         }
 
         /// <summary>
@@ -202,7 +200,22 @@ namespace OxyPlot.Xamarin.iOS
         /// Gets or sets a value indicating whether this <see cref="OxyPlot.Xamarin.iOS.PlotView"/> keeps the aspect ratio when pinching.
         /// </summary>
         /// <value><c>true</c> if keep aspect ratio when pinching; otherwise, <c>false</c>.</value>
-        public bool KeepAspectRatioWhenPinching { get; set; }
+        public bool KeepAspectRatioWhenPinching
+        {
+            get { return this.panZoomGesture.KeepAspectRatioWhenPinching; }
+            set { this.panZoomGesture.KeepAspectRatioWhenPinching = value; }
+        }
+
+        /// <summary>
+        /// How far apart touch points must be on a certain axis to enable scaling that axis.
+        /// (only applies if KeepAspectRatioWhenPinching == false)
+        /// </summary>
+        public double ZoomThreshold
+        {
+            get { return this.panZoomGesture.ZoomThreshold; }
+            set { this.panZoomGesture.ZoomThreshold = value; }
+        }
+
 
         /// <summary>
         /// Hides the tracker.
@@ -310,126 +323,20 @@ namespace OxyPlot.Xamarin.iOS
             }
         }
 
-        /// <summary>
-        /// Called when a touch gesture begins.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesBegan(NSSet touches, UIEvent evt)
+        private void HandlePanZoomGesture()
         {
-            if (this.activeTouches.Count >= 2)
+            switch (panZoomGesture.State)
             {
-                // we already have two touches
-                return;
-            }
-
-            // Grab 1-2 touches to track
-            var newTouches = touches.ToArray<UITouch>();
-            var firstTouch = !this.activeTouches.Any();
-
-            activeTouches.AddRange(newTouches.Take(2 - this.activeTouches.Count));
-
-            if (firstTouch)
-            {
-                // HandleTouchStarted initializes the entire multitouch gesture,
-                // with the first touch used for panning.
-                //
-                ActualController.HandleTouchStarted(this, this.activeTouches.First().ToTouchEventArgs(this));
-            }
-        }
-
-        /// <summary>
-        /// Called when a touch gesture is moving.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesMoved(NSSet touches, UIEvent evt)
-        {
-            if (activeTouches.Count > 0)
-            {
-                // get current and previous location of the first touch point
-                var t1 = this.activeTouches.First();
-                var l1 = t1.LocationInView(this).ToScreenPoint();
-                var pl1 = t1.Phase == UITouchPhase.Moved ? t1.PreviousLocationInView(this).ToScreenPoint() : l1;
-
-                var l = l1;
-                var t = l1 - pl1;
-                var s = new ScreenVector(1, 1);
-
-                if (activeTouches.Count > 1)
-                {
-                    // get current and previous location of the second touch point
-                    var t2 = this.activeTouches.ElementAt(1);
-                    var l2 = t2.LocationInView(this).ToScreenPoint();
-                    var pl2 = t2.Phase == UITouchPhase.Moved ? t2.PreviousLocationInView(this).ToScreenPoint() : l2;
-
-                    var d = l1 - l2;
-                    var pd = pl1 - pl2;
-
-                    if (!this.KeepAspectRatioWhenPinching)
-                    {
-                        var scalex = Math.Abs(pd.X) > PlotView.threshold && Math.Abs(d.X) > PlotView.threshold ? Math.Abs(d.X / pd.X) : 1;
-                        var scaley = Math.Abs(pd.Y) > PlotView.threshold && Math.Abs(d.Y) > PlotView.threshold ? Math.Abs(d.Y / pd.Y) : 1;
-                        s = new ScreenVector(scalex, scaley);
-                    }
-                    else
-                    {
-                        var scale = pd.Length > 0 ? d.Length / pd.Length : 1;
-                        s = new ScreenVector(scale, scale);
-                    }
-                }
-
-                var e = new OxyTouchEventArgs { Position = l, DeltaTranslation = t, DeltaScale = s };
-                this.ActualController.HandleTouchDelta(this, e);
-            }
-        }
-
-        /// <summary>
-        /// Called when a touch gesture ends.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesEnded(NSSet touches, UIEvent evt)
-        {
-            // We already have the only two touches we care about, so ignore the params
-            //
-            var secondTouch = this.activeTouches.ElementAtOrDefault(1);
-
-            if (secondTouch != null && secondTouch.Phase == UITouchPhase.Ended)
-            {
-                this.activeTouches.Remove(secondTouch);
-            }
-
-            var firstTouch = this.activeTouches.FirstOrDefault();
-
-            if (firstTouch != null && firstTouch.Phase == UITouchPhase.Ended)
-            {
-                this.activeTouches.Remove(firstTouch);
-
-                ActualController.HandleTouchCompleted(this, firstTouch.ToTouchEventArgs(this));
-
-                if (secondTouch != null && secondTouch.Phase != UITouchPhase.Ended)
-                {
-                    // Restart with the former-secondary touch now promoted to primary touch (congratulations!)
-                    //
-                    ActualController.HandleTouchStarted(this, secondTouch.ToTouchEventArgs(this));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Called when a touch gesture is cancelled.
-        /// </summary>
-        /// <param name="touches">The touches.</param>
-        /// <param name="evt">The event arguments.</param>
-        public override void TouchesCancelled(NSSet touches, UIEvent evt)
-        {
-            // TODO: Is it possible for one touch to be canceled while others remain in play?
-
-            var touch = this.activeTouches.FirstOrDefault();
-            if (touch != null && touch.Phase == UITouchPhase.Cancelled)
-            {
-                this.ActualController.HandleTouchCompleted(this, touch.ToTouchEventArgs(this));
+                case UIGestureRecognizerState.Began:
+                    ActualController.HandleTouchStarted(this, panZoomGesture.TouchEventArgs);
+                    break;
+                case UIGestureRecognizerState.Changed:
+                    ActualController.HandleTouchDelta(this, panZoomGesture.TouchEventArgs);
+                    break;
+                case UIGestureRecognizerState.Ended:
+                case UIGestureRecognizerState.Cancelled:
+                    ActualController.HandleTouchCompleted(this, panZoomGesture.TouchEventArgs);
+                    break;
             }
         }
     }

--- a/Source/OxyPlot/PlotController/Manipulators/TouchManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchManipulator.cs
@@ -15,11 +15,6 @@ namespace OxyPlot
     public class TouchManipulator : PlotManipulator<OxyTouchEventArgs>
     {
         /// <summary>
-        /// The previous position
-        /// </summary>
-        private ScreenPoint previousPosition;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TouchManipulator" /> class.
         /// </summary>
         /// <param name="plotView">The plot view.</param>
@@ -36,16 +31,17 @@ namespace OxyPlot
         {
             base.Delta(e);
 
-            var newPosition = this.previousPosition + e.DeltaTranslation;
+            var newPosition = e.Position;
+            var previousPosition = newPosition - e.DeltaTranslation;
 
             if (this.XAxis != null)
             {
-                this.XAxis.Pan(this.previousPosition, newPosition);
+                this.XAxis.Pan(previousPosition, newPosition);
             }
 
             if (this.YAxis != null)
             {
-                this.YAxis.Pan(this.previousPosition, newPosition);
+                this.YAxis.Pan(previousPosition, newPosition);
             }
 
             var current = this.InverseTransform(newPosition.X, newPosition.Y);
@@ -61,8 +57,6 @@ namespace OxyPlot
             }
 
             this.PlotView.InvalidatePlot(false);
-
-            this.previousPosition = newPosition;
         }
 
         /// <summary>
@@ -73,7 +67,6 @@ namespace OxyPlot
         {
             this.AssignAxes(e.Position);
             base.Started(e);
-            this.previousPosition = e.Position;
         }
     }
 }


### PR DESCRIPTION
Related to, but not an actual fix for, issue #340.

- Fixes the issue I mentioned with extra Started/Completed events being generated mid-gesture. This involves a change to TouchManipulator that affects other platforms, so I again must warn that I am unable to test with Android.
- Refactors the iOS touch processing out of PlotView and into a custom gesture recognizer (this was the original intent of this change, the above issue just got fixed along the way).
- Adds properties to set the zoom threshold and "AllowPinchPastZero" (open to ideas for a better name there) behavior. These only apply if KeepAspectRatioWhenPinching is false, and they each default to the previous behavior. The intent of both options is to make it harder for users to accidentally zoom.