### PR TITLE
Updated the changelog for my changes and made the Mobile NuGet empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Created a new OxyPlot.Mobile NuGet to combine the mobile platforms into a single NuGet. (#362)
 - Support for XWT (#295)
 - TwoColorAreaSeries (#299)
 - Delta values in AxisChangedEventArgs (#276)
 - Enable Git source server (added GitLink build step) (#267,#266)
 
 ### Changed
+- Changed the OxyPlot.Xamarin.Forms to require the OxyPlot.Mobile dependency instead of each separate NuGet. (#362)
 - Deleted PlotModel.ToSvg. Use the SvgExporter instead. (#347)
 - Deleted constructors with parameters. Use default constructors instead. (#347)
 - Deleted Axis.ShowMinorTicks. Use MinorTickSize = 0 instead. (#347)

--- a/Source/OxyPlot.Mobile.nuspec
+++ b/Source/OxyPlot.Mobile.nuspec
@@ -13,21 +13,24 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>plotting plot charting chart wp8 windows phone 8 windowsphone winphone winrt win8 metro store xamarin android ios monotouch</tags>
     <dependencies>
-      <dependency id="OxyPlot.Core" version="[0.0.0]"/>
+      <group targetFramework="MonoTouch1.0">
+        <dependency id="OxyPlot.Xamarin.iOS"/>
+      </group>
+      <group targetFramework="Xamarin.iOS1.0">
+        <dependency id="OxyPlot.Xamarin.iOS"/>
+      </group>
+      <group targetFramework="MonoAndroid1.0">
+        <dependency id="OxyPlot.Xamarin.Android"/>
+      </group>
+      <group targetFramework="wp80">
+        <dependency id="OxyPlot.WP8"/>
+      </group>
+      <group targetFramework="portable-windows8+wpa81">
+        <dependency id="OxyPlot.WindowsUniversal"/>
+      </group>	
+      <group>
+        <dependency id="OxyPlot.Core" version="[0.0.0]"/>
+      </group>
     </dependencies>
   </metadata>
-  <files>
-    <file src="..\Output\WindowsUniversal\OxyPlot.WindowsUniversal.???" target="lib\portable-windows8+wpa81\" />
-    <file src="..\Output\WindowsUniversal\OxyPlot.WindowsUniversal.xr.xml" target="lib\portable-windows8+wpa81\" />
-    <file src="..\Output\WindowsUniversal\Themes\*.*" target="lib\portable-windows8+wpa81\Themes\" />
-
-    <file src="..\Output\WP8\OxyPlot.WP8.???" target="lib\windowsphone8" />
-
-    <file src="..\Output\Xamarin.Android\OxyPlot.Xamarin.Android.???" target="lib\MonoAndroid" />	
-
-    <file src="..\Output\MonoTouch\OxyPlot.MonoTouch.???" target="lib\MonoTouch" />
-    <file src="..\Output\MonoTouch\OxyPlot.MonoTouch.???" target="lib\MonoTouch" />
-    <file src="..\Output\Xamarin.iOS\OxyPlot.Xamarin.iOS.???" target="lib\Xamarin.iOS10" />
-    <file src="..\Output\Xamarin.iOS\OxyPlot.Xamarin.iOS.???" target="lib\Xamarin.iOS10" />
-  </files>
 </package>


### PR DESCRIPTION
Based on the changes in #362 :

 - Added the OxyPlot.Mobile NuGet
 - OxyPlot.Xamarin.Forms now depends on OxyPlot.Mobile

The change in the android target platform to 2.3 was only for the ExampleBrowser app, not the library - which is already done.