### PR TITLE
Xamarin.Forms NuGet PCL fixes

### DIFF
--- a/Build/build-mobile.cmd
+++ b/Build/build-mobile.cmd
@@ -5,6 +5,7 @@ del /S /Q Output\*.*
 
 UpdateVersionNumbers.exe /VersionFromNuGet=OxyPlot.Core /Dependency=OxyPlot.Core /Dependency=OxyPlot.Mobile /ExtractReleaseNotes=CHANGELOG.md /Directory=.
 
+nuget restore Source\OxyPlot.Mobile.sln
 msbuild.exe Source\OxyPlot.Mobile.sln /p:Configuration=Release
 
 nuget pack Source\OxyPlot.Mobile.nuspec -OutputDirectory Output

--- a/Source/OxyPlot.Xamarin.Forms/OxyPlot.Xamarin.Forms.nuspec
+++ b/Source/OxyPlot.Xamarin.Forms/OxyPlot.Xamarin.Forms.nuspec
@@ -13,10 +13,24 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>plotting plot charting chart xamarin forms android windows phone ios</tags>
     <dependencies>
+	  <group targetFramework="MonoTouch">
+        <dependency id="OxyPlot.Mobile" version="[0.0.0]"/>
+      </group>
+      <group targetFramework="Xamarin.iOS10">
+        <dependency id="OxyPlot.Mobile" version="[0.0.0]"/>
+      </group>
+      <group targetFramework="MonoAndroid">
+        <dependency id="OxyPlot.Mobile" version="[0.0.0]"/>
+      </group>
+      <group targetFramework="windowsphone8">
+        <dependency id="OxyPlot.Mobile" version="[0.0.0]"/>
+      </group>
+      <group targetFramework="portable-windows8+wpa81">
+        <dependency id="OxyPlot.Mobile" version="[0.0.0]"/>
+      </group>
       <group>
         <dependency id="OxyPlot.Core" version="[0.0.0]"/>
-        <dependency id="OxyPlot.Mobile" version="[0.0.0]"/>
-        <dependency id="Xamarin.Forms"/>
+        <dependency id="Xamarin.Forms" version="1.3.3.6323" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Specifying the Mobile NuGet only on platforms 
 - not supported in PCL
 - specify version number for Xamarin.Forms to prevent the IDE from picking the latest pre-release

Restore the NuGets before building OxyPlot.Mobile
