### PR TITLE
fixes for CandleStickAndVolumeSeries + VolumeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Changed OxyPlot.Xamarin.Android target to Android level 10 (#223)
 - Separated WPF Plot and PlotView (#252,#239)
 - current CandleStickSeries renamed to OldCandleStickSeries, replaced by a faster implementation (#369)
+- fixed axis min/max calc & axis assignment for CandleStick + VolumeSeries (#389)
 
 ### Removed
 - OxyPlot.Metro project (superseded by OxyPlot.WindowsUniversal) (#241)

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickAndVolumeSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickAndVolumeSeriesExamples.cs
@@ -18,7 +18,7 @@ namespace ExampleLibrary
     public static class CandleStickAndVolumeSeriesExamples
     {
         [Example("Candles + Volume (combined volume), adjusting Y-axis")]
-        public static Example CombinedVolume_Adj()
+        public static Example CombinedVolume_Adjusting()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (combined volume)", 
@@ -28,7 +28,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (combined volume), natural Y-axis")]
-        public static Example CombinedVolume_Nat()
+        public static Example CombinedVolume_Natural()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (combined volume)", 
@@ -38,7 +38,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (stacked volume), adjusting Y-axis")]
-        public static Example StackedVolume_Adj()
+        public static Example StackedVolume_Adjusting()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (stacked volume)", 
@@ -48,7 +48,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (stacked volume), natural Y-axis")]
-        public static Example StackedVolume_Nat()
+        public static Example StackedVolume_Natural()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (stacked volume)", 
@@ -58,7 +58,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (+/- volume), adjusting Y-axis")]
-        public static Example PosNegVolume_Adj()
+        public static Example PosNegVolume_Adjusting()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (+/- volume)",
@@ -68,7 +68,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (+/- volume), natural Y-axis")]
-        public static Example PosNegVolume_Nat()
+        public static Example PosNegVolume_Natural()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (+/- volume)",
@@ -78,7 +78,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (volume not shown), adjusting Y-axis")]
-        public static Example NoVolume_Adj()
+        public static Example NoVolume_Adjusting()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (volume not shown)", 
@@ -88,7 +88,7 @@ namespace ExampleLibrary
         }
 
         [Example("Candles + Volume (volume not shown), natural Y-axis")]
-        public static Example NoVolume_Nat()
+        public static Example NoVolume_Natural()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (volume not shown)", 
@@ -150,7 +150,7 @@ namespace ExampleLibrary
             var barAxis = new LinearAxis
             {
                 Position = AxisPosition.Left,
-                Key = "Bars",
+                Key = series.BarAxisKey,
                 StartPosition = 0.25,
                 EndPosition = 1.0,
                 Minimum = naturalY ? double.NaN : Ymin,
@@ -159,7 +159,7 @@ namespace ExampleLibrary
             var volAxis = new LinearAxis
             {
                 Position = AxisPosition.Left,
-                Key = "Volume",
+                Key = series.VolumeAxisKey,
                 StartPosition = 0.0,
                 EndPosition = 0.22,
                 Minimum = naturalV ? double.NaN : 0,

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickAndVolumeSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickAndVolumeSeriesExamples.cs
@@ -17,42 +17,101 @@ namespace ExampleLibrary
     [Tags("Series")]
     public static class CandleStickAndVolumeSeriesExamples
     {
-        [Example("Candles + Volume (combined volume)")]
-        public static Example CombinedVolume()
+        [Example("Candles + Volume (combined volume), adjusting Y-axis")]
+        public static Example CombinedVolume_Adj()
         {
-            return CreateCandleStickAndVolumeSeriesExample("Candles + Volume (combined volume)", VolumeStyle.Combined);
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (combined volume)", 
+                VolumeStyle.Combined,
+                naturalY: false,
+                naturalV: false);
         }
 
-        [Example("Candles + Volume (stacked volume)")]
-        public static Example StackedVolume()
+        [Example("Candles + Volume (combined volume), natural Y-axis")]
+        public static Example CombinedVolume_Nat()
         {
-            return CreateCandleStickAndVolumeSeriesExample("Candles + Volume (stacked volume)", VolumeStyle.Stacked);
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (combined volume)", 
+                VolumeStyle.Combined,
+                naturalY: true,
+                naturalV: true);
         }
 
-        [Example("Candles + Volume (+/- volume)")]
-        public static Example PosNegVolume()
+        [Example("Candles + Volume (stacked volume), adjusting Y-axis")]
+        public static Example StackedVolume_Adj()
+        {
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (stacked volume)", 
+                VolumeStyle.Stacked,
+                naturalY: false,
+                naturalV: false);
+        }
+
+        [Example("Candles + Volume (stacked volume), natural Y-axis")]
+        public static Example StackedVolume_Nat()
+        {
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (stacked volume)", 
+                VolumeStyle.Stacked,
+                naturalY: true,
+                naturalV: true);
+        }
+
+        [Example("Candles + Volume (+/- volume), adjusting Y-axis")]
+        public static Example PosNegVolume_Adj()
         {
             return CreateCandleStickAndVolumeSeriesExample(
                 "Candles + Volume (+/- volume)",
-                VolumeStyle.PositiveNegative);
+                VolumeStyle.PositiveNegative,
+                naturalY: false,
+                naturalV: false);
         }
 
-        [Example("Candles + Volume (volume not shown)")]
-        public static Example NoVolume()
+        [Example("Candles + Volume (+/- volume), natural Y-axis")]
+        public static Example PosNegVolume_Nat()
         {
-            return CreateCandleStickAndVolumeSeriesExample("Candles + Volume (volume not shown)", VolumeStyle.None);
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (+/- volume)",
+                VolumeStyle.PositiveNegative,
+                naturalY: true,
+                naturalV: true);
+        }
+
+        [Example("Candles + Volume (volume not shown), adjusting Y-axis")]
+        public static Example NoVolume_Adj()
+        {
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (volume not shown)", 
+                VolumeStyle.None,
+                naturalY: false,
+                naturalV: false);
+        }
+
+        [Example("Candles + Volume (volume not shown), natural Y-axis")]
+        public static Example NoVolume_Nat()
+        {
+            return CreateCandleStickAndVolumeSeriesExample(
+                "Candles + Volume (volume not shown)", 
+                VolumeStyle.None,
+                naturalY: true,
+                naturalV: true);
         }
 
         /// <summary>
-        /// Creates the candlestick and volume series example.
+        /// Creates the candle stick and volume series example.
         /// </summary>
-        /// <param name="title">The title.</param>
-        /// <param name="style">The style.</param>
-        /// <param name="n">The number of bars.</param>
-        /// <returns>
-        /// An example.
-        /// </returns>
-        private static Example CreateCandleStickAndVolumeSeriesExample(string title, VolumeStyle style, int n = 10000)
+        /// <returns>The candle stick and volume series example.</returns>
+        /// <param name="title">Title.</param>
+        /// <param name="style">Style.</param>
+        /// <param name="n">N.</param>
+        /// <param name="naturalY">If set to <c>true</c> natural y.</param>
+        /// <param name="naturalV">If set to <c>true</c> natural v.</param>
+        private static Example CreateCandleStickAndVolumeSeriesExample(
+            string title, 
+            VolumeStyle style, 
+            int n = 10000,
+            bool naturalY = false,
+            bool naturalV = false)
         {
             var pm = new PlotModel { Title = title };
 
@@ -94,8 +153,8 @@ namespace ExampleLibrary
                 Key = "Bars",
                 StartPosition = 0.25,
                 EndPosition = 1.0,
-                Minimum = Ymin,
-                Maximum = Ymax
+                Minimum = naturalY ? double.NaN : Ymin,
+                Maximum = naturalY ? double.NaN : Ymax
             };
             var volAxis = new LinearAxis
             {
@@ -103,13 +162,14 @@ namespace ExampleLibrary
                 Key = "Volume",
                 StartPosition = 0.0,
                 EndPosition = 0.22,
-                Minimum = 0,
-                Maximum = 5000
+                Minimum = naturalV ? double.NaN : 0,
+                Maximum = naturalV ? double.NaN : 5000
             };
 
             switch (style)
             {
                 case VolumeStyle.None:
+                    barAxis.Key = null;
                     barAxis.StartPosition = 0.0;
                     pm.Axes.Add(timeAxis);
                     pm.Axes.Add(barAxis);
@@ -123,7 +183,7 @@ namespace ExampleLibrary
                     break;
 
                 case VolumeStyle.PositiveNegative:
-                    volAxis.Minimum = -5000;
+                    volAxis.Minimum = naturalV ? double.NaN : -5000;
                     pm.Axes.Add(timeAxis);
                     pm.Axes.Add(barAxis);
                     pm.Axes.Add(volAxis);
@@ -131,7 +191,11 @@ namespace ExampleLibrary
             }
 
             pm.Series.Add(series);
-            timeAxis.AxisChanged += (sender, e) => AdjustYExtent(series, timeAxis, barAxis);
+
+            if (naturalY == false)
+            {
+                timeAxis.AxisChanged += (sender, e) => AdjustYExtent(series, timeAxis, barAxis);
+            }
 
             var controller = new PlotController();
             controller.InputCommandBindings.Clear();

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/VolumeSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/VolumeSeriesExamples.cs
@@ -14,34 +14,55 @@ namespace ExampleLibrary
     [Tags("Series")]
     public static class VolumeSeriesExamples
     {
-        [Example("Just Volume (combined)")]
-        public static Example JustVolumeCombined()
+        [Example("Just Volume (combined), fixed axis")]
+        public static Example JustVolumeCombined_Fixed()
         {
-            return CreateVolumeSeries("Just Volume (combined)", VolumeStyle.Combined);
+            return CreateVolumeSeries("Just Volume (combined)", VolumeStyle.Combined, natural: false);
         }
 
-        [Example("Just Volume (stacked)")]
-        public static Example JustVolumeStacked()
+        [Example("Just Volume (combined), natural axis")]
+        public static Example JustVolumeCombined_Natural()
         {
-            return CreateVolumeSeries("Just Volume (stacked)", VolumeStyle.Stacked);
+            return CreateVolumeSeries("Just Volume (combined)", VolumeStyle.Combined, natural: true);
         }
 
-        [Example("Just Volume (+/-)")]
-        public static Example JustVolumePositiveNegative()
+        [Example("Just Volume (stacked), fixed axis")]
+        public static Example JustVolumeStacked_Fixed()
         {
-            return CreateVolumeSeries("Just Volume (+/-)", VolumeStyle.PositiveNegative);
+            return CreateVolumeSeries("Just Volume (stacked)", VolumeStyle.Stacked, natural: false);
+        }
+
+        [Example("Just Volume (stacked), natural axis")]
+        public static Example JustVolumeStacked_Natural()
+        {
+            return CreateVolumeSeries("Just Volume (stacked)", VolumeStyle.Stacked, natural: true);
+        }
+
+        [Example("Just Volume (+/-), fixed axis")]
+        public static Example JustVolumePositiveNegative_Fixed()
+        {
+            return CreateVolumeSeries("Just Volume (+/-)", VolumeStyle.PositiveNegative, natural: false);
+        }
+
+        [Example("Just Volume (+/-), natural axis")]
+        public static Example JustVolumePositiveNegative_Natural()
+        {
+            return CreateVolumeSeries("Just Volume (+/-)", VolumeStyle.PositiveNegative, natural: true);
         }
 
         /// <summary>
-        /// Creates a volume series example.
+        /// Creates the volume series.
         /// </summary>
+        /// <returns>The volume series.</returns>
         /// <param name="title">Title.</param>
         /// <param name="style">Style.</param>
-        /// <param name="n">The number of bars.</param>
-        /// <returns>
-        /// A volume series.
-        /// </returns>
-        private static Example CreateVolumeSeries(string title, VolumeStyle style, int n = 10000)
+        /// <param name="n">N.</param>
+        /// <param name="natural">If set to <c>true</c> natural.</param>
+        private static Example CreateVolumeSeries(
+            string title, 
+            VolumeStyle style, 
+            int n = 10000,
+            bool natural = false)
         {
             var pm = new PlotModel { Title = title };
 
@@ -79,8 +100,8 @@ namespace ExampleLibrary
                 Key = "Volume",
                 StartPosition = 0.0,
                 EndPosition = 1.0,
-                Minimum = 0,
-                Maximum = 10000
+                Minimum = natural ? double.NaN : 0,
+                Maximum = natural ? double.NaN : 10000
             };
 
             switch (style)
@@ -92,7 +113,7 @@ namespace ExampleLibrary
                     break;
 
                 case VolumeStyle.PositiveNegative:
-                    volAxis.Minimum = -10000;
+                    volAxis.Minimum = natural ? double.NaN : -10000;
                     pm.Axes.Add(timeAxis);
                     pm.Axes.Add(volAxis);
                     break;

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
@@ -46,16 +46,10 @@ namespace OxyPlot.Series
         private int winIndex;
 
         /// <summary>
-        /// The style of volume to be rendered
-        /// </summary>
-        private VolumeStyle volumeStyle;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref = "CandleStickAndVolumeSeries" /> class.
         /// </summary>
         public CandleStickAndVolumeSeries()
         {
-            this.YAxisKey = "Bars";
             this.PositiveColor = OxyColors.DarkGreen;
             this.NegativeColor = OxyColors.Red;
             this.SeparatorColor = OxyColors.Black;
@@ -66,6 +60,9 @@ namespace OxyPlot.Series
             this.NegativeHollow = false;
             this.PositiveHollow = true;
             this.StrokeIntensity = 0.80;
+            this.VolumeStyle = VolumeStyle.Combined;
+            this.VolumeAxisKey = "Volume";
+            this.BarAxisKey = null;
 
             this.TrackerFormatString = DefaultTrackerFormatString;
         }
@@ -104,27 +101,19 @@ namespace OxyPlot.Series
         public LinearAxis VolumeAxis { get; private set; }
 
         /// <summary>
-        /// Gets or sets the style of volume rendering
+        /// Gets or sets the volume axis key (defaults to "Volume")
         /// </summary>
-        public VolumeStyle VolumeStyle 
-        { 
-            get
-            {
-                return this.volumeStyle;
-            }
+        public string VolumeAxisKey { get; set; }
 
-            set
-            {
-                // if style has changed adjust axis min/max
-                if (value != this.volumeStyle && this.VolumeAxis != null)
-                {
-                    this.YAxis.ResetDataMaxMin();
-                    this.UpdateAxisMaxMin();
-                }
+        /// <summary>
+        /// Gets or sets the bar axis key (defaults to null, as is the primary axis).
+        /// </summary>
+        public string BarAxisKey { get; set; }
 
-                this.volumeStyle = value;
-            }
-        }
+        /// <summary>
+        /// Gets or sets the style of volume rendering (defaults to Combined)
+        /// </summary>
+        public VolumeStyle VolumeStyle { get; set; }
 
         /// <summary>
         /// Gets or sets the thickness of the bar lines
@@ -556,20 +545,10 @@ namespace OxyPlot.Series
         protected internal override void EnsureAxes()
         {
             // find volume axis
-            this.VolumeAxis = (LinearAxis)this.PlotModel.Axes.FirstOrDefault(a => a.Key == "Volume");
+            this.VolumeAxis = (LinearAxis)this.PlotModel.Axes.FirstOrDefault(a => a.Key == this.VolumeAxisKey);
 
-            // assign the bar axis if not found
-            var barAxis = this.PlotModel.Axes.FirstOrDefault(a => a.Key == "Bars");
-            if (barAxis == null)
-            {
-                // determine a bar axis fallback
-                var defAxis = this.PlotModel.Axes.FirstOrDefault(a => a.IsVertical() && a.Key != "Volume");
-               
-                // would be nice to avoid having to change the key & override base method
-                defAxis.Key = "Bars";
-            }
-
-            // now setup XYSeries axes
+            // now setup XYSeries axes, where BarAxisKey indicates the primary Y axis
+            this.YAxisKey = this.BarAxisKey;
             base.EnsureAxes();
         }
 

--- a/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
@@ -40,11 +40,6 @@ namespace OxyPlot.Series
         private int winIndex;
 
         /// <summary>
-        /// The style of volume to be rendered
-        /// </summary>
-        private VolumeStyle volumeStyle;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref = "VolumeSeries" /> class.
         /// </summary>
         public VolumeSeries()
@@ -83,30 +78,9 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Gets or sets the style of volume rendering
+        /// Gets or sets the style of volume rendering (defaults to Combined)
         /// </summary>
-        public VolumeStyle VolumeStyle 
-        { 
-            get
-            {
-                return this.volumeStyle;
-            }
-        
-            set
-            {
-                // if style has changed adjust axis min/max
-                if (value != this.volumeStyle && this.YAxis != null)
-                {
-                    this.volumeStyle = value;
-                    this.YAxis.ResetDataMaxMin();
-                    this.UpdateAxisMaxMin();
-                }
-                else
-                {
-                    this.volumeStyle = value;
-                }
-            }
-        }
+        public VolumeStyle VolumeStyle { get; set; }
 
         /// <summary>
         /// Gets or sets the thickness of the bar lines


### PR DESCRIPTION
This addresses issue #389:

1. missing UpdateMaxMin() for default axis sizing
    * added UpdateMaxMin() and some behavior around this to allow the use of these series without explicitly setting Minimum and Maximum on the axes.
2. CandleStickAndVolume series would throw an exception if created with a Y axis without the "Bars" key (normally used to distinguish the volume and bars axis)
    * now will find a default axis if Axis.Key = "Bars" is not available

I have implemented tests for the above.