### PR TITLE
Wpf: Override FrameworkElement.LogicalChildren in Plot

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,6 +41,7 @@ Jonathan Shore <jonathan.shore@gmail.com>
 julien.bataille
 Just Slon <just.slon@gmail.com>
 kenny_evoleap
+Kenny Nygaard
 Kevin Crowell <crowell@proteinmetrics.com>
 LECO® Corporation
 Levi Botelho <levi_botelho@hotmail.com>

--- a/Source/OxyPlot.Wpf/Plot.cs
+++ b/Source/OxyPlot.Wpf/Plot.cs
@@ -97,6 +97,30 @@ namespace OxyPlot.Wpf
         }
 
         /// <summary>
+        /// Gets an enumerator for logical child elements of this element.
+        /// </summary>
+        protected override System.Collections.IEnumerator LogicalChildren
+        {
+            get
+            {
+                foreach (var annotation in this.Annotations)
+                {
+                    yield return annotation;
+                }
+
+                foreach (var axis in this.Axes)
+                {
+                    yield return axis;
+                }
+
+                foreach (var series in this.Series)
+                {
+                    yield return series;
+                }
+            }
+        }
+
+        /// <summary>
         /// Updates the model. If Model==<c>null</c>, an internal model will be created. The ActualModel.Update will be called (updates all series data).
         /// </summary>
         /// <param name="updateData">if set to <c>true</c> , all data collections will be updated.</param>


### PR DESCRIPTION
Fixes #40 

Needed to override FrameworkElement.LogicalChildren in order to pass on DataContext and other inherited properties.