### PR TITLE
Chocolatey should not prompt in AppVeyor script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,10 @@
     ftp_password:
       secure: 8Zwx5dScSahnbraTsKTP3g==
   install:
-    - cinst stylecop
-    - cinst LynxToolkit
-    - cinst gtksharp
-    - cinst gitlink -Pre
+    - cinst stylecop -y
+    - cinst LynxToolkit -y
+    - cinst gtksharp -y
+    - cinst gitlink -Pre -y
   platform: Any CPU
   configuration: Release
   before_build:
@@ -59,10 +59,10 @@
     ftp_password:
       secure: 8Zwx5dScSahnbraTsKTP3g==
   install:
-    - cinst stylecop
-    - cinst LynxToolkit
-    - cinst gtksharp
-    - cinst gitlink -Pre
+    - cinst stylecop -y
+    - cinst LynxToolkit -y
+    - cinst gtksharp -y
+    - cinst gitlink -Pre -y
   platform: Any CPU
   configuration: Release
   before_build:


### PR DESCRIPTION
To fix the following message in the build log:

```
!!ATTENTION!!
The next version of Chocolatey (v0.9.9) will require -y to perform
  behaviors that change state without prompting for confirmation. Start
  using it now in your automated scripts.
 
  For details on the all new Chocolatey, visit http://bit.ly/new_choco
```