### PR TITLE
Fix tracker position in WinForms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - ManipulatorBase.GetCursorType method (#447)
 
 ### Fixed
+- Tracker position is wrong when PlotView is offset from origin (#455)
 - CategoryAxis should use StringFormat (#415)
 - Fixed the dependency of OxyPlot.Xamarin.Forms NuGet (#370)
 - Add default ctor for Xamarin.Forms iOS renderer (#348)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ eric
 Garrett
 Geert van Horrik <geert@catenalogic.com>
 Gimly
+Iain Nicol <git@iainnicol.com>
 Iurii Gazin <archeg@gmail.com>
 jaykul
 jezza323

--- a/Source/OxyPlot.WindowsForms/PlotView.cs
+++ b/Source/OxyPlot.WindowsForms/PlotView.cs
@@ -320,8 +320,8 @@ namespace OxyPlot.WindowsForms
             }
 
             this.trackerLabel.Text = data.ToString();
-            this.trackerLabel.Top = (int)data.Position.Y - this.Top;
-            this.trackerLabel.Left = (int)data.Position.X - this.Left;
+            this.trackerLabel.Top = (int)data.Position.Y;
+            this.trackerLabel.Left = (int)data.Position.X;
             this.trackerLabel.Visible = true;
         }
 


### PR DESCRIPTION
This was fun to debug!  I couldn't see the tracker.  My first, incorrect, guess was that I had to set the TrackerFormatString.