### PR TITLE
Fix LineSeries NullReferenceException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project will be documented in this file.
 - Inaccurate tracker when using LogarithmicAxis (#443)
 - Fix reset of transforms in WinForms render context (#489)
 - Fix StringFormat for TimeSpanAxis not recognizing f, ff, fff, etc (#330)
+- Fix  LineSeries SMOOTH=True will crash WinForms on right click (#499)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -81,6 +81,7 @@ namespace OxyPlot.Series
 
             this.CanTrackerInterpolatePoints = true;
             this.LabelMargin = 6;
+            this.smoothedPoints = new List<DataPoint>();
         }
 
         /// <summary>
@@ -261,7 +262,7 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Gets or sets the smoothed points.
+        /// Gets the smoothed points.
         /// </summary>
         /// <value>The smoothed points.</value>
         protected List<DataPoint> SmoothedPoints
@@ -269,11 +270,6 @@ namespace OxyPlot.Series
             get
             {
                 return this.smoothedPoints;
-            }
-
-            set
-            {
-                this.smoothedPoints = value;
             }
         }
 
@@ -299,18 +295,23 @@ namespace OxyPlot.Series
                 }
             }
 
-            if (interpolate && this.Smooth && this.SmoothedPoints != null)
+            if (interpolate && this.Smooth)
             {
                 var result = this.GetNearestInterpolatedPointInternal(this.SmoothedPoints, point);
-                result.Text = StringHelper.Format(
-                    this.ActualCulture, 
-                    this.TrackerFormatString,
-                    result.Item,
-                    this.Title,
-                    this.XAxis.Title ?? XYAxisSeries.DefaultXAxisTitle,
-                    this.XAxis.GetValue(result.DataPoint.X),
-                    this.YAxis.Title ?? XYAxisSeries.DefaultYAxisTitle,
-                    this.YAxis.GetValue(result.DataPoint.Y));
+                if (result != null)
+                {
+                    result.Text = StringHelper.Format(
+                        this.ActualCulture,
+                        this.TrackerFormatString,
+                        result.Item,
+                        this.Title,
+                        this.XAxis.Title ?? XYAxisSeries.DefaultXAxisTitle,
+                        this.XAxis.GetValue(result.DataPoint.X),
+                        this.YAxis.Title ?? XYAxisSeries.DefaultYAxisTitle,
+                        this.YAxis.GetValue(result.DataPoint.Y));
+                }
+
+                return result;
             }
 
             return base.GetNearestPoint(point, interpolate);
@@ -413,16 +414,16 @@ namespace OxyPlot.Series
                 // Make sure the smooth points are re-evaluated.
                 this.ResetSmoothedPoints();
 
-                if (this.smoothedPoints.Count == 0)
+                if (this.SmoothedPoints.Count == 0)
                 {
                     return;
                 }
 
                 // Update the max/min from the smoothed points
-                this.MinX = this.smoothedPoints.Where(x => !double.IsNaN(x.X)).Min(x => x.X);
-                this.MinY = this.smoothedPoints.Where(x => !double.IsNaN(x.Y)).Min(x => x.Y);
-                this.MaxX = this.smoothedPoints.Where(x => !double.IsNaN(x.X)).Max(x => x.X);
-                this.MaxY = this.smoothedPoints.Where(x => !double.IsNaN(x.Y)).Max(x => x.Y);
+                this.MinX = this.SmoothedPoints.Where(x => !double.IsNaN(x.X)).Min(x => x.X);
+                this.MinY = this.SmoothedPoints.Where(x => !double.IsNaN(x.Y)).Min(x => x.Y);
+                this.MaxX = this.SmoothedPoints.Where(x => !double.IsNaN(x.X)).Max(x => x.X);
+                this.MaxY = this.SmoothedPoints.Where(x => !double.IsNaN(x.Y)).Max(x => x.Y);
             }
             else
             {


### PR DESCRIPTION
NullReferenceException in LineSeries.GetNearestPoints() when Smooth =
true