### PR TITLE
Update TargetFrameworkVersion to v4.5

### DIFF
--- a/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp.csproj
+++ b/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OxyPlot.GtkSharp</RootNamespace>
     <AssemblyName>OxyPlot.GtkSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <ProductVersion>8.0.30703</ProductVersion>


### PR DESCRIPTION
Fixes build error:

     GraphicsRenderContext.cs(24,42): error CS0012: The type `System.Object' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

because OxyPlot already targeting v4.5 since this commit 096c0cf833f969af6f00d01f602f126048e8497e
