### PR TITLE
Updated the pack scripts to use the mono NuGet

### DIFF
--- a/Build/build-xamarin.sh
+++ b/Build/build-xamarin.sh
@@ -45,7 +45,7 @@ ls -al ../Output/Xamarin.Mac/OxyPlot*
 
 
 # Start the packaging
-$NUGET pack ../Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.nuspec -OutputDirectory ../Output
-$NUGET pack ../Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.nuspec -OutputDirectory ../Output
-$NUGET pack ../Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.nuspec -OutputDirectory ../Output
+$NUGET pack ../Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.nuspec -BasePath ../Source/OxyPlot.Xamarin.iOS/ -OutputDirectory ../Output
+$NUGET pack ../Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.nuspec -BasePath ../Source/OxyPlot.Xamarin.Android/ -OutputDirectory ../Output
+$NUGET pack ../Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.nuspec -BasePath ../Source/OxyPlot.Xamarin.Mac/ -OutputDirectory ../Output
 ls -al ../Output/*.nupkg

--- a/Build/build.sh
+++ b/Build/build.sh
@@ -31,7 +31,17 @@ else
 	echo "  OK"
 fi
 ls -al ../Output/Xamarin.iOS/OxyPlot*
-mate build-ios.log
+
+echo
+echo "Building for MonoTouch"
+# Build OxyPlot. The output will be created in the $OUTPUT folder.
+"$MDTOOL" build "--configuration:Release" $SOURCE/OxyPlot.MonoTouch.sln > build-monotouch.log
+if [ $? -ne 0 ]; then
+echo "  FAILED"
+else
+echo "  OK"
+fi
+ls -al ../Output/MonoTouch/OxyPlot*
 
 echo
 echo "Building for Xamarin.Android"
@@ -43,4 +53,3 @@ else
 fi
 
 ls -al ../Output/Xamarin.Android/OxyPlot*
-mate build-android.log

--- a/Build/pack-mac.sh
+++ b/Build/pack-mac.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-NUGET=/usr/local/bin/NuGet.exe
+NUGET=/usr/bin/nuget
 
 rm -f ../Output/*.nupkg
 
 # Create Xamarin.Mac NuGet package
-mono $NUGET pack ../Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.nuspec -OutputDirectory ../Output
+$NUGET pack ../Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.nuspec -BasePath ../Source/OxyPlot.Xamarin.Mac/ -OutputDirectory ../Output
 
 ls -al ../Output/*.nupkg

--- a/Build/pack.sh
+++ b/Build/pack.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-NUGET=/usr/local/bin/NuGet.exe
+NUGET=/usr/bin/nuget
 
 rm -f ../Output/*.nupkg
 
 # Create Xamarin.iOS NuGet package
-mono $NUGET pack ../Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.nuspec -OutputDirectory ../Output
+$NUGET pack ../Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.nuspec -BasePath ../Source/OxyPlot.Xamarin.iOS/ -OutputDirectory ../Output
 
 # Create Xamarin.Android NuGet package
-mono $NUGET pack ../Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.nuspec -OutputDirectory ../Output
+$NUGET pack ../Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.nuspec -BasePath ../Source/OxyPlot.Xamarin.Android/ -OutputDirectory ../Output
 
 ls -al ../Output/*.nupkg


### PR DESCRIPTION
 - this has "more" optimised support for non-Windows platforms
 - use the `-BasePath` argument to avoid any working-directory or path issues

This has no theoretical change as I believe the default `BasePath` is actually the directory of the `.nuspec`, but I know that this does not always work - as can be seen by the fact that although it finds the assemblies (no not-found errors), it doesn't actually include them in the `.nupkg` (not in the uploaded NuGet)