### PR TITLE
Fix for Xamarin platform NuGets in VS

### DIFF
--- a/Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.nuspec
+++ b/Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.nuspec
@@ -19,9 +19,6 @@
   <files>
     <file src="../../Output/Xamarin.Android/OxyPlot.Xamarin.Android.???" target="lib/MonoAndroid"/>
 
-    <file src="../../LICENSE" />
-    <file src="../../AUTHORS" />
-    <file src="../../CONTRIBUTORS" />
     <file src="../../README.md" />
     <file src="../../CHANGELOG.md" />
   </files>

--- a/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.nuspec
+++ b/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.nuspec
@@ -18,9 +18,6 @@
   <files>
     <file src="../../Output/Xamarin.Mac/OxyPlot.Xamarin.Mac.???" target="lib/Xamarin.Mac20"/>
 
-    <file src="../../LICENSE" />
-    <file src="../../AUTHORS" />
-    <file src="../../CONTRIBUTORS" />
     <file src="../../README.md" />
     <file src="../../CHANGELOG.md" />
   </files>

--- a/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.nuspec
+++ b/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.nuspec
@@ -20,9 +20,6 @@
     <file src="../../Output/MonoTouch/OxyPlot.MonoTouch.???" target="lib/MonoTouch"/>
     <file src="../../Output/Xamarin.iOS/OxyPlot.Xamarin.iOS.???" target="lib/Xamarin.iOS10"/>
 
-    <file src="../../LICENSE" />
-    <file src="../../AUTHORS" />
-    <file src="../../CONTRIBUTORS" />
     <file src="../../README.md" />
     <file src="../../CHANGELOG.md" />
   </files>


### PR DESCRIPTION
For some reason, only the Xamarin platforms struggle to install extension-less files. The same logic applies when installing to any other project type.