### PR TITLE
Fixed issue where a tap would transition PanZoomGestureRecognizer to …

### DIFF
--- a/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PanZoomGestureRecognizer.cs
@@ -193,7 +193,15 @@ namespace OxyPlot.MonoTouch
                 if (!this.activeTouches.Any())
                 {
                     this.TouchEventArgs = firstTouch.ToTouchEventArgs(this.View);
-                    this.State = UIGestureRecognizerState.Ended;
+
+					if (this.State == UIGestureRecognizerState.Possible)
+					{
+						this.State = UIGestureRecognizerState.Failed;
+					}
+					else
+					{
+						this.State = UIGestureRecognizerState.Ended;
+					}
                 }
             }
         }
@@ -228,7 +236,15 @@ namespace OxyPlot.MonoTouch
 				if (!this.activeTouches.Any())
 				{
 					this.TouchEventArgs = firstTouch.ToTouchEventArgs(this.View);
-					this.State = UIGestureRecognizerState.Cancelled;
+
+					if (this.State == UIGestureRecognizerState.Possible)
+					{
+						this.State = UIGestureRecognizerState.Failed;
+					}
+					else
+					{
+						this.State = UIGestureRecognizerState.Cancelled;
+					}
 				}
 			}
         }


### PR DESCRIPTION
…Ended rather than Failed, firing a TouchCompleted for a touch that never started (and potentially interfering with other gesture recognizers that the application might have added, e.g. a UITapGestureRecognizer)