### PR TITLE
Fixes for #554 (CandleStickSeries legend scaling issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@ All notable changes to this project will be documented in this file.
 - Fix  LineSeries SMOOTH=True will crash WinForms on right click (#499)
 - Fix PlotView leak on iOS (#503)
 - This PlotModel is already in use by some other PlotView control (#497)
-- LegendTextColor not synchronized between wpf.Plot and InternalModel #548 
+- LegendTextColor not synchronized between wpf.Plot and InternalModel (#548)
+- Legend in CandleStickSeries does not scale correctly (#554)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,6 +41,7 @@ Johan20D
 Jonathan Shore <jonathan.shore@gmail.com>
 julien.bataille
 Just Slon <just.slon@gmail.com>
+kc1212 <kc04bc@gmx.com>
 kenny_evoleap
 Kenny Nygaard
 Kevin Crowell <crowell@proteinmetrics.com>

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
@@ -429,9 +429,9 @@ namespace OxyPlot.Series
             var fillUp = this.GetSelectableFillColor(this.PositiveColor);
             var lineUp = this.GetSelectableColor(this.PositiveColor.ChangeIntensity(0.70));
 
-            var candlewidth =
+            var candlewidth = Math.Min(legendBox.Width,
                 this.XAxis.Transform(this.data[0].X + datacandlewidth) -
-                this.XAxis.Transform(this.data[0].X);
+                this.XAxis.Transform(this.data[0].X));
 
             rc.DrawLine(
                 new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
@@ -429,9 +429,9 @@ namespace OxyPlot.Series
             var fillUp = this.GetSelectableFillColor(this.PositiveColor);
             var lineUp = this.GetSelectableColor(this.PositiveColor.ChangeIntensity(0.70));
 
-            var candlewidth = Math.Min(legendBox.Width,
-                this.XAxis.Transform(this.data[0].X + datacandlewidth) -
-                this.XAxis.Transform(this.data[0].X));
+            var candlewidth = Math.Min(
+                legendBox.Width,
+                this.XAxis.Transform(this.data[0].X + datacandlewidth) - this.XAxis.Transform(this.data[0].X));
 
             rc.DrawLine(
                 new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
@@ -202,9 +202,9 @@ namespace OxyPlot.Series
 
             var datacandlewidth = (this.CandleWidth > 0) ? this.CandleWidth : this.minDx * 0.80;
 
-            var candlewidth = 
+            var candlewidth = Math.Min(legendBox.Width,
                 this.XAxis.Transform(this.Items[0].X + datacandlewidth) -
-                this.XAxis.Transform(this.Items[0].X); 
+                this.XAxis.Transform(this.Items[0].X));
 
             rc.DrawLine(
                 new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
@@ -202,9 +202,9 @@ namespace OxyPlot.Series
 
             var datacandlewidth = (this.CandleWidth > 0) ? this.CandleWidth : this.minDx * 0.80;
 
-            var candlewidth = Math.Min(legendBox.Width,
-                this.XAxis.Transform(this.Items[0].X + datacandlewidth) -
-                this.XAxis.Transform(this.Items[0].X));
+            var candlewidth = Math.Min(
+                legendBox.Width,
+                this.XAxis.Transform(this.Items[0].X + datacandlewidth) - this.XAxis.Transform(this.Items[0].X));
 
             rc.DrawLine(
                 new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },


### PR DESCRIPTION
I added some code such that the legend will not scale beyond the legend box. Not sure if tests are needed. I did some bench testing and it looked fine.
![oxyplot](https://cloud.githubusercontent.com/assets/1093806/9205643/55f77f38-405b-11e5-8795-7c255fae7ac0.png)
Please verify.