### PR TITLE
Fix issue #256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - PlotElement.Format method. Use StringHelper.Format instead.
 
 ### Fixed
+- HeatMapSeries.GetValue returns NaN instead of calculating a wrong value in proximity to NaN (#256)
 - Tracker position is wrong when PlotView is offset from origin (#455)
 - CategoryAxis should use StringFormat (#415)
 - Fixed the dependency of OxyPlot.Xamarin.Forms NuGet (#370)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Benoit Blanchon <>
 br
 brantheman
 Brannon King
+Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
 Cyril Martin <cyril.martin.cm@gmail.com>
 darrelbrown

--- a/Source/Examples/ExampleLibrary/Series/HeatMapSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HeatMapSeriesExamples.cs
@@ -82,6 +82,25 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("2×3, interpolated with two NaN values, flat data")]
+        public static PlotModel InterpolatedWithNanValueFlat()
+        {
+            var model = CreateExample("Interpolated including two NaN values, otherwise 4.71", true);
+            var hms = (HeatMapSeries)model.Series[0];
+
+            double datum = 4.71d;
+            hms.Data[0, 0] = datum;
+            hms.Data[0, 1] = datum;
+            hms.Data[0, 2] = datum;
+            hms.Data[1, 0] = datum;
+            hms.Data[1, 1] = datum;
+            hms.Data[1, 2] = datum;
+
+            hms.Data[0, 1] = double.NaN;
+            hms.Data[1, 0] = double.NaN;
+            return model;
+        }
+
         [Example("2×3, not interpolated")]
         public static PlotModel NotInterpolated()
         {
@@ -99,6 +118,27 @@ namespace ExampleLibrary
             hms.Data[1, 0] = double.NaN;
             return model;
         }
+
+        [Example("2×3, not interpolated with two NaN values, flat data")]
+        public static PlotModel NotInterpolatedWithNanValueFlat()
+        {
+            var model = CreateExample("Not interpolated values including two NaN values, otherwise 4.71", false);
+            var ca = (LinearColorAxis)model.Axes[0];
+            ca.InvalidNumberColor = OxyColors.Transparent;
+            var hms = (HeatMapSeries)model.Series[0];
+
+            double datum = 4.71d;
+            hms.Data[0, 0] = datum;
+            hms.Data[0, 1] = datum;
+            hms.Data[0, 2] = datum;
+            hms.Data[1, 0] = datum;
+            hms.Data[1, 1] = datum;
+            hms.Data[1, 2] = datum;
+
+            hms.Data[0, 1] = double.NaN;
+            hms.Data[1, 0] = double.NaN;
+            return model;
+        }	
 
         [Example("2×3, reversed x-axis")]
         public static PlotModel NotInterpolatedReversedX()


### PR DESCRIPTION
HeatMapSeries.GetValue returns double.NaN instead of calculating a
nonsense value in proximity to double.NaN.

Introduce tests that generate a flat data heat map to better illustrate
the bug that was fixed.