### PR TITLE
Fix CodeGenerator exception for types without parameterless ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ All notable changes to this project will be documented in this file.
 - This PlotModel is already in use by some other PlotView control (#497)
 - LegendTextColor not synchronized between wpf.Plot and InternalModel (#548)
 - Legend in CandleStickSeries does not scale correctly (#554)
+- Fix CodeGenerator exception for types without parameterless ctor (#573)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/OxyPlot.AppVeyor.sln
+++ b/Source/OxyPlot.AppVeyor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OxyPlot.Wpf", "OxyPlot.Wpf\OxyPlot.Wpf.csproj", "{698CCD8E-ADCC-4565-8517-5EDD36F07155}"
 EndProject

--- a/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
+++ b/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
@@ -83,6 +83,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)\..\StyleCop.targets" Condition=" '$(OS)' == 'Windows_NT' " />
 </Project>

--- a/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
+++ b/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
@@ -1,0 +1,39 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CodeGeneratorTests.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides unit tests for the CodeGenerator.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Tests
+{
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Provides unit tests for the <see cref="CodeGenerator" />.
+    /// </summary>
+    [TestFixture]
+    public class CodeGeneratorTests
+    {
+        /// <summary>
+        /// Test that code can be generated for all examples in the example library.
+        /// </summary>
+        [Test]
+        public void GenerateCodeForAllExamplesInExampleLibrary()
+        {
+            foreach (var ei in ExampleLibrary.Examples.GetList())
+            {
+                var pm = ei.PlotModel;
+                if (pm == null)
+                {
+                    continue;
+                }
+
+                var code = pm.ToCode();
+                Assert.That(code, Is.Not.Null, ei.Title);
+            }
+        }
+    }
+}

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Axes\AxisTests.cs" />
     <Compile Include="Axes\AxisUtilitiesTests.cs" />
     <Compile Include="Axes\LinearAxisTests.cs" />
+    <Compile Include="Foundation\CodeGeneratorTests.cs" />
     <Compile Include="Graphics\ElementCollectionTests.cs" />
     <Compile Include="NullRenderContext.cs" />
     <Compile Include="PlotModelExtensions.cs" />
@@ -144,6 +145,9 @@
       <Project>{7A0B35C0-DD17-4964-8E9A-44D6CECDC692}</Project>
       <Name>OxyPlot</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)\..\StyleCop.targets" Condition=" '$(OS)' == 'Windows_NT' " />

--- a/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
+++ b/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
@@ -97,6 +97,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)\..\StyleCop.targets" Condition=" '$(OS)' == 'Windows_NT' " />
 </Project>

--- a/Source/OxyPlot/Foundation/CodeGenerator/CodeGenerator.cs
+++ b/Source/OxyPlot/Foundation/CodeGenerator/CodeGenerator.cs
@@ -135,9 +135,19 @@ namespace OxyPlot
         /// <returns>The variable name.</returns>
         private string Add(object obj)
         {
-            Type type = obj.GetType();
-            object defaultInstance = Activator.CreateInstance(type);
-            string varName = this.GetNewVariableName(type);
+            var type = obj.GetType();
+#if UNIVERSAL
+            var hasParameterLessCtor = type.GetTypeInfo().DeclaredConstructors.Any(ci => ci.GetParameters().Length == 0);
+#else
+            var hasParameterLessCtor = type.GetConstructors().Any(ci => ci.GetParameters().Length == 0);
+#endif
+            if (!hasParameterLessCtor)
+            {
+                return string.Format("/* Cannot generate code for {0} constructor */", type.Name);
+            }
+
+            var defaultInstance = Activator.CreateInstance(type);
+            var varName = this.GetNewVariableName(type);
             this.variables.Add(varName, true);
             this.AppendLine("var {0} = new {1}();", varName, type.Name);
             this.SetProperties(obj, varName, defaultInstance);

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -203,7 +203,7 @@ namespace OxyPlot.Series
         {
             get
             {
-                return new System.Collections.ObjectModel.ReadOnlyCollection<T>(this.ActualPointsList);
+                return this.ActualPointsList != null ? new System.Collections.ObjectModel.ReadOnlyCollection<T>(this.ActualPointsList) : null;
             }
         }
 


### PR DESCRIPTION
Add tests to generate code for all examples in example library.
A null exception on ScatterSeries is also fixed.

This should solve #573