### PR TITLE
Fix NullReferenceException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to this project will be documented in this file.
 - Fix CodeGenerator exception for types without parameterless ctor (#573)
 - Migrate automatic package restore (#557)
 - Fix rendering of rotated 'math' text (#569, #448)
+- Fix null reference exception when ActualPoints was null rendering a StairStepSeries (#582) 
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,6 +19,7 @@ brantheman
 Brannon King
 Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
+Carlos Teixeira <karlmtc@gmail.com>
 Cyril Martin <cyril.martin.cm@gmail.com>
 darrelbrown
 David Laundav <davelaundav@gmail.com>

--- a/Source/OxyPlot/Series/StairStepSeries.cs
+++ b/Source/OxyPlot/Series/StairStepSeries.cs
@@ -141,7 +141,7 @@ namespace OxyPlot.Series
         /// <param name="rc">The rendering context.</param>
         public override void Render(IRenderContext rc)
         {
-            if (this.ActualPoints.Count == 0)
+            if (this.ActualPoints == null || this.ActualPoints.Count == 0)
             {
                 return;
             }


### PR DESCRIPTION
If ActualPoints is null, we can't access the count. We need to check for null first.