### PR TITLE
#587: Fixing a double comparison issue causing infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable changes to this project will be documented in this file.
 - Migrate automatic package restore (#557)
 - Fix rendering of rotated 'math' text (#569, #448)
 - Export demo (WPF) (#568)
+- Fixing a double comparison issue causing infinite loop (#587)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/OxyPlot/Axes/DateTimeAxis.cs
+++ b/Source/OxyPlot/Axes/DateTimeAxis.cs
@@ -325,7 +325,7 @@ namespace OxyPlot.Axes
                 }
 
                 double nextInterval = goodIntervals.FirstOrDefault(i => i > interval);
-                if (Math.Abs(nextInterval) < double.Epsilon)
+                if (Math.Abs(nextInterval) <= double.Epsilon)
                 {
                     nextInterval = interval * 2;
                 }


### PR DESCRIPTION
So I went the easy way ;) This seems to be more of a data type issue than a issue with OxyPlot's logic. Plus imho that method needs some refactoring in order to extract the logic for testing.