### PR TITLE
Throw exception if Xamarin.Forms renderer is not 'initialized'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ All notable changes to this project will be documented in this file.
 - Change to semantic versioning (#595)
 - Change GTKSharp3 project to x86 (#599)
 - Change OxyPlot.Xamarin.Android to API Level 15 (#614)
+- Add Xamarin.Forms renderer initialization to PlotViewRenderer (#632)
+- Marked OxyPlot.Xamarin.Forms.Platform.*.Forms.Init() obsolete (#632)
+- Throw exception if Xamarin.Forms renderer is not 'initialized' (#492)
 
 ### Removed
 - StyleCop tasks (#556)
@@ -108,7 +111,6 @@ All notable changes to this project will be documented in this file.
 - Rendering math text with syntax error gets stuck in an endless loop (#624)
 - Fix issue with MinimumRange not taking Minimum and Maximum values into account (#550)
 - Do not set default Controller in PlotView ctor (#436)
-- Throw exception if Xamarin.Forms renderer is not 'initialized' (#492)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable changes to this project will be documented in this file.
 - Rendering math text with syntax error gets stuck in an endless loop (#624)
 - Fix issue with MinimumRange not taking Minimum and Maximum values into account (#550)
 - Do not set default Controller in PlotView ctor (#436)
+- Throw exception if Xamarin.Forms renderer is not 'initialized' (#492)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/Examples/Xamarin.Forms/IssueDemos/IssueDemos.Droid/MainActivity.cs
+++ b/Source/Examples/Xamarin.Forms/IssueDemos/IssueDemos.Droid/MainActivity.cs
@@ -17,7 +17,7 @@ namespace IssueDemos.Droid
             base.OnCreate(bundle);
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
-            OxyPlot.Xamarin.Forms.Platform.Android.Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.Android.PlotViewRenderer.Init();
             LoadApplication(new App());
         }
     }

--- a/Source/Examples/Xamarin.Forms/IssueDemos/IssueDemos.WinPhone/MainPage.xaml.cs
+++ b/Source/Examples/Xamarin.Forms/IssueDemos/IssueDemos.WinPhone/MainPage.xaml.cs
@@ -18,7 +18,7 @@ namespace IssueDemos.WinPhone
             SupportedOrientations = SupportedPageOrientation.PortraitOrLandscape;
 
             global::Xamarin.Forms.Forms.Init();
-            OxyPlot.Xamarin.Forms.Platform.WP8.Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.WP8.PlotViewRenderer.Init();
             LoadApplication(new IssueDemos.App());
         }
     }

--- a/Source/Examples/Xamarin.Forms/IssueDemos/IssueDemos.iOS/AppDelegate.cs
+++ b/Source/Examples/Xamarin.Forms/IssueDemos/IssueDemos.iOS/AppDelegate.cs
@@ -23,7 +23,7 @@ namespace IssueDemos.iOS
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
             global::Xamarin.Forms.Forms.Init();
-            OxyPlot.Xamarin.Forms.Platform.iOS.Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.iOS.PlotViewRenderer.Init();
             LoadApplication(new App());
 
             return base.FinishedLaunching(app, options);

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.Droid/MainActivity.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.Droid/MainActivity.cs
@@ -10,8 +10,6 @@ namespace SimpleDemo.Droid
     using Android.Content.PM;
     using Android.OS;
 
-    using OxyPlot.Xamarin.Forms.Platform.Android;
-
     using Xamarin.Forms.Platform.Android;
 
     [Activity(Label = "SimpleDemo", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
@@ -21,7 +19,7 @@ namespace SimpleDemo.Droid
         {
             base.OnCreate(bundle);
 
-            Forms.Init(); 
+            OxyPlot.Xamarin.Forms.Platform.Android.Forms.Init(); 
             Xamarin.Forms.Forms.Init(this, bundle);
             this.LoadApplication(new App());
         }

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.Droid/MainActivity.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.Droid/MainActivity.cs
@@ -19,8 +19,8 @@ namespace SimpleDemo.Droid
         {
             base.OnCreate(bundle);
 
-            OxyPlot.Xamarin.Forms.Platform.Android.Forms.Init(); 
             Xamarin.Forms.Forms.Init(this, bundle);
+            OxyPlot.Xamarin.Forms.Platform.Android.PlotViewRenderer.Init();
             this.LoadApplication(new App());
         }
     }

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.WinPhone/MainPage.xaml.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.WinPhone/MainPage.xaml.cs
@@ -23,8 +23,8 @@ namespace SimpleDemo.WinPhone
             this.InitializeComponent();
             this.SupportedOrientations = SupportedPageOrientation.PortraitOrLandscape;
 
-            OxyPlot.Xamarin.Forms.Platform.WP8.Forms.Init();
             Xamarin.Forms.Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.WP8.PlotViewRenderer.Init();
             this.LoadApplication(new SimpleDemo.App());
         }
     }

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.iOS/AppDelegate.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.iOS/AppDelegate.cs
@@ -8,8 +8,6 @@ namespace SimpleDemo.iOS
 {
     using Foundation;
 
-    using OxyPlot.Xamarin.Forms.Platform.iOS;
-
     using UIKit;
 
     using Xamarin.Forms.Platform.iOS;
@@ -39,7 +37,7 @@ namespace SimpleDemo.iOS
         /// </returns>
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
-            Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.iOS.Forms.Init();
             Xamarin.Forms.Forms.Init();
             this.LoadApplication(new App());
 

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.iOS/AppDelegate.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo.iOS/AppDelegate.cs
@@ -37,8 +37,8 @@ namespace SimpleDemo.iOS
         /// </returns>
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
-            OxyPlot.Xamarin.Forms.Platform.iOS.Forms.Init();
             Xamarin.Forms.Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.iOS.PlotViewRenderer.Init();
             this.LoadApplication(new App());
 
             return base.FinishedLaunching(app, options);

--- a/Source/Examples/Xamarin.Forms/SimpleDemo2/SimpleDemo2.Droid/MainActivity.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo2/SimpleDemo2.Droid/MainActivity.cs
@@ -17,7 +17,7 @@ namespace SimpleDemo2.Droid
 			base.OnCreate (bundle);
 
 			global::Xamarin.Forms.Forms.Init (this, bundle);
-		    OxyPlot.Xamarin.Forms.Platform.Android.Forms.Init();
+		    OxyPlot.Xamarin.Forms.Platform.Android.PlotViewRenderer.Init();
 			LoadApplication (new SimpleDemo2.App ());
 		}
 	}

--- a/Source/Examples/Xamarin.Forms/SimpleDemo2/SimpleDemo2.WinPhone/MainPage.xaml.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo2/SimpleDemo2.WinPhone/MainPage.xaml.cs
@@ -18,7 +18,7 @@ namespace SimpleDemo2.WinPhone
 			SupportedOrientations = SupportedPageOrientation.PortraitOrLandscape;
 
 			global::Xamarin.Forms.Forms.Init ();
-            OxyPlot.Xamarin.Forms.Platform.WP8.Forms.Init();
+            OxyPlot.Xamarin.Forms.Platform.WP8.PlotViewRenderer.Init();
             LoadApplication(new SimpleDemo2.App ());
 		}
 	}

--- a/Source/Examples/Xamarin.Forms/SimpleDemo2/SimpleDemo2.iOS/AppDelegate.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo2/SimpleDemo2.iOS/AppDelegate.cs
@@ -23,7 +23,7 @@ namespace SimpleDemo2.iOS
 		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 		{
 			global::Xamarin.Forms.Forms.Init ();
-            OxyPlot.Xamarin.Forms.Platform.iOS.Forms.Init ();
+            OxyPlot.Xamarin.Forms.Platform.iOS.PlotViewRenderer.Init ();
 			LoadApplication (new SimpleDemo2.App ());
 
 			return base.FinishedLaunching (app, options);

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/Forms.cs
@@ -22,6 +22,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
         {
             // Just bring this assembly into the current appdomain.
             // Forms.Init() should now find it!
+            PlotView.IsRendererInitialized = true;
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/Forms.cs
@@ -9,6 +9,8 @@
 
 namespace OxyPlot.Xamarin.Forms.Platform.Android
 {
+    using System;
+
     /// <summary>
     /// Initializes OxyPlot renderers for use with Xamarin.Forms.
     /// </summary>
@@ -17,12 +19,10 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
         /// <summary>
         /// Initializes OxyPlot for Xamarin.Forms.
         /// </summary>
-        /// <remarks>This method must be called before Forms.Init().</remarks>
+        [Obsolete("Use PlotViewRenderer.Init() instead.")]
         public static void Init()
         {
-            // Just bring this assembly into the current appdomain.
-            // Forms.Init() should now find it!
-            PlotView.IsRendererInitialized = true;
+            PlotViewRenderer.Init();
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
@@ -19,10 +19,28 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
     public class PlotViewRenderer : ViewRenderer<Xamarin.Forms.PlotView, PlotView>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="PlotViewRenderer"/> class.
+        /// </summary>
+        static PlotViewRenderer()
+        {
+            Init();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PlotViewRenderer"/> class.
         /// </summary>
         public PlotViewRenderer()
         {
+            // Do not delete
+        }
+
+        /// <summary>
+        /// Initializes the renderer.
+        /// </summary>
+        /// <remarks>This method must be called before a <see cref="T:PlotView" /> is used.</remarks>
+        public static void Init()
+        {
+            OxyPlot.Xamarin.Forms.PlotView.IsRendererInitialized = true;
         }
 
         /// <summary>

--- a/Source/OxyPlot.Xamarin.Forms.Platform.WP8/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.WP8/Forms.cs
@@ -9,6 +9,8 @@
 
 namespace OxyPlot.Xamarin.Forms.Platform.WP8
 {
+    using System;
+
     /// <summary>
     /// Initializes OxyPlot renderers for use with Xamarin.Forms.
     /// </summary>
@@ -17,12 +19,10 @@ namespace OxyPlot.Xamarin.Forms.Platform.WP8
         /// <summary>
         /// Initializes OxyPlot for Xamarin.Forms.
         /// </summary>
-        /// <remarks>This method must be called before Forms.Init().</remarks>
+        [Obsolete("Use PlotViewRenderer.Init() instead.")]
         public static void Init()
         {
-            // Just bring this assembly into the current appdomain.
-            // Forms.Init() should now find it!
-            PlotView.IsRendererInitialized = true;
+            PlotViewRenderer.Init();
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.WP8/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.WP8/Forms.cs
@@ -22,6 +22,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.WP8
         {
             // Just bring this assembly into the current appdomain.
             // Forms.Init() should now find it!
+            PlotView.IsRendererInitialized = true;
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.WP8/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.WP8/PlotViewRenderer.cs
@@ -19,10 +19,28 @@ namespace OxyPlot.Xamarin.Forms.Platform.WP8
     public class PlotViewRenderer : ViewRenderer<Xamarin.Forms.PlotView, PlotView>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="PlotViewRenderer"/> class.
+        /// </summary>
+        static PlotViewRenderer()
+        {
+            Init();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PlotViewRenderer"/> class.
         /// </summary>
         public PlotViewRenderer()
         {
+            // Do not delete
+        }
+
+        /// <summary>
+        /// Initializes the renderer.
+        /// </summary>
+        /// <remarks>This method must be called before a <see cref="T:PlotView" /> is used.</remarks>
+        public static void Init()
+        {
+            OxyPlot.Xamarin.Forms.PlotView.IsRendererInitialized = true;
         }
 
         /// <summary>

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS.Classic/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS.Classic/Forms.cs
@@ -9,6 +9,8 @@
 
 namespace OxyPlot.Xamarin.Forms.Platform.iOS.Classic
 {
+    using System;
+
     /// <summary>
     /// Initializes OxyPlot renderers for use with Xamarin.Forms.
     /// </summary>
@@ -17,12 +19,11 @@ namespace OxyPlot.Xamarin.Forms.Platform.iOS.Classic
         /// <summary>
         /// Initializes OxyPlot for Xamarin.Forms.
         /// </summary>
-        /// <remarks>This method must be called before Forms.Init().</remarks>
+        /// <remarks>This method must be called before a <see cref="T:PlotView" /> is used.</remarks>
+        [Obsolete("Use PlotViewRenderer.Init() instead.")]
         public static void Init()
         {
-            // Just bring this assembly into the current appdomain.
-            // Forms.Init() should now find it!
-            PlotView.IsRendererInitialized = true;
+            PlotViewRenderer.Init();
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS.Classic/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS.Classic/Forms.cs
@@ -22,6 +22,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.iOS.Classic
         {
             // Just bring this assembly into the current appdomain.
             // Forms.Init() should now find it!
+            PlotView.IsRendererInitialized = true;
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS.Classic/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS.Classic/PlotViewRenderer.cs
@@ -19,10 +19,28 @@ namespace OxyPlot.Xamarin.Forms.Platform.iOS.Classic
     public class PlotViewRenderer : ViewRenderer<Xamarin.Forms.PlotView, PlotView>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="PlotViewRenderer"/> class.
+        /// </summary>
+        static PlotViewRenderer()
+        {
+            Init();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PlotViewRenderer"/> class.
         /// </summary>
         public PlotViewRenderer()
         {
+            // Do not delete
+        }
+
+        /// <summary>
+        /// Initializes the renderer.
+        /// </summary>
+        /// <remarks>This method must be called before a <see cref="T:PlotView" /> is used.</remarks>
+        public static new void Init()
+        {
+            OxyPlot.Xamarin.Forms.PlotView.IsRendererInitialized = true;
         }
 
         /// <summary>

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/Forms.cs
@@ -22,6 +22,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.iOS
         {
             // Just bring this assembly into the current appdomain.
             // Forms.Init() should now find it!
+            PlotView.IsRendererInitialized = true;
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/Forms.cs
@@ -9,6 +9,8 @@
 
 namespace OxyPlot.Xamarin.Forms.Platform.iOS
 {
+    using System;
+
     /// <summary>
     /// Initializes OxyPlot renderers for use with Xamarin.Forms.
     /// </summary>
@@ -17,12 +19,10 @@ namespace OxyPlot.Xamarin.Forms.Platform.iOS
         /// <summary>
         /// Initializes OxyPlot for Xamarin.Forms.
         /// </summary>
-        /// <remarks>This method must be called before Forms.Init().</remarks>
+        [Obsolete("Use PlotViewRenderer.Init() instead.")]
         public static void Init()
         {
-            // Just bring this assembly into the current appdomain.
-            // Forms.Init() should now find it!
-            PlotView.IsRendererInitialized = true;
+            PlotViewRenderer.Init();
         }
     }
 }

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/PlotViewRenderer.cs
@@ -16,10 +16,28 @@ namespace OxyPlot.Xamarin.Forms.Platform.iOS
     public class PlotViewRenderer : ViewRenderer<Xamarin.Forms.PlotView, PlotView>
     {
         /// <summary>
+        /// Initializes static members of the <see cref="PlotViewRenderer"/> class.
+        /// </summary>
+        static PlotViewRenderer()
+        {
+            Init();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PlotViewRenderer"/> class.
         /// </summary>
         public PlotViewRenderer()
         {
+            // Do not delete
+        }
+
+        /// <summary>
+        /// Initializes the renderer.
+        /// </summary>
+        /// <remarks>This method must be called before a <see cref="T:PlotView" /> is used.</remarks>
+        public static new void Init()
+        {
+            OxyPlot.Xamarin.Forms.PlotView.IsRendererInitialized = true;
         }
 
         /// <summary>

--- a/Source/OxyPlot.Xamarin.Forms/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Forms/PlotView.cs
@@ -43,15 +43,15 @@ namespace OxyPlot.Xamarin.Forms
                 {
                     case TargetPlatform.WinPhone:
                         message +=
-                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.WP8.Forms.Init();` after `Xamarin.Forms.Forms.Init();` in the Windows Phone app project.";
+                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.WP8.PlotViewRenderer.Init();` after `Xamarin.Forms.Forms.Init();` in the Windows Phone app project.";
                         break;
                     case TargetPlatform.Android:
                         message +=
-                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.Android.Forms.Init();` after `Xamarin.Forms.Forms.Init();` in the Android app project.";
+                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.Android.PlotViewRenderer.Init();` after `Xamarin.Forms.Forms.Init();` in the Android app project.";
                         break;
                     case TargetPlatform.iOS:
                         message +=
-                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.iOS.Forms.Init();` after `Xamarin.Forms.Forms.Init();` in the iOS app project.";
+                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.iOS.PlotViewRenderer.Init();` after `Xamarin.Forms.Forms.Init();` in the iOS app project.";
                         break;
                 }
                 throw new InvalidOperationException(message);

--- a/Source/OxyPlot.Xamarin.Forms/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Forms/PlotView.cs
@@ -9,6 +9,8 @@
 
 namespace OxyPlot.Xamarin.Forms
 {
+    using System;
+
     using OxyPlot;
 
     using global::Xamarin.Forms;
@@ -29,6 +31,34 @@ namespace OxyPlot.Xamarin.Forms
         public static readonly BindableProperty ModelProperty = BindableProperty.Create<PlotView, PlotModel>(p => p.Model, null);
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PlotView"/> class.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Renderer is not initialized</exception>
+        public PlotView()
+        {
+            if (!IsRendererInitialized)
+            {
+                var message = "Renderer is not initialized.";
+                switch (Device.OS)
+                {
+                    case TargetPlatform.WinPhone:
+                        message +=
+                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.WP8.Forms.Init();` after `Xamarin.Forms.Forms.Init();` in the Windows Phone app project.";
+                        break;
+                    case TargetPlatform.Android:
+                        message +=
+                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.Android.Forms.Init();` after `Xamarin.Forms.Forms.Init();` in the Android app project.";
+                        break;
+                    case TargetPlatform.iOS:
+                        message +=
+                            "\nRemember to add `OxyPlot.Xamarin.Forms.Platform.iOS.Forms.Init();` after `Xamarin.Forms.Forms.Init();` in the iOS app project.";
+                        break;
+                }
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the <see cref="PlotModel"/> to view.
         /// </summary>
         /// <value>The model.</value>
@@ -47,5 +77,11 @@ namespace OxyPlot.Xamarin.Forms
             get { return (PlotController)this.GetValue(ControllerProperty); }
             set { this.SetValue(ControllerProperty, value); }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the renderer is "initialized".
+        /// </summary>
+        /// <value><c>true</c> if the renderer is initialized; otherwise, <c>false</c>.</value>
+        public static bool IsRendererInitialized { get; set; }
     }
 }


### PR DESCRIPTION
Improved feedback (throws exception) if renderer is not initalized. Related to issue #492