### PR TITLE
Fixed rendering with clipping on Xamarin.Android (fixes #649)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ All notable changes to this project will be documented in this file.
 - Fix issue with MinimumRange not taking Minimum and Maximum values into account (#550)
 - Do not set default Controller in PlotView ctor (#436)
 - Corrected owner type of Wpf.PathAnnotation dependency properties (#645)
+- Fixed partial plot rendering on Xamarin.Android (#649)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Garrett
 Geert van Horrik <geert@catenalogic.com>
 Gimly
 Iain Nicol <git@iainnicol.com>
+Ilya Skriblovsky <IlyaSkriblovsky@gmail.com>
 Iurii Gazin <archeg@gmail.com>
 jaykul
 jezza323

--- a/Source/OxyPlot.Xamarin.Android/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Android/PlotView.cs
@@ -348,13 +348,8 @@ namespace OxyPlot.Xamarin.Android
                 }
 
                 this.rc.SetTarget(canvas);
-                using (var bounds = new Rect())
-                {
-                    canvas.GetClipBounds(bounds);
-                    var width = bounds.Right - bounds.Left;
-                    var height = bounds.Bottom - bounds.Top;
-                    ((IPlotModel)actualModel).Render(this.rc, width / Scale, height / Scale);
-                }
+                
+                ((IPlotModel)actualModel).Render(this.rc, Width / Scale, Height / Scale);
             }
         }
 


### PR DESCRIPTION
Xamarin.Android was drawing distorted plot if Canvas has clipping rect not equal to PlotView's size

`Canvas.ClipBounds` can easily be only a part of View's bounds. But `IPlotModel.Render` expects full width and height of the plot.