### PR TITLE
Implement RenderLegend for LinearBarSeries (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - ThreeColorLineSeries (#378)
 - Xamarin.Android, Xamarin.iOS and Xamarin.Forms packages built at AppVeyor (#274)
 - Add LegendLineSpacing property in PlotModel (#622)
+- Implement RenderLegend for LinearBarSeries (#663)
 
 ### Changed
 - Renamed OxyPlot.WindowsUniversal to OxyPlot.Windows (#242)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ efontana2
 elliatab
 episage <tilosag@gmail.com>
 eric
+Francois Botha <igitur@gmail.com>
 Garrett
 Geert van Horrik <geert@catenalogic.com>
 Gimly
@@ -74,7 +75,7 @@ stefan-schweiger
 Steve Hoelzer <shoelzer@gmail.com>
 Sven Dummis
 Taldoras <taldoras@googlemail.com>
-thepretender	
+thepretender
 tephyrnex
 Thomas Ibel <tibel@users.noreply.github.com>
 Tomasz Cielecki <tomasz@ostebaronen.dk>

--- a/Source/OxyPlot/Series/BarSeries/LinearBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/LinearBarSeries.cs
@@ -166,6 +166,25 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
+        /// Renders the legend symbol for the line series on the
+        /// specified rendering context.
+        /// </summary>
+        /// <param name="rc">The rendering context.</param>
+        /// <param name="legendBox">The bounding rectangle of the legend box.</param>
+        public override void RenderLegend(IRenderContext rc, OxyRect legendBox)
+        {
+            var xmid = (legendBox.Left + legendBox.Right) / 2;
+            var ymid = (legendBox.Top + legendBox.Bottom) / 2;
+            var height = (legendBox.Bottom - legendBox.Top) * 0.8;
+            var width = height;
+            rc.DrawRectangleAsPolygon(
+                new OxyRect(xmid - (0.5 * width), ymid - (0.5 * height), width, height),
+                this.GetSelectableColor(this.ActualColor),
+                this.StrokeColor,
+                this.StrokeThickness);
+        }
+
+        /// <summary>
         /// Sets default values from the plot model.
         /// </summary>
         /// <param name="model">The plot model.</param>


### PR DESCRIPTION
LinearBarSeries' legend didn't render correctly because RenderLegend() wasn't implemented. This PR implements the method and fixes #663 .

Hope I follow the guidelines correctly.