### PR TITLE
Update PdfRenderContext.cs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file.
 - PlotElement.Format method. Use StringHelper.Format instead.
 
 ### Fixed
+- Fixed PDFRenderContext text alignment issues for rotated text (#723)
 - HeatMapSeries.GetValue returns NaN instead of calculating a wrong value in proximity to NaN (#256)
 - Tracker position is wrong when PlotView is offset from origin (#455)
 - CategoryAxis should use StringFormat (#415)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ kc1212 <kc04bc@gmx.com>
 kenny_evoleap
 Kenny Nygaard
 Kevin Crowell <crowell@proteinmetrics.com>
+Kyle Pulvermacher
 LECO® Corporation
 Levi Botelho <levi_botelho@hotmail.com>
 lsowen

--- a/Source/OxyPlot.Pdf/PdfRenderContext.cs
+++ b/Source/OxyPlot.Pdf/PdfRenderContext.cs
@@ -306,7 +306,7 @@ namespace OxyPlot.Pdf
             this.g.TranslateTransform(dx, dy);
             if (Math.Abs(rotate) > double.Epsilon)
             {
-                this.g.RotateAtTransform((float)rotate, new XPoint((float)p.X + (float)(size.Width / 2.0), (float)p.Y));
+                this.g.RotateAtTransform((float)rotate, new XPoint((float)p.X - dx, (float)p.Y - dy));
             }
 
             this.g.TranslateTransform((float)p.X, (float)p.Y);


### PR DESCRIPTION
Per Issue #672 

Rotation was not compensating for the initial text alignment translations.