### PR TITLE
Update OxyPlot.Xamarin.Forms nuspec XF 2.0.0.6490

### DIFF
--- a/Source/OxyPlot.Xamarin.Forms/OxyPlot.Xamarin.Forms.nuspec
+++ b/Source/OxyPlot.Xamarin.Forms/OxyPlot.Xamarin.Forms.nuspec
@@ -15,23 +15,23 @@
     <dependencies>
       <group targetFramework="MonoTouch">
         <dependency id="OxyPlot.Xamarin.iOS" version="[$version$]"/>
-        <dependency id="Xamarin.Forms" version="1.5.0.6447" />
+        <dependency id="Xamarin.Forms" version="2.0.0.6490" />
       </group>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="OxyPlot.Xamarin.iOS" version="[$version$]"/>
-        <dependency id="Xamarin.Forms" version="1.5.0.6447" />
+        <dependency id="Xamarin.Forms" version="2.0.0.6490" />
       </group>
       <group targetFramework="MonoAndroid">
         <dependency id="OxyPlot.Xamarin.Android" version="[$version$]"/>
-        <dependency id="Xamarin.Forms" version="1.5.0.6447" />
+        <dependency id="Xamarin.Forms" version="2.0.0.6490" />
       </group>
       <group targetFramework="windowsphone8">
         <dependency id="OxyPlot.WP8" version="[$version$]"/>
-        <dependency id="Xamarin.Forms" version="1.5.0.6447" />
+        <dependency id="Xamarin.Forms" version="2.0.0.6490" />
       </group>
       <group>
         <dependency id="OxyPlot.Core" version="[$version$]"/>
-        <dependency id="Xamarin.Forms" version="1.5.0.6447" />
+        <dependency id="Xamarin.Forms" version="2.0.0.6490" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Additionally, the portable library target string could be extended to include +UAP10 support, but I'm guessing the build should need to be extended then also to copy output from UWP release build directory to a lib/UAP10 folder to enable adding after line 52 these lines: 

    <file src="..\..\Output\Xamarin.Forms.Platform.UWP\Xamarin.Forms.Platform.UWP.???" target="lib/UAP10" />
    <file src="..\..\Output\Xamarin.Forms.Platform.UWP\Xamarin.Forms.???" target="lib/UAP10" />

I don't have AppVeyor experience for that, but I see the UWP .csproj builds, although it's not included in the .sln (or such file hasn't been pushed yet)