### PR TITLE
Fix HeatMapSeries cannot plot on Universal Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ All notable changes to this project will be documented in this file.
 - Axis.MinimumRange did not work correctly (#711)
 - FillColor in ErrorColumnSeries (#736)
 - XAxisKey and YAxisKey added to Wpf.Annotations (#743)
+- Fix HeatMapSeries cannot plot on Universal Windows (#745)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -1337,6 +1337,33 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("#745: HeatMap not working in Windows Universal")]
+        public static PlotModel PlotHeatMap()
+        {
+            var model = new PlotModel { Title = "FOOBAR" };
+            model.Axes.Add(new LinearColorAxis
+            {
+                Position = AxisPosition.Right,
+                Palette = OxyPalettes.Jet(500),
+                HighColor = OxyColors.Gray,
+                LowColor = OxyColors.Black
+            });
+
+            var data = new double[,] { { 1, 2 }, { 1, 1 }, { 2, 1 }, { 2, 2 } };
+
+            var hs = new HeatMapSeries
+            {
+                Background = OxyColors.Red,
+                X0 = 0,
+                X1 = 2,
+                Y0 = 0,
+                Y1 = 3,
+                Data = data,
+            };
+            model.Series.Add(hs);
+            return model;
+        }
+
         /* NEW ISSUE TEMPLATE
          [Example("#123: Issue Description")]
          public static PlotModel IssueDescription()


### PR DESCRIPTION
Current implementation of `ConvertToRandomAccessStream()` deadlocked with the await and the `.Result` in the calling method. 