### PR TITLE
Fix StemSeries Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project will be documented in this file.
 - ListFiller (#705)
 
 ### Fixed
+- StemSeries Tracking to allow tracking on tiny stems (#809)
 - Fixed PDFRenderContext text alignment issues for rotated text (#723)
 - HeatMapSeries.GetValue returns NaN instead of calculating a wrong value in proximity to NaN (#256)
 - Tracker position is wrong when PlotView is offset from origin (#455)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -86,6 +86,7 @@ tephyrnex
 Thomas Ibel <tibel@users.noreply.github.com>
 Tomasz Cielecki <tomasz@ostebaronen.dk>
 ToplandJ <jostein.topland@nov.com>
+VisualMelon
 vhoehn <veit.hoehn@hte-company.de>
 Vsevolod Kukol <sevo@sevo.org>
 Xavier <Xavier@xavier-PC.lsi>

--- a/Source/OxyPlot/Series/StemSeries.cs
+++ b/Source/OxyPlot/Series/StemSeries.cs
@@ -65,12 +65,12 @@ namespace OxyPlot.Series
 
                 if (double.IsNaN(u))
                 {
-                    continue;
+                    u = 1; // we are a tiny line, snap to the end
                 }
 
                 if (u < 0 || u > 1)
                 {
-                    continue; // outside line
+                    u = 1; // we are outside the line, snap to the end
                 }
 
                 var sp = sp1 + ((sp2 - sp1) * u);


### PR DESCRIPTION
Fixes #809 .

### Checklist

- [ x ] I have included examples or tests (existing example is quite adequate)
- [ x ] I have updated the change log
- [ x ] I am listed in the CONTRIBUTORS file
- [ x ] I have cleaned up the commit history (use rebase and squash) (none deemed necessary)

### Changes proposed in this pull request:

- Change the behaviour of StemSeries tracking so that it snaps to the end of the series, allowing the tracking of zero height and otherwise really small stems, thus resolving #809.

@oxyplot/admins
