### PR TITLE
Area series plots only visible range. Added two colors mode for AreaS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Support for Windows Universal 10.0 apps (#615)
 - Support Unicode in OxyPlot.Pdf (#789)
 - TouchTrackerManipulator (#787)
+- Optimized AreaSeries performance, added two colors mode (different from TwoColorAreaSeries).
 
 ### Changed
 - Renamed OxyPlot.WindowsUniversal to OxyPlot.Windows (#242)

--- a/Source/Examples/ExampleLibrary/Series/AreaSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/AreaSeriesExamples.cs
@@ -32,7 +32,20 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
-        [Example("Crossing lines")]
+		[Example("Two colors mode")]
+		public static PlotModel TwoColorsMode()
+		{
+			var plotModel1 = new PlotModel { Title = "AreaSeries with different area colors" };
+			var areaSeries1 = CreateExampleAreaSeries();
+			areaSeries1.TwoColorMode = true;
+			areaSeries1.ConstantY2 = 60;
+			areaSeries1.Color = OxyColors.Red;
+			areaSeries1.Color2 = OxyColors.Blue;
+			plotModel1.Series.Add(areaSeries1);
+			return plotModel1;
+		}
+
+		[Example("Crossing lines")]
         public static PlotModel CrossingLines()
         {
             var plotModel1 = new PlotModel { Title = "AreaSeries with crossing lines" };

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -331,6 +331,8 @@ namespace OxyPlot.Wpf
             StreamGeometryContext sgc = null;
             PathGeometry pathGeometry = null;
             int count = 0;
+	        bool fillDefined = !fill.IsUndefined();
+	        bool strokeDefined = !stroke.IsUndefined();
 
             foreach (var polygon in polygons)
             {
@@ -338,7 +340,7 @@ namespace OxyPlot.Wpf
                 {
                     path = this.CreateAndAdd<Path>();
                     this.SetStroke(path, stroke, thickness, lineJoin, dashArray, 0, aliased);
-                    if (!fill.IsUndefined())
+                    if (fillDefined)
                     {
                         path.Fill = this.GetCachedBrush(fill);
                     }
@@ -363,14 +365,14 @@ namespace OxyPlot.Wpf
                     {
                         if (usg)
                         {
-                            sgc.BeginFigure(point, !fill.IsUndefined(), true);
+                            sgc.BeginFigure(point, fillDefined, true);
                         }
                         else
                         {
                             figure = new PathFigure
                             {
                                 StartPoint = point,
-                                IsFilled = !fill.IsUndefined(),
+                                IsFilled = fillDefined,
                                 IsClosed = true
                             };
                             pathGeometry.Figures.Add(figure);
@@ -382,11 +384,11 @@ namespace OxyPlot.Wpf
                     {
                         if (usg)
                         {
-                            sgc.LineTo(point, !stroke.IsUndefined(), true);
+							sgc.LineTo(point, strokeDefined, true);
                         }
                         else
                         {
-                            figure.Segments.Add(new LineSegment(point, !stroke.IsUndefined()) { IsSmoothJoin = true });
+							figure.Segments.Add(new LineSegment(point, strokeDefined) { IsSmoothJoin = true });
                         }
                     }
                 }

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Rendering\OxySizeExtensions.cs" />
     <Compile Include="Reporting\PlotModelExtensions.cs" />
     <Compile Include="Series\BarSeries\LinearBarSeries.cs" />
+    <Compile Include="Series\DataPointHelper.cs" />
     <Compile Include="Series\IScatterPointProvider.cs" />
     <Compile Include="Input\Gestures\OxyMouseEnterGesture.cs" />
     <Compile Include="PlotController\EventArgs\OxyInputEventArgs.cs" />

--- a/Source/OxyPlot/Series/AreaSeries.cs
+++ b/Source/OxyPlot/Series/AreaSeries.cs
@@ -9,8 +9,8 @@
 
 namespace OxyPlot.Series
 {
-    using System;
-    using System.Collections.Generic;
+	using System;
+	using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,14 +33,25 @@ namespace OxyPlot.Series
         /// </summary>
         private List<DataPoint> actualPoints2;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref = "AreaSeries" /> class.
-        /// </summary>
-        public AreaSeries()
+		/// <summary>
+		/// The index of the data item at the start of visible window
+		/// </summary>
+		private int winIndex;
+
+		/// <summary>
+		/// The index of the data item at the start of visible window
+		/// </summary>
+		private int winIndex2;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref = "AreaSeries" /> class.
+		/// </summary>
+		public AreaSeries()
         {
             this.Reverse2 = true;
             this.Color2 = OxyColors.Automatic;
             this.Fill = OxyColors.Automatic;
+	        this.Fill2 = OxyColors.Automatic;
         }
 
         /// <summary>
@@ -89,11 +100,17 @@ namespace OxyPlot.Series
         /// <value>The fill color.</value>
         public OxyColor Fill { get; set; }
 
-        /// <summary>
-        /// Gets the actual fill color of the area.
-        /// </summary>
-        /// <value>The actual fill color.</value>
-        public OxyColor ActualFill
+		/// <summary>
+		/// Gets or sets the fill color of the second area in two colors mode.
+		/// </summary>
+		/// <value>The fill color of the second area.</value>
+		public OxyColor Fill2 { get; set; }
+
+		/// <summary>
+		/// Gets the actual fill color of the area.
+		/// </summary>
+		/// <value>The actual fill color.</value>
+		public OxyColor ActualFill
         {
             get
             {
@@ -101,12 +118,24 @@ namespace OxyPlot.Series
             }
         }
 
-        /// <summary>
-        /// Gets the second list of points.
-        /// </summary>
-        /// <value>The second list of points.</value>
-        /// <remarks>This property is not used if <see cref="P:ItemsSource" /> is set.</remarks>
-        public List<DataPoint> Points2
+		/// <summary>
+		/// Gets the actual fill color of the second area in two colors mode.
+		/// </summary>
+		/// <value>The actual second fill color.</value>
+		public OxyColor ActualFill2
+		{
+			get
+			{
+				return this.Fill2.GetActualColor(OxyColor.FromAColor(100, this.ActualColor2));
+			}
+		}
+
+		/// <summary>
+		/// Gets the second list of points.
+		/// </summary>
+		/// <value>The second list of points.</value>
+		/// <remarks>This property is not used if <see cref="P:ItemsSource" /> is set.</remarks>
+		public List<DataPoint> Points2
         {
             get
             {
@@ -122,6 +151,15 @@ namespace OxyPlot.Series
         /// the second dataset should be reversed to get a
         /// closed polygon.</remarks>
         public bool Reverse2 { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether two color mode should be used.
+		/// </summary>
+		/// <value><c>true</c> if two color mode should be used; otherwise, <c>false</c>.</value>
+		/// <remarks> When using two color mode, Points and Points2 collections are considered
+		/// as different areas. They are painted with different colors and ConstantY2 is used to divide
+		/// the polygons horizontally. </remarks>
+		public bool TwoColorMode { get; set; }
 
         /// <summary>
         /// Gets the actual points of the second data set.
@@ -189,146 +227,88 @@ namespace OxyPlot.Series
         /// <param name="rc">The rendering context.</param>
         public override void Render(IRenderContext rc)
         {
-            var actualPoints = this.ActualPoints;
-            if (actualPoints == null || actualPoints.Count == 0)
-            {
-                return;
-            }
+			this.VerifyAxes();
 
-            var actualPoints2 = this.ActualPoints2;
-            if (actualPoints2 == null || actualPoints2.Count == 0)
-            {
-                return;
-            }
+			var actualPoints = this.ActualPoints;
+			if (actualPoints == null || actualPoints.Count == 0)
+			{
+				return;
+			}
 
-            this.VerifyAxes();
+			var actualPoints2 = this.ActualPoints2;
+			if (actualPoints2 == null || actualPoints2.Count == 0)
+			{
+				return;
+			}
 
-            double minDistSquared = this.MinimumSegmentLength * this.MinimumSegmentLength;
+			// determine render range
+			var xmin = this.XAxis.ActualMinimum;
+			var xmax = this.XAxis.ActualMaximum;
+			this.winIndex = DataPointHelper.FindIndex(actualPoints, xmin, this.winIndex);
+			this.winIndex2 = DataPointHelper.FindIndex(actualPoints2, xmin, this.winIndex2);
+
+	        if (this.winIndex > 0)
+	        {
+		        this.winIndex--;
+	        }
+			if (this.winIndex2 > 0)
+			{
+				this.winIndex2--;
+			}
+
+			double minDistSquared = this.MinimumSegmentLength * this.MinimumSegmentLength;
 
             var clippingRect = this.GetClippingRect();
             rc.SetClip(clippingRect);
 
-            // Manage NaN's
-            var chunkedListsOfPoints = this.Split(actualPoints, p => double.IsNaN(p.Y));
-            var chunkedListsOfPoints2 = this.Split(actualPoints2, p => double.IsNaN(p.Y));
+            var chunksOfPoints = new List<List<ScreenPoint>>();
+			var chunksOfPoints2 = new List<List<ScreenPoint>>();
 
-            // TODO: Possible multiple enumeration of IEnumerable...
-            for (int chunkIndex = 0; chunkIndex < chunkedListsOfPoints.Count(); chunkIndex++)
-            {
-                var chunkActualPoints = chunkedListsOfPoints.ElementAt(chunkIndex).ToList();
+			this.RenderChunkedPoints(actualPoints, chunksOfPoints, this.winIndex, xmax, rc, clippingRect, minDistSquared, false, this.ActualColor);
+			this.RenderChunkedPoints(actualPoints2, chunksOfPoints2, this.winIndex2, xmax, rc, clippingRect, minDistSquared, this.Reverse2, this.ActualColor2);
 
-                // Transform all points to screen coordinates
-                int n0 = chunkActualPoints.Count;
-                IList<ScreenPoint> pts0 = new ScreenPoint[n0];
-                for (int i = 0; i < n0; i++)
-                {
-                    pts0[i] = this.XAxis.Transform(chunkActualPoints[i].X, chunkActualPoints[i].Y, this.YAxis);
-                }
-
-                if (this.Smooth)
-                {
-                    var rpts0 = ScreenPointHelper.ResamplePoints(pts0, this.MinimumSegmentLength);
-                    pts0 = CanonicalSplineHelper.CreateSpline(rpts0, 0.5, null, false, 0.25);
-                }
-
-                var dashArray = this.ActualDashArray;
-
-                // draw the clipped lines
-                rc.DrawClippedLine(
-                    clippingRect,
-                    pts0,
-                    minDistSquared,
-                    this.GetSelectableColor(this.ActualColor),
-                    this.StrokeThickness,
-                    dashArray,
-                    this.LineJoin,
-                    false);
-            }
-
-            for (int chunkIndex = 0; chunkIndex < chunkedListsOfPoints2.Count(); chunkIndex++)
-            {
-                var chunkActualPoints2 = chunkedListsOfPoints2.ElementAt(chunkIndex).ToList();
-
-                // Transform all points to screen coordinates
-                int n1 = chunkActualPoints2.Count;
-                IList<ScreenPoint> pts1 = new ScreenPoint[n1];
-                for (int i = 0; i < n1; i++)
-                {
-                    int j = this.Reverse2 ? n1 - 1 - i : i;
-                    pts1[j] = this.XAxis.Transform(chunkActualPoints2[i].X, chunkActualPoints2[i].Y, this.YAxis);
-                }
-
-                if (this.Smooth)
-                {
-                    var rpts1 = ScreenPointHelper.ResamplePoints(pts1, this.MinimumSegmentLength);
-                    pts1 = CanonicalSplineHelper.CreateSpline(rpts1, 0.5, null, false, 0.25);
-                }
-
-                var dashArray = this.ActualDashArray;
-
-                // draw the clipped lines
-                rc.DrawClippedLine(
-                    clippingRect,
-                    pts1,
-                    minDistSquared,
-                    this.GetSelectableColor(this.ActualColor2),
-                    this.StrokeThickness,
-                    dashArray,
-                    this.LineJoin,
-                    false);
-            }
-
-            if (chunkedListsOfPoints.Count() != chunkedListsOfPoints2.Count())
+			if (chunksOfPoints.Count != chunksOfPoints2.Count)
             {
                 rc.ResetClip();
                 return;
             }
 
-            // Draw the fill
-            for (int chunkIndex = 0; chunkIndex < chunkedListsOfPoints.Count(); chunkIndex++)
+			// Draw the fill
+			for (int chunkIndex = 0; chunkIndex < chunksOfPoints.Count; chunkIndex++)
             {
-                var chunkActualPoints = chunkedListsOfPoints.ElementAt(chunkIndex).ToList();
-                var chunkActualPoints2 = chunkedListsOfPoints2.ElementAt(chunkIndex).ToList();
-
-                // Transform all points to screen coordinates
-                int n0 = chunkActualPoints.Count;
-                IList<ScreenPoint> pts0 = new ScreenPoint[n0];
-                for (int i = 0; i < n0; i++)
-                {
-                    pts0[i] = this.XAxis.Transform(chunkActualPoints[i].X, chunkActualPoints[i].Y, this.YAxis);
-                }
-
-                int n1 = chunkActualPoints2.Count;
-                IList<ScreenPoint> pts1 = new ScreenPoint[n1];
-                for (int i = 0; i < n1; i++)
-                {
-                    int j = this.Reverse2 ? n1 - 1 - i : i;
-                    pts1[j] = this.XAxis.Transform(chunkActualPoints2[i].X, chunkActualPoints2[i].Y, this.YAxis);
-                }
-
-                if (this.Smooth)
-                {
-                    var rpts0 = ScreenPointHelper.ResamplePoints(pts0, this.MinimumSegmentLength);
-                    var rpts1 = ScreenPointHelper.ResamplePoints(pts1, this.MinimumSegmentLength);
-
-                    pts0 = CanonicalSplineHelper.CreateSpline(rpts0, 0.5, null, false, 0.25);
-                    pts1 = CanonicalSplineHelper.CreateSpline(rpts1, 0.5, null, false, 0.25);
-                }
-
-                // combine the two lines and draw the clipped area
-                var pts = new List<ScreenPoint>();
-                pts.AddRange(pts1);
-                pts.AddRange(pts0);
+	            var pts = chunksOfPoints[chunkIndex];
+	            var pts2 = chunksOfPoints2[chunkIndex];
 
                 // pts = SutherlandHodgmanClipping.ClipPolygon(clippingRect, pts);
-                rc.DrawClippedPolygon(clippingRect, pts, minDistSquared, this.GetSelectableFillColor(this.ActualFill), OxyColors.Undefined);
+	            if (this.TwoColorMode)
+	            {
+					var const1 = this.GetConstantScreenPoints2(pts);
+					var const2 = this.GetConstantScreenPoints2(pts2);
+
+					var poligon = new List<ScreenPoint>(const1);
+					poligon.AddRange(pts);
+
+					var poligon2 = new List<ScreenPoint>(const2);
+		            poligon2.AddRange(pts2);
+
+					rc.DrawClippedPolygon(clippingRect, poligon, minDistSquared, this.GetSelectableFillColor(this.ActualFill), OxyColors.Undefined);
+					rc.DrawClippedPolygon(clippingRect, poligon2, minDistSquared, this.GetSelectableFillColor(this.ActualFill2), OxyColors.Undefined);
+				}
+	            else
+	            {
+					// combine the two lines and draw the clipped area
+					var allPts = new List<ScreenPoint>();
+					allPts.AddRange(pts2);
+					allPts.AddRange(pts);
+					rc.DrawClippedPolygon(clippingRect, allPts, minDistSquared, this.GetSelectableFillColor(this.ActualFill), OxyColors.Undefined);
+				}
 
                 var markerSizes = new[] { this.MarkerSize };
 
                 // draw the markers on top
                 rc.DrawMarkers(
                     clippingRect,
-                    pts0,
+                    pts,
                     this.MarkerType,
                     null,
                     markerSizes,
@@ -338,7 +318,7 @@ namespace OxyPlot.Series
                     1);
                 rc.DrawMarkers(
                     clippingRect,
-                    pts1,
+                    pts2,
                     this.MarkerType,
                     null,
                     markerSizes,
@@ -351,7 +331,88 @@ namespace OxyPlot.Series
             rc.ResetClip();
         }
 
-        /// <summary>
+	    /// <summary>
+	    /// Renders data points skipping NaN values.
+	    /// </summary>
+	    /// <param name="actualPoints">Points list.</param>
+	    /// <param name="chunksOfPoints">A list where chunks will be placed.</param>
+	    /// <param name="xMax"></param>
+	    /// <param name="rc">Render context</param>
+	    /// <param name="clippingRect">Clipping rect.</param>
+	    /// <param name="minDistSquared">Minimal distance squared.</param>
+	    /// <param name="reverse">Reverse points.</param>
+	    /// <param name="color">Stroke color.</param>
+	    /// <param name="startIdx"></param>
+	    private void RenderChunkedPoints(List<DataPoint> actualPoints, List<List<ScreenPoint>> chunksOfPoints, int startIdx, double xMax, IRenderContext rc, OxyRect clippingRect, double minDistSquared, bool reverse, OxyColor color)
+	    {
+			var dashArray = this.ActualDashArray;
+			var screenPoints = new List<ScreenPoint>();
+		    
+			Action<List<ScreenPoint>> finalizeChunk = list =>
+			{
+				var final = list;
+
+				if (reverse)
+				{
+					final.Reverse();
+				}
+
+				if (this.Smooth)
+				{
+					var resampled = ScreenPointHelper.ResamplePoints(final, this.MinimumSegmentLength);
+					final = CanonicalSplineHelper.CreateSpline(resampled, 0.5, null, false, 0.25);
+				}
+
+				chunksOfPoints.Add(final);
+
+				rc.DrawClippedLine(clippingRect,
+									final,
+									minDistSquared,
+									this.GetSelectableColor(color),
+									this.StrokeThickness,
+									dashArray,
+									this.LineJoin,
+									false);
+			};
+
+		    bool stop = false;
+		    for (int i = startIdx; i < actualPoints.Count; i++)
+		    {
+			    var point = actualPoints[i];
+			    
+				if (double.IsNaN(point.Y))
+				{
+					if (screenPoints.Count == 0)
+					{
+						continue;
+					}
+
+					finalizeChunk(screenPoints);
+					screenPoints = new List<ScreenPoint>();
+				}
+				else
+				{
+					var sp = this.XAxis.Transform(point.X, point.Y, this.YAxis);
+					screenPoints.Add(sp);
+				}
+
+			    if (stop)
+			    {
+				    break;
+			    }
+				if (point.X > xMax)
+				{
+					stop = true;
+				}
+			}
+
+		    if (screenPoints.Count > 0)
+			{
+				finalizeChunk(screenPoints);
+			}
+	    }
+
+	    /// <summary>
         /// Renders the legend symbol for the line series on the
         /// specified rendering context.
         /// </summary>
@@ -434,23 +495,29 @@ namespace OxyPlot.Series
             }
         }
 
-        /// <summary>
-        /// Split an IEnumerable<typeparamref name="T"/> into chunks (sub-lists), based on a split condition
-        /// (input items with splitCondition == true will not be included in output)
-        /// </summary>
-        /// <typeparam name="T">The type of the input list item</typeparam>
-        /// <param name="source">The input list</param>
-        /// <param name="splitCondition">The split condition</param>
-        /// <returns>A collection of a collection of <typeparamref name="T"/> items</returns>
-        private IEnumerable<IEnumerable<T>> Split<T>(IEnumerable<T> source, Func<T, bool> splitCondition)
-        {
-            source = source.SkipWhile(splitCondition);
-            // TODO: possible multiple enumeration of IEnumerable
-            while (source.Any())
-            {
-                yield return source.TakeWhile(x => !splitCondition(x));
-                source = source.SkipWhile(x => !splitCondition(x)).SkipWhile(splitCondition);
-            }
-        }
-    }
+		/// <summary>
+		/// Gets the screnn points when <see cref="P:ConstantY2" /> is used.
+		/// </summary>
+		/// <returns>A sequence of <see cref="T:DataPoint"/>.</returns>
+		private List<ScreenPoint> GetConstantScreenPoints2(List<ScreenPoint> source)
+		{
+			var result = new List<ScreenPoint>();
+
+			if (double.IsNaN(this.ConstantY2) || source.Count <= 0)
+			{
+				return result;
+			}
+
+			double y = this.YAxis.Transform(this.ConstantY2);
+			result.Add(new ScreenPoint(source[0].X, y));
+			result.Add(new ScreenPoint(source[source.Count - 1].X, y));
+
+			if (this.Reverse2)
+			{
+				result.Reverse();
+			}
+
+			return result;
+		}
+	}
 }

--- a/Source/OxyPlot/Series/DataPointHelper.cs
+++ b/Source/OxyPlot/Series/DataPointHelper.cs
@@ -2,6 +2,9 @@
 
 namespace OxyPlot.Series
 {
+	/// <summary>
+	/// Data point helper functions.
+	/// </summary>
 	public class DataPointHelper
 	{
 		/// <summary>

--- a/Source/OxyPlot/Series/DataPointHelper.cs
+++ b/Source/OxyPlot/Series/DataPointHelper.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+
+namespace OxyPlot.Series
+{
+	public class DataPointHelper
+	{
+		/// <summary>
+		/// Find index of max(x) &lt;= target x in a list of data points
+		/// </summary>
+		/// <param name='items'>
+		/// vector of data points
+		/// </param>
+		/// <param name='targetX'>
+		/// target x.
+		/// </param>
+		/// <param name='guess'>
+		/// initial guess index.
+		/// </param>
+		/// <returns>
+		/// index of x with max(x) &lt;= target x or -1 if cannot find
+		/// </returns>
+		public static int FindIndex(List<DataPoint> items, double targetX, int guess)
+		{
+			int lastguess = 0;
+			int start = 0;
+			int end = items.Count - 1;
+
+			while (start <= end)
+			{
+				if (guess < start)
+				{
+					return lastguess;
+				}
+				else if (guess > end)
+				{
+					return end;
+				}
+
+				var guessX = items[guess].X;
+				if (guessX.Equals(targetX))
+				{
+					return guess;
+				}
+				else if (guessX > targetX)
+				{
+					end = guess - 1;
+					if (end < start)
+					{
+						return lastguess;
+					}
+					else if (end == start)
+					{
+						return end;
+					}
+				}
+				else
+				{
+					start = guess + 1;
+					lastguess = guess;
+				}
+
+				if (start >= end)
+				{
+					return lastguess;
+				}
+
+				var endX = items[end].X;
+				var startX = items[start].X;
+
+				var m = (end - start + 1) / (endX - startX);
+				guess = start + (int)((targetX - startX) * m);
+			}
+
+			return lastguess;
+		}
+	}
+}


### PR DESCRIPTION
Fixes # .

### Checklist

+  I have included examples or tests
+ I have updated the change log
+ I am listed in the CONTRIBUTORS file
+ I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Area series plots only visible range. Added two colors mode for AreaSeries. See the provided example.

@oxyplot/admins