### PR TITLE
Support string[] as ItemsSource in CategoryAxis #825

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ All notable changes to this project will be documented in this file.
 - Axis should never go into infinite loop (#758)
 - Exception in BarSeriesBase (#790)
 - Vertical Axes Title Font Bug (#474)
+- Support string[] as ItemsSource in CategoryAxis #825
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/Examples/ExampleLibrary/Axes/CategoryAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/CategoryAxisExamples.cs
@@ -24,6 +24,34 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
+        [Example("ItemsSource - string[]")]
+        public static PlotModel ItemsSourceStrings()
+        {
+            var model = new PlotModel { Title = "CategoryAxis with string[] as ItemsSource" };
+            model.Axes.Add(new CategoryAxis
+            {
+                StringFormat = "Item {0}",
+                ItemsSource = new[] { "A", "B", "C" }
+            });
+            var linearAxis = new LinearAxis { Position = AxisPosition.Left };
+            model.Axes.Add(linearAxis);
+            return model;
+        }
+
+        [Example("ItemsSource - int[]")]
+        public static PlotModel ItemsSourceValues()
+        {
+            var model = new PlotModel { Title = "CategoryAxis with int[] as ItemsSource" };
+            model.Axes.Add(new CategoryAxis
+            {
+                StringFormat = "Item {0}",
+                ItemsSource = new[] { 10, 100, 123 }
+            });
+            var linearAxis = new LinearAxis { Position = AxisPosition.Left };
+            model.Axes.Add(linearAxis);
+            return model;
+        }
+
         [Example("MajorStep")]
         public static PlotModel MajorStepCategoryAxis()
         {

--- a/Source/OxyPlot.Tests/Utilities/ReflectionExtensionsTests.cs
+++ b/Source/OxyPlot.Tests/Utilities/ReflectionExtensionsTests.cs
@@ -6,7 +6,9 @@
 
 namespace OxyPlot.Tests
 {
+    using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
 
@@ -17,16 +19,6 @@ namespace OxyPlot.Tests
     [TestFixture]
     public class ReflectionExtensionsTests
     {
-        [Test]
-        public void AddFormattedRangeWithSimpleProperties()
-        {
-            var items = new List<Item> { new Item { A = 1, B = 2 } };
-            var result = new List<string>();
-            result.AddFormattedRange(items, "A", "0.0", CultureInfo.InvariantCulture);
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result[0], Is.EqualTo("1.0"));
-        }
-
         [Test]
         public void AddRangeWithSimpleProperties()
         {
@@ -67,6 +59,23 @@ namespace OxyPlot.Tests
             Assert.That(result.Count, Is.EqualTo(1));
             Assert.That(result[0].X, Is.EqualTo(1.1));
             Assert.That(result[0].Y, Is.EqualTo(2.2));
+        }
+
+        [Test]
+        public void FormatIntegers()
+        {
+            var items = new[] { 1, 2, 3 };
+            CollectionAssert.AreEqual(new[] { "1", "2", "3" }, items.Format(null, null, CultureInfo.InvariantCulture));
+            CollectionAssert.AreEqual(new[] { "01", "02", "03" }, items.Format("", "00", CultureInfo.InvariantCulture));
+            CollectionAssert.AreEqual(new[] { "Item 1", "Item 2", "Item 3" }, items.Format(null, "Item {0}", CultureInfo.InvariantCulture));
+        }
+
+        [Test]
+        public void FormatStrings()
+        {
+            var items = new[] { "One", "Two", "Three" };
+            CollectionAssert.AreEqual(new[] { "3", "3", "5" }, items.Format("Length", null, CultureInfo.InvariantCulture));
+            CollectionAssert.AreEqual(new[] { "Item One", "Item Two", "Item Three" }, items.Format(null, "Item {0}", CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/Source/OxyPlot.Tests/Utilities/StringHelperTests.cs
+++ b/Source/OxyPlot.Tests/Utilities/StringHelperTests.cs
@@ -37,6 +37,15 @@ namespace OxyPlot.Tests
                 StringHelper.Format(CultureInfo.InvariantCulture, "{Text}", item));
         }
 
+        [Test]
+        public void CreateValidFormatString()
+        {
+            Assert.AreEqual("{0}", StringHelper.CreateValidFormatString(null), "null");
+            Assert.AreEqual("{0}", StringHelper.CreateValidFormatString(string.Empty), "empty");
+            Assert.AreEqual("{0:0.00}", StringHelper.CreateValidFormatString("0.00"), "0.00");
+            Assert.AreEqual("Item {0}", StringHelper.CreateValidFormatString("Item {0}"), "Item {0}");
+        }
+
         public class Item
         {
             public string Text { get; set; }

--- a/Source/OxyPlot/Axes/CategoryAxis.cs
+++ b/Source/OxyPlot/Axes/CategoryAxis.cs
@@ -514,7 +514,7 @@ namespace OxyPlot.Axes
             if (this.ItemsSource != null)
             {
                 this.itemsSourceLabels.Clear();
-                this.itemsSourceLabels.AddFormattedRange(this.ItemsSource, this.LabelField, this.StringFormat, this.ActualCulture);
+                this.itemsSourceLabels.AddRange(this.ItemsSource.Format(this.LabelField, this.StringFormat, this.ActualCulture));
                 return;
             }
 

--- a/Source/OxyPlot/Utilities/ReflectionExtensions.cs
+++ b/Source/OxyPlot/Utilities/ReflectionExtensions.cs
@@ -13,6 +13,8 @@ namespace OxyPlot
     using System.Collections;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
+    using System.Net;
     using System.Reflection;
 
     using OxyPlot.Axes;
@@ -55,23 +57,31 @@ namespace OxyPlot
         }
 
         /// <summary>
-        /// Fills a formatted string collection by the specified property of a source enumerable.
+        /// Formats each item in a sequence by the specified format string and property.
         /// </summary>
-        /// <param name="target">The target list to be filled.</param>
         /// <param name="source">The source target.</param>
         /// <param name="propertyName">The property name.</param>
-        /// <param name="formatString">The format string.</param>
-        /// <param name="provider">The provider.</param>
+        /// <param name="formatString">The format string. The format argument {0} can be used for the value of the property in each element of the sequence.</param>
+        /// <param name="provider">The format provider.</param>
         /// <exception cref="System.InvalidOperationException">Could not find property.</exception>
-        public static void AddFormattedRange(this List<string> target, IEnumerable source, string propertyName, string formatString, IFormatProvider provider)
+        public static IEnumerable<string> Format(this IEnumerable source, string propertyName, string formatString, IFormatProvider provider)
         {
-            var pi = new ReflectionPath(propertyName);
-            var fs = "{0:" + formatString + "}";
-            foreach (var o in source)
+            var fs = StringHelper.CreateValidFormatString(formatString);
+            if (string.IsNullOrEmpty(propertyName))
             {
-                var v = pi.GetValue(o);
-                var value = string.Format(provider, fs, v);
-                target.Add(value);
+                foreach (var element in source)
+                {
+                    yield return string.Format(provider, fs, element);
+                }
+            }
+            else
+            {
+                var reflectionPath = new ReflectionPath(propertyName);
+                foreach (var element in source)
+                {
+                    var value = reflectionPath.GetValue(element);
+                    yield return string.Format(provider, fs, value);
+                }
             }
         }
 

--- a/Source/OxyPlot/Utilities/StringHelper.cs
+++ b/Source/OxyPlot/Utilities/StringHelper.cs
@@ -41,7 +41,7 @@ namespace OxyPlot
             // Replace items on the format {Property[:Formatstring]}
             var s = FormattingExpression.Replace(
                 formatString,
-                delegate(Match match)
+                delegate (Match match)
                 {
                     var property = match.Groups["Property"].Value;
                     if (property.Length > 0 && char.IsDigit(property[0]))
@@ -65,6 +65,26 @@ namespace OxyPlot
             // Also apply the standard formatting
             s = string.Format(provider, s, values);
             return s;
+        }
+
+        /// <summary>
+        /// Creates a valid format string on the form "{0:###}".
+        /// </summary>
+        /// <param name="input">The input format string.</param>
+        /// <returns>The corrected format string.</returns>
+        public static string CreateValidFormatString(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return "{0}";
+            }
+
+            if (input.Contains("{"))
+            {
+                return input;
+            }
+
+            return string.Concat("{0:", input, "}");
         }
     }
 }


### PR DESCRIPTION
Fixes #825

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix the issue

@oxyplot/admins

