### PR TITLE
Change default number format for Axis to "g6" (#841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project will be documented in this file.
 - Rewrite LogarithmicAxis tick calculation (#820)
 - Change Axis methods to protected virtual (#837)
 - Move CalculateMinorInterval and CreateTickValues to AxisUtilities (#837)
+- Change default number format to "g6" in Axis base class (#841)
 
 ### Removed
 - StyleCop tasks (#556)

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1252,11 +1252,10 @@ namespace OxyPlot.Axes
 
             this.ActualStringFormat = this.StringFormat;
 
-            // if (ActualStringFormat==null)
-            // {
-            // if (ActualMaximum > 1e6 || ActualMinimum < 1e-6)
-            // ActualStringFormat = "#.#e-0";
-            // }
+            if (this.ActualStringFormat == null)
+            {
+                this.ActualStringFormat = "g6";
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #841 

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Change standard numerical format for Axis to "g6".

@oxyplot/admins