### PR TITLE
Fix #794 axis alignment with MinimumRange or MaximumRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ All notable changes to this project will be documented in this file.
 - LogarithmicAxis sometimes places major ticks outside of the axis range (#850)
 - LineSeries with smoothing raises exception (#72)
 - Exception when legend is outside and plot area is small (#880)
+- Axis alignment with MinimumRange (#794)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@ Carlos Anderson <carlosjanderson@gmail.com>
 Carlos Teixeira <karlmtc@gmail.com>
 Choden Konigsmark <choden.konigsmark@gmail.com>
 classicboss302
+csabar <rumancsabi@gmail.com>
 Cyril Martin <cyril.martin.cm@gmail.com>
 darrelbrown
 David Laundav <davelaundav@gmail.com>

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -1500,7 +1500,7 @@ namespace ExampleLibrary
         }
 
         /// <summary>
-        /// Creates a demo PlotModel with MinimumRange defined 
+        /// Creates a demo PlotModel with MinimumRange defined
         /// and with series with values which are within this range.
         /// </summary>
         /// <returns>The created PlotModel</returns>
@@ -1571,6 +1571,65 @@ namespace ExampleLibrary
             return model;
         }
 
+        /// <summary>
+        /// Creates a demo PlotModel with MinimumRange defined
+        /// and with series with values which are within this range.
+        /// </summary>
+        /// <returns>The created PlotModel</returns>
+        [Example("#794: Axis alignment when MinimumRange is set with AbsoluteMaximum")]
+        public static PlotModel MinimumRangeAbsoluteMaximumTest()
+        {
+            var model = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MinimumRange = 1,
+                AbsoluteMaximum = 10.5
+            };
+
+            model.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+            series.Points.Add(new DataPoint(4, 10.1));
+
+            model.Series.Add(series);
+
+            return model;
+        }
+
+        /// <summary>
+        /// Creates a demo PlotModel with MinimumRange defined
+        /// and with series with values which are within this range.
+        /// </summary>
+        /// <returns>The created PlotModel</returns>
+        [Example("#794: Axis alignment when MinimumRange is set with AbsoluteMinimum")]
+        public static PlotModel MinimumRangeAbsoluteMinimumTest()
+        {
+            var model = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MinimumRange = 1,
+                AbsoluteMinimum = 10,
+            };
+
+            model.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+            series.Points.Add(new DataPoint(4, 10.1));
+
+            model.Series.Add(series);
+
+            return model;
+        }
 
         /* NEW ISSUE TEMPLATE
            [Example("#123: Issue Description")]

--- a/Source/OxyPlot.Tests/Axes/AxisTests.cs
+++ b/Source/OxyPlot.Tests/Axes/AxisTests.cs
@@ -464,5 +464,203 @@ namespace OxyPlot.Tests
             Assert.That(yaxis.DesiredSize.Width, Is.EqualTo(50.0).Within(0.5), "y-axis width");
             Assert.That(yaxis.DesiredSize.Height, Is.EqualTo(0.0).Within(1e-6), "y-axis height");
         }
+
+        /// <summary>
+        /// Tests the alignment of the series, if minimum range is set
+        /// </summary>
+        [Test]
+        public void Axis_VerticalAlignment_MinimumRange()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MinimumRange = 1,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            double dataMin = 10.1;
+            double dataMax = 10.3;
+            double dataCenter = (dataMax + dataMin) / 2;
+
+            // Center should be the between data min and max
+            Assert.AreEqual(dataCenter, (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-5, "center");
+            Assert.AreEqual(dataCenter - 0.5, plot.Axes[0].ActualMinimum, 1e-5, "minimum");
+            Assert.AreEqual(dataCenter + 0.5, plot.Axes[0].ActualMaximum, 1e-5, "maximum");
+        }
+
+        /// <summary>
+        /// Tests the alignment of the series, if MinimumRange and the AbsoluteMaximum are set
+        /// </summary>
+        [Test]
+        public void Axis_VerticalAlignment_MinimumRange_AbsoluteMaximum()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MinimumRange = 1,
+                AbsoluteMaximum = 10.5,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            // Center should be the between AbsoluteMaximum and the (AboluteMaximum - MinimumRange)
+            Assert.AreEqual(yaxis.AbsoluteMaximum, plot.Axes[0].ActualMaximum, 0, "absolute maximum");
+            Assert.AreEqual(yaxis.AbsoluteMaximum - (yaxis.MinimumRange / 2), (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-5, "center");
+            Assert.AreEqual(yaxis.AbsoluteMaximum - yaxis.MinimumRange, plot.Axes[0].ActualMinimum, 1e-5, "minimum");
+        }
+
+        /// <summary>
+        /// Tests the alignment of the series, if MinimumRange and the AbsoluteMaximum are set
+        /// </summary>
+        [Test]
+        public void Axis_VerticalAlignment_MinimumRange_AbsoluteMinimum()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MinimumRange = 1,
+                AbsoluteMinimum = 10,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            // Center should be the between AbsoluteMinimum and the (AboluteMinimum + MinimumRange)
+            Assert.AreEqual(yaxis.AbsoluteMinimum, plot.Axes[0].ActualMinimum, 0, "absolute minimum");
+            Assert.AreEqual(yaxis.AbsoluteMinimum + (yaxis.MinimumRange / 2), (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-5, "center");
+            Assert.AreEqual(yaxis.AbsoluteMinimum + yaxis.MinimumRange, plot.Axes[0].ActualMaximum, 1e-5, "maximum");
+        }
+
+        /// <summary>
+        /// Tests the alignment of the series, if maximum range is set.
+        /// </summary>
+        [Test]
+        public void Axis_VerticalAlignment_MaximumRange()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MaximumRange = 0.1,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            double dataMin = 10.1;
+            double dataMax = 10.3;
+            double dataCenter = (dataMax + dataMin) / 2;
+
+            // Center should be the between data min and max
+            Assert.AreEqual(dataCenter, (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-5, "center");
+            Assert.AreEqual(dataCenter - 0.05, plot.Axes[0].ActualMinimum, 1e-5, "minimum");
+            Assert.AreEqual(dataCenter + 0.05, plot.Axes[0].ActualMaximum, 1e-5, "maximum");
+        }
+
+        /// <summary>
+        /// Tests the alignment of the series, if MaximumRange and the AbsoluteMaximum are set.
+        /// </summary>
+        [Test]
+        public void Axis_VerticalAlignment_MaximumRange_AbsoluteMaximum()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MaximumRange = 0.1,
+                AbsoluteMaximum = 10.22,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            // Range is between AbsoluteMaximum and the (AboluteMaximum - MaximumRange)
+            Assert.AreEqual(yaxis.AbsoluteMaximum, plot.Axes[0].ActualMaximum, 0, "absolute maximum");
+            Assert.AreEqual(yaxis.AbsoluteMaximum - (yaxis.MaximumRange / 2), (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-6, "center");
+            Assert.AreEqual(yaxis.AbsoluteMaximum - yaxis.MaximumRange, plot.Axes[0].ActualMinimum, 1e-6, "minimum");
+        }
+
+        /// <summary>
+        /// Tests the alignment of the series, if MaximumRange and the AbsoluteMinimum are set.
+        /// </summary>
+        [Test]
+        public void Axis_VerticalAlignment_MaximumRange_AbsoluteMinimum()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left,
+                MaximumRange = 0.1,
+                AbsoluteMinimum = 10.16,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0, 10.1));
+            series.Points.Add(new DataPoint(1, 10.15));
+            series.Points.Add(new DataPoint(2, 10.3));
+            series.Points.Add(new DataPoint(3, 10.25));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            // Range is between AbsoluteMinimum and the (AboluteMinimum + MaximumRange)
+            Assert.AreEqual(yaxis.AbsoluteMinimum, plot.Axes[0].ActualMinimum, 0, "absolute minimum");
+            Assert.AreEqual(yaxis.AbsoluteMinimum + (yaxis.MaximumRange / 2), (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-6, "center");
+            Assert.AreEqual(yaxis.AbsoluteMinimum + yaxis.MaximumRange, plot.Axes[0].ActualMaximum, 1e-6, "maximum");
+        }
     }
 }

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1402,12 +1402,24 @@ namespace OxyPlot.Axes
             {
                 if (this.ActualMinimum + this.MinimumRange < this.AbsoluteMaximum)
                 {
+                    var average = (this.ActualMaximum + this.ActualMinimum) * 0.5;
+                    var delta = this.MinimumRange / 2;
+                    this.ActualMinimum = average - delta;
+                    this.ActualMaximum = average + delta;
+
                     if (this.ActualMinimum < this.AbsoluteMinimum)
                     {
+                        var diff = this.AbsoluteMinimum - this.ActualMinimum;
                         this.ActualMinimum = this.AbsoluteMinimum;
+                        this.ActualMaximum += diff;
                     }
 
-                    this.ActualMaximum = this.ActualMinimum + this.MinimumRange;
+                    if (this.ActualMaximum > this.AbsoluteMaximum)
+                    {
+                        var diff = this.AbsoluteMaximum - this.ActualMaximum;
+                        this.ActualMaximum = this.AbsoluteMaximum;
+                        this.ActualMinimum += diff;
+                    }
                 }
                 else
                 {
@@ -1429,13 +1441,24 @@ namespace OxyPlot.Axes
             {
                 if (this.ActualMinimum + this.MaximumRange < this.AbsoluteMaximum)
                 {
+                    var average = (this.ActualMaximum + this.ActualMinimum) * 0.5;
+                    var delta = this.MaximumRange / 2;
+                    this.ActualMinimum = average - delta;
+                    this.ActualMaximum = average + delta;
+
                     if (this.ActualMinimum < this.AbsoluteMinimum)
                     {
+                        var diff = this.AbsoluteMinimum - this.ActualMinimum;
                         this.ActualMinimum = this.AbsoluteMinimum;
+                        this.ActualMaximum += diff;
                     }
 
-                    // Adjust the actual maximum only
-                    this.ActualMaximum = this.ActualMinimum + this.MaximumRange;
+                    if (this.ActualMaximum > this.AbsoluteMaximum)
+                    {
+                        var diff = this.AbsoluteMaximum - this.ActualMaximum;
+                        this.ActualMaximum = this.AbsoluteMaximum;
+                        this.ActualMinimum += diff;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #794 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- When the minimum range is set and the data dispersion is less than minimum range, the series are aligned to the center
- When the maximum range is set and the data dispersion is more than maximum range, the series are aligned to the center
- The changes affected tests `OxyPlot.Tests.AxisTests.A13B_BadConditionedAxis_SettingMinimumRange` and `OxyPlot.Tests.AxisTests.A16_TwoClosePoints` because the axes are aligned to center.

@oxyplot/admins