### PR TITLE
Color minor and major ticks differently (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Extracted visible window search code from CandleStickSeries and made a generic version in XYSeries. Used it to omptimize AreaSeries performance. (#834)
 - Optimized rednering performance of RectangleBarSeries (#834).
 - PdfExporter implementing IExporter (#845)
+- Color minor and major ticks differently (#417)
 
 ### Changed
 - Renamed OxyPlot.WindowsUniversal to OxyPlot.Windows (#242)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,6 +75,7 @@ Oystein Bjorke <oystein.bjorke@gmail.com>
 Patrice Marin <patrice.marin@thomsonreuters.com>
 Philippe AURIOU <p.auriou@live.fr>
 Piotr Warzocha <pw@piootr.pl>
+ryang <decatf@gmail.com>
 Senen Fernandez <senenf@gmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>
 Soarc <gor.rustamyan@gmail.com>

--- a/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
@@ -51,6 +51,29 @@ namespace ExampleLibrary
             return CreateTickStyleExample(TickStyle.Outside);
         }
 
+        [Example("TickStyle: Color major and minor ticks differently")]
+        public static PlotModel TickLineColor()
+        {
+            var plotModel1 = new PlotModel { Title = "Color major and minor ticks differently" };
+            plotModel1.Axes.Add(new LinearAxis
+            {
+                Position = AxisPosition.Left,
+                MajorGridlineThickness = 3,
+                MinorGridlineThickness = 3,
+                TicklineColor = OxyColors.Blue,
+                MinorTicklineColor = OxyColors.Gray,
+            });
+            plotModel1.Axes.Add(new LinearAxis
+            {
+                Position = AxisPosition.Bottom,
+                MajorGridlineThickness = 3,
+                MinorGridlineThickness = 3,
+                TicklineColor = OxyColors.Blue,
+                MinorTicklineColor = OxyColors.Gray,
+            });
+            return plotModel1;
+        }
+
         [Example("GridLinestyle: None (default)")]
         public static PlotModel GridlineStyleNone()
         {

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -74,6 +74,7 @@ namespace OxyPlot.Axes
 
             this.TickStyle = TickStyle.Outside;
             this.TicklineColor = OxyColors.Black;
+            this.MinorTicklineColor = OxyColors.Automatic;
 
             this.AxislineStyle = LineStyle.None;
             this.AxislineColor = OxyColors.Black;
@@ -414,6 +415,11 @@ namespace OxyPlot.Axes
         /// Gets or sets the interval between minor ticks. The default value is <c>double.NaN</c>.
         /// </summary>
         public double MinorStep { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the minor ticks. The default value is <see cref="OxyColors.Automatic"/>.
+        /// </summary>
+        public OxyColor MinorTicklineColor { get; set; }
 
         /// <summary>
         /// Gets or sets the size of the minor ticks. The default value is <c>4</c>.

--- a/Source/OxyPlot/Axes/Rendering/AxisRendererBase.cs
+++ b/Source/OxyPlot/Axes/Rendering/AxisRendererBase.cs
@@ -181,9 +181,11 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         protected virtual void CreatePens(Axis axis)
         {
+            var minorTickColor = axis.MinorTicklineColor.Equals(OxyColors.Automatic) ? axis.TicklineColor : axis.MinorTicklineColor;
+
             this.MinorPen = OxyPen.Create(axis.MinorGridlineColor, axis.MinorGridlineThickness, axis.MinorGridlineStyle);
             this.MajorPen = OxyPen.Create(axis.MajorGridlineColor, axis.MajorGridlineThickness, axis.MajorGridlineStyle);
-            this.MinorTickPen = OxyPen.Create(axis.TicklineColor, axis.MinorGridlineThickness);
+            this.MinorTickPen = OxyPen.Create(minorTickColor, axis.MinorGridlineThickness);
             this.MajorTickPen = OxyPen.Create(axis.TicklineColor, axis.MajorGridlineThickness);
             this.ZeroPen = OxyPen.Create(axis.TicklineColor, axis.MajorGridlineThickness);
             this.ExtraPen = OxyPen.Create(axis.ExtraGridlineColor, axis.ExtraGridlineThickness, axis.ExtraGridlineStyle);


### PR DESCRIPTION
Fixes #417.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-  Color minor and major ticks differently #417
- This adds MinorTicklineColor to Axis. It defaults to Automatic color. In this case it takes the value of TicklineColor.

@oxyplot/admins

