### PR TITLE
Fix weird number formatting on logarithmic axes (10*10^x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ All notable changes to this project will be documented in this file.
 - LineSeries with smoothing raises exception (#72)
 - Exception when legend is outside and plot area is small (#880)
 - Axis alignment with MinimumRange (#794)
+- Fixed strange number formatting when using LogarithmicAxis with very large or very small Series (#589)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -76,6 +76,7 @@ Oystein Bjorke <oystein.bjorke@gmail.com>
 Patrice Marin <patrice.marin@thomsonreuters.com>
 Philippe AURIOU <p.auriou@live.fr>
 Piotr Warzocha <pw@piootr.pl>
+Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
 Senen Fernandez <senenf@gmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -1157,38 +1157,27 @@ namespace ExampleLibrary
             return model;
         }
 
+        /// <summary>
+        /// Contains example code for https://github.com/oxyplot/oxyplot/issues/42
+        /// </summary>
+        /// <returns>The plot model.</returns>
         [Example("#42: ContourSeries not working for not square data array")]
-        public static PlotModel IssueDescription()
+        public static PlotModel IndexOutOfRangeContour()
         {
-            int n = 100;
-            double x0 = -3.1;
-            double x1 = 3.1;
-            double y0 = -3;
-            double y1 = 3;
-            Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
-            // see https://github.com/oxyplot/oxyplot/issues/511
-            var xvalues = ArrayBuilder.CreateVector(x0, x1, n * 10);
-            var yvalues = ArrayBuilder.CreateVector(y0, y1, n);
-            var peaksData = ArrayBuilder.Evaluate(peaks, xvalues, yvalues);
-            var model = new PlotModel { Title = "Peaks" };
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
+            var model = new PlotModel { Title = "Issue #42" };
+            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(5) });
 
-            var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
-            model.Series.Add(hms);
-            //if (includeContours)
+            var x = ArrayBuilder.CreateVector(0, 1, 20);
+            var y = ArrayBuilder.CreateVector(-1, 1, 2);
+            var data = ArrayBuilder.Evaluate((a, b) => a * b, x, y);
+
+            var contour = new ContourSeries
             {
-                var cs = new ContourSeries
-                {
-                    Color = OxyColors.Black,
-                    FontSize = 0,
-                    ContourLevelStep = 1,
-                    LabelBackground = OxyColors.Undefined,
-                    ColumnCoordinates = yvalues,
-                    RowCoordinates = xvalues,
-                    Data = peaksData
-                };
-                model.Series.Add(cs);
-            }
+                ColumnCoordinates = y,
+                RowCoordinates = x,
+                Data = data
+            };
+            model.Series.Add(contour);
 
             return model;
         }
@@ -1627,6 +1616,37 @@ namespace ExampleLibrary
             series.Points.Add(new DataPoint(4, 10.1));
 
             model.Series.Add(series);
+
+            return model;
+        }
+
+        /// Creates a demo PlotModel with the data from the issue.
+        /// </summary>
+        /// <returns>The created PlotModel</returns>
+        [Example("#589: LogarithmicAxis glitches with multiple series containing small data")]
+        public static PlotModel LogaritmicAxesSuperExponentialFormatTest()
+        {
+            var model = new PlotModel();
+            model.Axes.Add(new LogarithmicAxis
+            {
+                UseSuperExponentialFormat = true,
+                Position = AxisPosition.Bottom,
+                MajorGridlineStyle = LineStyle.Dot,
+                PowerPadding = true
+            });
+
+            model.Axes.Add(new LogarithmicAxis
+            {
+                UseSuperExponentialFormat = true,
+                Position = AxisPosition.Left,
+                MajorGridlineStyle = LineStyle.Dot,
+                PowerPadding = true
+            });
+
+            var series1 = new LineSeries();
+            series1.Points.Add(new DataPoint(1e5, 1e-14));
+            series1.Points.Add(new DataPoint(4e7, 1e-12));
+            model.Series.Add(series1);
 
             return model;
         }

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -22,12 +22,17 @@ namespace OxyPlot.Axes
         /// <summary>
         /// Exponent function.
         /// </summary>
-        protected static readonly Func<double, double> Exponent = x => Math.Floor(Math.Log(Math.Abs(x), 10));
+        protected static readonly Func<double, double> Exponent = x => Math.Floor(ThresholdRound(Math.Log(Math.Abs(x), 10)));
 
         /// <summary>
         /// Mantissa function.
         /// </summary>
-        protected static readonly Func<double, double> Mantissa = x => x / Math.Pow(10, Exponent(x));
+        protected static readonly Func<double, double> Mantissa = x => ThresholdRound(x / Math.Pow(10, Exponent(x)));
+
+        /// <summary>
+        /// Rounds a value if the difference between the rounded value and the original value is less than 1e-6.
+        /// </summary>
+        protected static readonly Func<double, double> ThresholdRound = x => Math.Abs(Math.Round(x) - x) < 1e-6 ? Math.Round(x) : x;
 
         /// <summary>
         /// The offset.


### PR DESCRIPTION
Fixes #589 .

Example for #589  is added to the library.
Edited example for #42, removed unnecessary code.

Added my name to the contributors file.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins

Solve weird number formatting as reported in issue #589 by adding rounding function to Axis object to round values that are less than 1e-6 away from an integer.