### PR TITLE
Use axis.MinorTicklineColor.IsAutomatic()

### DIFF
--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -419,6 +419,8 @@ namespace OxyPlot.Axes
         /// <summary>
         /// Gets or sets the color of the minor ticks. The default value is <see cref="OxyColors.Automatic"/>.
         /// </summary>
+        /// <remarks>If the value is <see cref="OxyColors.Automatic"/>, the value of
+        /// <see cref="Axis.TicklineColor"/> will be used.</remarks>
         public OxyColor MinorTicklineColor { get; set; }
 
         /// <summary>

--- a/Source/OxyPlot/Axes/Rendering/AxisRendererBase.cs
+++ b/Source/OxyPlot/Axes/Rendering/AxisRendererBase.cs
@@ -181,7 +181,7 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         protected virtual void CreatePens(Axis axis)
         {
-            var minorTickColor = axis.MinorTicklineColor.Equals(OxyColors.Automatic) ? axis.TicklineColor : axis.MinorTicklineColor;
+            var minorTickColor = axis.MinorTicklineColor.IsAutomatic() ? axis.TicklineColor : axis.MinorTicklineColor;
 
             this.MinorPen = OxyPen.Create(axis.MinorGridlineColor, axis.MinorGridlineThickness, axis.MinorGridlineStyle);
             this.MajorPen = OxyPen.Create(axis.MajorGridlineColor, axis.MajorGridlineThickness, axis.MajorGridlineStyle);


### PR DESCRIPTION
Address some comments in pull request #873 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- Use axis.MinorTicklineColor.IsAutomatic()
- Documents the behavior when MajorTickColor is automatic.

@oxyplot/admins


I guess #873 got merged anyways but this addresses the use of axis.MinorTicklineColorEquals() vs IsAutomatic().

I also documented the behavior when the property is automatic. Otherwise it's only implied and leaves you to look at the source to know what the default value does.  