### PR TITLE
Add missing virtual keywords to allow overridding

### DIFF
--- a/Source/OxyPlot/Graphics/ControllerBase.cs
+++ b/Source/OxyPlot/Graphics/ControllerBase.cs
@@ -61,7 +61,7 @@ namespace OxyPlot
         /// <param name="gesture">The gesture.</param>
         /// <param name="args">The <see cref="OxyInputEventArgs" /> instance containing the event data.</param>
         /// <returns><c>true</c> if the event was handled.</returns>
-        public bool HandleGesture(IView view, OxyInputGesture gesture, OxyInputEventArgs args)
+        public virtual bool HandleGesture(IView view, OxyInputGesture gesture, OxyInputEventArgs args)
         {
             var command = this.GetCommand(gesture);
             return this.HandleCommand(command, view, args);
@@ -227,7 +227,7 @@ namespace OxyPlot
         /// <param name="view">The plot view.</param>
         /// <param name="args">The <see cref="OxyTouchEventArgs" /> instance containing the event data.</param>
         /// <returns><c>true</c> if the event was handled.</returns>
-        public bool HandleTouchStarted(IView view, OxyTouchEventArgs args)
+        public virtual bool HandleTouchStarted(IView view, OxyTouchEventArgs args)
         {
             lock (this.GetSyncRoot(view))
             {
@@ -251,7 +251,7 @@ namespace OxyPlot
         /// <param name="view">The plot view.</param>
         /// <param name="args">The <see cref="OxyTouchEventArgs" /> instance containing the event data.</param>
         /// <returns><c>true</c> if the event was handled.</returns>
-        public bool HandleTouchDelta(IView view, OxyTouchEventArgs args)
+        public virtual bool HandleTouchDelta(IView view, OxyTouchEventArgs args)
         {
             lock (this.GetSyncRoot(view))
             {
@@ -279,7 +279,7 @@ namespace OxyPlot
         /// <param name="view">The plot view.</param>
         /// <param name="args">The <see cref="OxyTouchEventArgs" /> instance containing the event data.</param>
         /// <returns><c>true</c> if the event was handled.</returns>
-        public bool HandleTouchCompleted(IView view, OxyTouchEventArgs args)
+        public virtual bool HandleTouchCompleted(IView view, OxyTouchEventArgs args)
         {
             lock (this.GetSyncRoot(view))
             {


### PR DESCRIPTION
All of the touch/gesture based methods in ControllerBase seemed to be missing the virtual keyword.  All other methods had virtual.  In order for me to add custom tap behavior in Xamarin.Android, I need to override the touch/gesture methods here.