### PR TITLE
Add pie series to the .NET 4.0 assembly

### DIFF
--- a/Source/OxyPlot.Wpf/OxyPlot.Wpf_NET40.csproj
+++ b/Source/OxyPlot.Wpf/OxyPlot.Wpf_NET40.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Series\BarSeries\LinearBarSeries.cs" />
     <Compile Include="Series\BoxPlotSeries.cs" />
     <Compile Include="Series\HeatMapSeries.cs" />
+    <Compile Include="Series\PieSeries.cs" />
     <Compile Include="Series\ScatterSeries{T}.cs" />
     <Compile Include="Series\StairStepSeries.cs" />
     <Compile Include="Series\ScatterErrorSeries.cs" />


### PR DESCRIPTION
In #890 I forgot to add the `PieSeries` class to the `OxyPlot.Wpf_NET40.csproj` file. Sorry about this.