### PR TITLE
Fixed: NullReferenceException if this.IsXMonotonic != true

### DIFF
--- a/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
@@ -157,9 +157,10 @@ namespace OxyPlot.Series
             int startIdx = 0;
             double xmax = double.MaxValue;
 
+            this.ActualBarRectangles = new List<OxyRect>();
+
             if (this.IsXMonotonic)
             {
-                this.ActualBarRectangles = new List<OxyRect>();
                 var xmin = this.XAxis.ActualMinimum;
                 xmax = this.XAxis.ActualMaximum;
                 this.WindowStartIndex = this.UpdateWindowStartIndex(this.Items, rect => rect.X0, xmin, this.WindowStartIndex);


### PR DESCRIPTION
Fixes NullReferenceException if this.IsXMonotonic != true 

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log - no change, only a small fix
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Fix a regression which was introduced in #840

@oxyplot/admins

