### PR TITLE
Bugfix format exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ All notable changes to this project will be documented in this file.
 - Change default number format to "g6" in Axis base class (#841)
 - Push packages to myget.org (#847)
 - Improve tracker style (Windows Forms) (#106)
+- Change the default axis format string to "g" instead of "g6" (#951)
 
 ### Removed
 - StyleCop tasks (#556)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -63,6 +63,7 @@ Levi Botelho <levi_botelho@hotmail.com>
 Linquize
 lsowen
 Luka B
+Matt Williams
 Matthew Leibowitz <mattleibow@live.com>
 Memphisch <memphis@machzwo.de>
 Mendel Monteiro-Beckerman

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1272,7 +1272,7 @@ namespace OxyPlot.Axes
 
             if (this.ActualStringFormat == null)
             {
-                this.ActualStringFormat = "g6";
+                this.ActualStringFormat = "g";
             }
         }
 


### PR DESCRIPTION
Fixes #951 .

### Checklist

- [ ] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change the default axis format string to "g" instead of "g6".

@oxyplot/admins
