### PR TITLE
Patch for resize bug with LogarithmicAxis (#957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ All notable changes to this project will be documented in this file.
 - Axis alignment with MinimumRange (#794)
 - Fixed strange number formatting when using LogarithmicAxis with very large or very small Series (#589)
 - Fixed LogarithmicAxis to no longer freeze when the axis is reversed (#925)
+- Prevent endless loop in LogarithmicAxis (#957)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -93,6 +93,7 @@ tephyrnex
 Thomas Ibel <tibel@users.noreply.github.com>
 Tomasz Cielecki <tomasz@ostebaronen.dk>
 ToplandJ <jostein.topland@nov.com>
+Udo Liess
 VisualMelon
 vhoehn <veit.hoehn@hte-company.de>
 Vsevolod Kukol <sevo@sevo.org>

--- a/Source/OxyPlot/Axes/LogarithmicAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicAxis.cs
@@ -292,17 +292,18 @@ namespace OxyPlot.Axes
         internal IList<double> LogDecadeTicks(double step = 1)
         {
             var ret = new List<double>();
-
-            var last = double.NaN;
-            for (var exponent = Math.Ceiling(this.LogActualMinimum); exponent <= this.LogActualMaximum; exponent += step)
+            if (step > 0)
             {
-                if (exponent <= last)
-                    break;
-                last = exponent;
-                if (exponent >= this.LogActualMinimum)
-                    ret.Add(exponent);
+                var last = double.NaN;
+                for (var exponent = Math.Ceiling(this.LogActualMinimum); exponent <= this.LogActualMaximum; exponent += step)
+                {
+                    if (exponent <= last)
+                        break;
+                    last = exponent;
+                    if (exponent >= this.LogActualMinimum)
+                        ret.Add(exponent);
+                }
             }
-
             return ret;
         }
 

--- a/Source/OxyPlot/Axes/LogarithmicAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicAxis.cs
@@ -293,19 +293,14 @@ namespace OxyPlot.Axes
         {
             var ret = new List<double>();
 
-            for (var exponent = Math.Ceiling(this.LogActualMinimum);; exponent += step)
+            var last = double.NaN;
+            for (var exponent = Math.Ceiling(this.LogActualMinimum); exponent <= this.LogActualMaximum; exponent += step)
             {
-                if (exponent < this.LogActualMinimum)
-                {
-                    continue;
-                }
-
-                if (exponent > this.LogActualMaximum)
-                {
+                if (exponent <= last)
                     break;
-                }
-
-                ret.Add(exponent);
+                last = exponent;
+                if (exponent >= this.LogActualMinimum)
+                    ret.Add(exponent);
             }
 
             return ret;


### PR DESCRIPTION
Fixes #957
Method LogarithmicAxis.LogDecadeTicks had to be fixed. If step<=0 the function could run endless. Even a very small step value could lead to unchanged loop variable exponent. Now the progress of iteration is checked.
In order to get only reasonable ticks the parameter step is checked to be >0.