### PR TITLE
Improve text rendering in OxyPlot.GtkSharp by using Pango rather than…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project will be documented in this file.
 - Push packages to myget.org (#847)
 - Improve tracker style (Windows Forms) (#106)
 - Change the default format string to `null` for TimeSpanAxis and DateTimeAxis (#951)
+- Font rendering in OxyPlot.GtkSharp improved by using Pango (#972)
 
 ### Removed
 - StyleCop tasks (#556)

--- a/Source/Examples/GtkSharp/ExampleBrowser/ExampleBrowserGtk3.csproj
+++ b/Source/Examples/GtkSharp/ExampleBrowser/ExampleBrowserGtk3.csproj
@@ -49,11 +49,12 @@
     <Reference Include="gtk-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gtk-sharp-3.0</Package>
     </Reference>
-    <Reference Include="pango-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <Package>gtk-sharp-3.0</Package>
-    </Reference>
     <Reference Include="gio-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gio-sharp-3.0</Package>
+    </Reference>
+    <Reference Include="pango-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=x86">
+      <Package>gtk-sharp-3.0</Package>
+      <HintPath>C:\Program Files (x86)\GtkSharp\3.0\lib\gtk-sharp-3.0\pango-sharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -88,4 +89,3 @@
   </Target>
   -->
 </Project>
-

--- a/Source/OxyPlot.GtkSharp/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.GtkSharp/GraphicsRenderContext.cs
@@ -15,6 +15,7 @@ namespace OxyPlot.GtkSharp
     using System.Linq;
 
     using Cairo;
+    using Pango;
 
     using Gdk;
 
@@ -23,11 +24,6 @@ namespace OxyPlot.GtkSharp
     /// </summary>
     public class GraphicsRenderContext : RenderContextBase
     {
-        /// <summary>
-        /// The font size factor.
-        /// </summary>
-        private const double FontsizeFactor = 1.0;
-
         /// <summary>
         /// The image cache.
         /// </summary>
@@ -41,13 +37,13 @@ namespace OxyPlot.GtkSharp
         /// <summary>
         /// The GDI+ drawing surface.
         /// </summary>
-        private Context g;
+        private Cairo.Context g;
 
         /// <summary>
         /// Sets the graphics target.
         /// </summary>
         /// <param name="graphics">The graphics surface.</param>
-        public void SetGraphicsTarget(Context graphics)
+        public void SetGraphicsTarget(Cairo.Context graphics)
         {
             this.g = graphics;
             this.g.Antialias = Antialias.Subpixel; // TODO  .TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
@@ -262,20 +258,24 @@ namespace OxyPlot.GtkSharp
             VerticalAlignment valign,
             OxySize? maxSize)
         {
-            var fw = fontWeight >= 700 ? FontWeight.Bold : FontWeight.Normal;
-
-            this.g.Save();
-            this.g.SetFontSize(fontSize * FontsizeFactor);
-            this.g.SelectFontFace(fontFamily, FontSlant.Normal, fw);
-
-            // using (var sf = new StringFormat { Alignment = StringAlignment.Near })
-            var size = this.g.TextExtents(text);
+            Pango.Layout layout = Pango.CairoHelper.CreateLayout(this.g);
+            Pango.FontDescription font = new Pango.FontDescription();
+            font.Family = fontFamily;
+            font.Weight = (fontWeight >= 700) ? Pango.Weight.Bold : Pango.Weight.Normal;
+            font.AbsoluteSize = (int)(fontSize * Pango.Scale.PangoScale);
+            layout.FontDescription = font;
+            layout.SetText(text);
+            Pango.Rectangle inkRect;
+            Pango.Rectangle size;
+            layout.GetExtents(out inkRect, out size);
+            size.Width /= (int)Pango.Scale.PangoScale;
+            size.Height /= (int)Pango.Scale.PangoScale;
             if (maxSize != null)
             {
-                size.Width = Math.Min(size.Width, maxSize.Value.Width);
-                size.Height = Math.Min(size.Height, maxSize.Value.Height);
+                size.Width = Math.Min(size.Width, (int)maxSize.Value.Width);
+                size.Height = Math.Min(size.Height, (int)maxSize.Value.Height);
             }
-
+            this.g.Save();
             double dx = 0;
             if (halign == HorizontalAlignment.Center)
             {
@@ -306,11 +306,10 @@ namespace OxyPlot.GtkSharp
 
             this.g.Translate(dx, dy);
 
-            // g.Rectangle(0, 0, size.Width + 0.1f, size.Height + 0.1f);
-            this.g.MoveTo(0, size.Height + 0.1f);
+            g.Rectangle(0, 0, size.Width + 0.1f, size.Height + 0.1f);
+            g.Clip();
             this.g.SetSourceColor(fill);
-            this.g.ShowText(text);
-
+            Pango.CairoHelper.ShowLayout(this.g, layout);
             this.g.Restore();
         }
 
@@ -328,15 +327,19 @@ namespace OxyPlot.GtkSharp
             {
                 return OxySize.Empty;
             }
-
-            var fs = (fontWeight >= 700) ? FontWeight.Bold : FontWeight.Normal;
-
             this.g.Save();
-            this.g.SetFontSize((float)fontSize * FontsizeFactor);
-            this.g.SelectFontFace(fontFamily, FontSlant.Normal, fs);
-            var size = this.g.TextExtents(text);
+            Pango.Layout layout = Pango.CairoHelper.CreateLayout(this.g);
+            Pango.FontDescription font = new Pango.FontDescription();
+            font.Family = fontFamily;
+            font.Weight = (fontWeight >= 700) ? Pango.Weight.Bold : Pango.Weight.Normal;
+            font.AbsoluteSize = (int)(fontSize * Pango.Scale.PangoScale);
+            layout.FontDescription = font;
+            layout.SetText(text);
+            Pango.Rectangle inkRect;
+            Pango.Rectangle logicalRect;
+            layout.GetExtents(out inkRect, out logicalRect);
             this.g.Restore();
-            return new OxySize(size.Width, size.Height);
+            return new OxySize(logicalRect.Width / Pango.Scale.PangoScale, logicalRect.Height / Pango.Scale.PangoScale);
         }
 
         /// <summary>
@@ -413,7 +416,7 @@ namespace OxyPlot.GtkSharp
                 this.g.Translate(x, y);
                 this.g.Scale(scalex, scaley);
                 this.g.Rectangle(0, 0, rectw, recth);
-                CairoHelper.SetSourcePixbuf(
+                Gdk.CairoHelper.SetSourcePixbuf(
                     this.g,
                     image,
                     (rectw - image.Width) / 2.0,

--- a/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp.csproj
+++ b/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp.csproj
@@ -61,6 +61,9 @@
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
       <HintPath>C:\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\gtk-sharp.dll</HintPath>
     </Reference>
+    <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <HintPath>C:\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\pango-sharp.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.cs">

--- a/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp3.csproj
+++ b/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp3.csproj
@@ -64,6 +64,9 @@
     <Reference Include="gio-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gio-sharp-3.0</Package>
     </Reference>
+    <Reference Include="pango-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <Package>gtk-sharp-3.0</Package>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.cs">

--- a/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp3_NET40.csproj
+++ b/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp3_NET40.csproj
@@ -64,6 +64,10 @@
     <Reference Include="cairo-sharp, Version=1.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
       <Package>gtk-sharp-3.0</Package>
     </Reference>
+    <Reference Include="pango-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files (x86)\GtkSharp\3.0\lib\gtk-sharp-3.0\pango-sharp.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.cs">
@@ -95,5 +99,8 @@
       <Project>{1C1D9807-BE39-40A4-87DE-3F81E7C651E5}</Project>
       <Name>OxyPlot_NET40</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
 </Project>

--- a/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp_NET40.csproj
+++ b/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp_NET40.csproj
@@ -54,6 +54,9 @@
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
       <HintPath>C:\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\gtk-sharp.dll</HintPath>
     </Reference>
+    <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <HintPath>C:\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\pango-sharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo">


### PR DESCRIPTION
… Cairo primitives.

Fixes #972 .

### Checklist

- [X ] I have included examples or tests
- [X] I have updated the change log
- [X ] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Use Cairo to render text in OxyPlot.GtkSharp.

Earlier attempt failed on Gtk3 builds. Now trying to work around git issues.

@oxyplot/admins



