### PR TITLE
Implemented display of tracker information in OxyPlot.GtkSharp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Support for PieSeries in OxyPlot.Wpf (#878)
 - Filter in example browser (#118)
 - Support for tooltips on WPF annotations
+- Support for tracker in OxyPlot.GtkSharp
 
 ### Changed
 - Fixed closing file stream for PdfReportWriter when PdfReportWriter is closed or disposed of. (#892)

--- a/Source/OxyPlot.GtkSharp/PlotViewGtk2.cs
+++ b/Source/OxyPlot.GtkSharp/PlotViewGtk2.cs
@@ -46,6 +46,8 @@ namespace OxyPlot.GtkSharp
                 cr.Rectangle(evnt.Area.X, evnt.Area.Y, evnt.Area.Width, evnt.Area.Height);
                 cr.Clip();
                 this.DrawPlot(cr);
+                if (this.trackerLabel != null && this.trackerLabel.Visible)
+                    this.trackerLabel.Parent.QueueDraw();
             }
 
             return base.OnExposeEvent(evnt);


### PR DESCRIPTION
Fixes #973 .

### Checklist

- [x] I have included examples or tests (tests in ExampleBrowser suffice)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

These changes implement a tracker in OxyPlot.GtkSharp, based largely on the implementation in OxyPlot.WindowsForms. It uses a Gtk Label to display the tracker information. This necessitated deriving PlotView from a Gtk Layout, rather than a Gtk DrawingArea, so that child widgets could be supported.

@oxyplot/admins

