### PR TITLE
Fix problem with OxyPlot.GtkSharp not always showing the correct exam…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ All notable changes to this project will be documented in this file.
 - Fixed LogarithmicAxis to no longer freeze when the axis is reversed (#925)
 - Prevent endless loop in LogarithmicAxis (#957)
 - Fixed WPF series data not refreshed when not visible (included WPF LiveDemo)
+- Fixed bug in selection of plot to display in OxyPlot.GtkSharp ExampleBrowser (#979)
 
 ## [2014.1.546] - 2014-10-22
 ### Added

--- a/Source/Examples/GtkSharp/ExampleBrowser/MainWindow.cs
+++ b/Source/Examples/GtkSharp/ExampleBrowser/MainWindow.cs
@@ -68,7 +68,7 @@ namespace ExampleBrowser
                     last = ex.Category;
                 }
 
-                treeModel.AppendValues(iter, ex.Title);
+                treeModel.AppendValues(iter, ex.Title, ex.Category);
             }
 
             this.treeView.Model = treeModel;
@@ -87,12 +87,7 @@ namespace ExampleBrowser
                     string val1 = (string)selectedModel.GetValue(selectedNode, 0);
                     string val2 = (string)selectedModel.GetValue(selectedNode, 1);
 
-                    var info = this.Examples.FirstOrDefault(ex => ex.Title == val1)
-                            ?? this.Examples.FirstOrDefault(ex => ex.Category == val1);
-                    if (info != null)
-                    {
-                        this.SelectedExample = info;
-                    }
+                    this.SelectedExample = this.Examples.FirstOrDefault(ex => ex.Category == val2 && ex.Title == val1);
                 }
             };
 


### PR DESCRIPTION
Fixes #979 .

### Checklist

- [x] I have included examples or tests (see standard ExampleBrowser)
- [x ] I have updated the change log
- [x ] I am listed in the CONTRIBUTORS file
- [x ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Corrected a problem with establishing the correct plot to display in the OxyPlot.GtkSharp ExampleBrowser.

@oxyplot/admins

