### PR TITLE
Fix double-to-int conversion bug which was causing axis title to not …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to this project will be documented in this file.
 - Improve tracker style (Windows Forms) (#106)
 - Font rendering in OxyPlot.GtkSharp improved by using Pango (#972)
 - Improved LineSeries performance (#834)
+- Fixed bug causing axes titles to not display in OxyPlot.GtkSharp (#989)
 
 ### Changed
 - Fixed closing file stream for PdfReportWriter when PdfReportWriter is closed or disposed of. (#892)

--- a/Source/OxyPlot.GtkSharp/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.GtkSharp/GraphicsRenderContext.cs
@@ -272,8 +272,10 @@ namespace OxyPlot.GtkSharp
             size.Height /= (int)Pango.Scale.PangoScale;
             if (maxSize != null)
             {
-                size.Width = Math.Min(size.Width, (int)maxSize.Value.Width);
-                size.Height = Math.Min(size.Height, (int)maxSize.Value.Height);
+                int maxWidth = (int)Math.Min((Double)Int32.MaxValue, maxSize.Value.Width);
+                int maxHeight = (int)Math.Min((Double)Int32.MaxValue, maxSize.Value.Height);
+                size.Width = Math.Min(size.Width, maxWidth);
+                size.Height = Math.Min(size.Height, maxHeight);
             }
             this.g.Save();
             double dx = 0;


### PR DESCRIPTION
…appear.

Fixes #989.

### Checklist

- [x] I have included examples or tests (see ExampleBrowser)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- The corrects a bug I accidentally introducted in PR #976, which was causing axis titles to not be rendered in OxyPlot.GtkSharp. 
- The problem was a consequence of a value of Double.MaxValue for the height element of the "maxSize" parameter of DrawText being cast directly to an int. The resulting integer overflow led to a negative value being used as the maximum height.

@oxyplot/admins

