### PR TITLE
Fixed drawing of plot backgrounds in OxyPlot.GtkSharp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ All notable changes to this project will be documented in this file.
 - Fixed bug in selection of plot to display in OxyPlot.GtkSharp ExampleBrowser (#979)
 - Fixed non-interpolation of HeatMapSeries in OxyPlot.GtkSharp (#980)
 - Fixed axis min/max calc and axis assignment for CandleStick + VolumeSeries (#389)
+- Fixed drawing of plot backgrounds in OxyPlot.GtkSharp (#990)
 
 ## [0.2014.1.546] - 2014-10-22
 ### Added

--- a/Source/OxyPlot.GtkSharp/PlotView.cs
+++ b/Source/OxyPlot.GtkSharp/PlotView.cs
@@ -431,7 +431,8 @@ namespace OxyPlot.GtkSharp
                     {
                         if (!this.model.Background.IsUndefined())
                         {
-                            this.renderContext.DrawRectangle(Allocation.ToOxyRect(), this.model.Background, OxyColors.Undefined, 0);
+                            OxyRect rect = new OxyRect(0, 0, Allocation.Width, Allocation.Height);
+                            this.renderContext.DrawRectangle(rect, this.model.Background, OxyColors.Undefined, 0);
                         }
 
                         ((IPlotModel)this.model).Render(this.renderContext, Allocation.Width, Allocation.Height);


### PR DESCRIPTION
Fixes #990 .

### Checklist

- [x] I have included examples or tests (see ExampleBrowser application)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- This change correctly positions the rendering of plot backgrounds to place them correctly on the plot area.

@oxyplot/admins

