### PR TITLE
Automatically update Min and Max if no min and max setted

### DIFF
--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1201,6 +1201,19 @@ namespace OxyPlot.Axes
                 // The user has zoomed/panned the axis, use the ViewMaximum value.
                 this.ActualMaximum = this.ViewMaximum;
             }
+            else if (this.Maximum == 0 && this.Minimum == 0)
+            {
+                // The Maximum value has not been set
+                if (this.DataMaximum >= 0)
+                {
+                    this.ActualMaximum = this.DataMaximum * 1.5;
+                }
+                else
+                {
+                    this.ActualMaximum = this.DataMaximum * 0.5;
+                }
+
+            }
             else if (!double.IsNaN(this.Maximum))
             {
                 // The Maximum value has been set
@@ -1215,6 +1228,18 @@ namespace OxyPlot.Axes
             if (!double.IsNaN(this.ViewMinimum))
             {
                 this.ActualMinimum = this.ViewMinimum;
+            }
+            else if (this.Maximum == 0 && this.Minimum == 0)
+            {
+                // The Minimum value has not been set
+                if (this.DataMinimum >= 0)
+                {
+                    this.ActualMinimum = this.DataMinimum * 0.5;
+                }
+                else
+                {
+                    this.ActualMinimum = this.DataMinimum * 1.5;
+                }
             }
             else if (!double.IsNaN(this.Minimum))
             {


### PR DESCRIPTION
Fixes # .
### Checklist
- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)
### Changes proposed in this pull request:
## 
## 
## 

@oxyplot/admins

Automatically UpdateActualMaxMin 

update Min and Max if no min and max setted
