### PR TITLE
Manipulation when using touch is not working in Windows 10 v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - The `Smooth` property in LineSeries and PolylineAnnotation (#494)
 
 ### Fixed
-- 
+- Manipulation when using touch is not working in Windows (#1011)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot/PlotController/Manipulators/TouchManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchManipulator.cs
@@ -24,6 +24,12 @@ namespace OxyPlot
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether <c>e.Handled</c> should be set to <c>true</c>
+        /// in case pan or zoom is enabled.
+        /// </summary>
+        protected bool SetHandledForPanOrZoom { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether panning is enabled.
         /// </summary>
         private bool IsPanEnabled { get; set; }
@@ -40,7 +46,11 @@ namespace OxyPlot
         public override void Completed(OxyTouchEventArgs e)
         {
             base.Completed(e);
-            e.Handled |= this.IsPanEnabled || this.IsZoomEnabled;
+
+            if (this.SetHandledForPanOrZoom)
+            {
+                e.Handled |= this.IsPanEnabled || this.IsZoomEnabled;
+            }
         }
 
         /// <summary>
@@ -93,13 +103,16 @@ namespace OxyPlot
             this.AssignAxes(e.Position);
             base.Started(e);
 
-            this.IsPanEnabled = (this.XAxis != null && this.XAxis.IsPanEnabled)
-                                || (this.YAxis != null && this.YAxis.IsPanEnabled);
+            if (this.SetHandledForPanOrZoom)
+            {
+                this.IsPanEnabled = (this.XAxis != null && this.XAxis.IsPanEnabled)
+                                    || (this.YAxis != null && this.YAxis.IsPanEnabled);
 
-            this.IsZoomEnabled = (this.XAxis != null && this.XAxis.IsZoomEnabled)
-                                 || (this.YAxis != null && this.YAxis.IsZoomEnabled);
+                this.IsZoomEnabled = (this.XAxis != null && this.XAxis.IsZoomEnabled)
+                                     || (this.YAxis != null && this.YAxis.IsZoomEnabled);
 
-            e.Handled |= this.IsPanEnabled || this.IsZoomEnabled;
+                e.Handled |= this.IsPanEnabled || this.IsZoomEnabled;
+            }
         }
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -29,6 +29,9 @@ namespace OxyPlot
             this.Snap = true;
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
+
+            // Note: the tracker manipulator should not handle pan or zoom
+            this.SetHandledForPanOrZoom = false;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1011.

Note that this PR replaces #1012 (this one is without the example changes).

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Manipulation when using touch is not working in Windows (#1011)

@oxyplot/admins
