### PR TITLE
Implemented zoom capability up to Milliseconds

### DIFF
--- a/Source/OxyPlot/Axes/DateTimeAxis.cs
+++ b/Source/OxyPlot/Axes/DateTimeAxis.cs
@@ -251,6 +251,13 @@ namespace OxyPlot.Axes
                     }
 
                     break;
+                case DateTimeIntervalType.Milliseconds:
+                    this.ActualMinorStep = this.ActualMajorStep;
+                    if (this.ActualStringFormat == null)
+                    {
+                        this.ActualStringFormat = "HH:mm:ss.fff";
+                    }
+                    break;
                 case DateTimeIntervalType.Manual:
                     break;
                 case DateTimeIntervalType.Auto:
@@ -302,15 +309,19 @@ namespace OxyPlot.Axes
             const double Hour = Day / 24;
             const double Minute = Hour / 60;
             const double Second = Minute / 60;
+            const double HoundredMilliseconds = Minute / 60 / 1000 * 100;
+            const double TenMilliseconds = Minute / 60 / 1000 * 10;
+            const double Millisecond = Minute / 60 / 1000;
 
             double range = Math.Abs(this.ActualMinimum - this.ActualMaximum);
 
             var goodIntervals = new[]
                                     {
-                                        Second, 2 * Second, 5 * Second, 10 * Second, 30 * Second, Minute, 2 * Minute,
-                                        5 * Minute, 10 * Minute, 30 * Minute, Hour, 4 * Hour, 8 * Hour, 12 * Hour, Day,
-                                        2 * Day, 5 * Day, Week, 2 * Week, Month, 2 * Month, 3 * Month, 4 * Month,
-                                        6 * Month, Year
+                                        Millisecond, 2 * Millisecond,5 * Millisecond,
+                                        TenMilliseconds,2 * TenMilliseconds,5* TenMilliseconds,
+                                        HoundredMilliseconds,2 * HoundredMilliseconds, 5 * HoundredMilliseconds,
+                                        Second, 2 * Second, 5 * Second,
+                                        10 * Second, 30 * Second, Minute, 2 * Minute, 5 * Minute, 10 * Minute, 30 * Minute, Hour, 4 * Hour, 8 * Hour, 12 * Hour, Day, 2 * Day, 5 * Day, Week, 2 * Week, Month, 2 * Month, 3 * Month, 4 * Month, 6 * Month, Year
                                     };
 
             double interval = goodIntervals[0];
@@ -338,7 +349,11 @@ namespace OxyPlot.Axes
 
             if (this.IntervalType == DateTimeIntervalType.Auto)
             {
-                this.actualIntervalType = DateTimeIntervalType.Seconds;
+                this.actualIntervalType = DateTimeIntervalType.Milliseconds;
+                if (interval >= 1.0 / 24 / 60 / 10)
+                {
+                    this.actualIntervalType = DateTimeIntervalType.Seconds;
+                }
                 if (interval >= 1.0 / 24 / 60)
                 {
                     this.actualIntervalType = DateTimeIntervalType.Minutes;
@@ -395,6 +410,12 @@ namespace OxyPlot.Axes
                         break;
                     case DateTimeIntervalType.Hours:
                         this.actualMinorIntervalType = DateTimeIntervalType.Minutes;
+                        break;
+                    case DateTimeIntervalType.Minutes:
+                        this.actualMinorIntervalType = DateTimeIntervalType.Seconds;
+                        break;
+                    case DateTimeIntervalType.Seconds:
+                        this.actualMinorIntervalType = DateTimeIntervalType.Milliseconds;
                         break;
                     default:
                         this.actualMinorIntervalType = DateTimeIntervalType.Days;


### PR DESCRIPTION
In the DateTimeAxis the minum value intervals reached up to seconds, so I added milliseconds to "CalculateActualInterval". As well as ths ActualStringFormat in "UpdateIntervals".