### PR TITLE
Fixed plot render issues introduced with the monotonicity optimizations

### DIFF
--- a/Source/OxyPlot/Series/DataPointSeries.cs
+++ b/Source/OxyPlot/Series/DataPointSeries.cs
@@ -125,6 +125,8 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal override void UpdateData()
         {
+            base.UpdateData();
+            
             if (this.ItemsSource == null)
             {
                 return;


### PR DESCRIPTION
To reproduce the issue, zoom in to the second half of a LineSeries in a plot, decrease the number of data points used in a LineSeries (while still covering the same x-axis interval) and call PlotModel.InvalidatePlot(true). The LineSeries will disappear instead of getting rendered correctly.

I have fixed the issue as follows:

Make sure base.UpdateData() is called in DataPointSeries, otherwise XYAxisSeries.WindowStartIndex is not reset to zero in XYAxisSeries.UpdateData() after a data change (because the base method is never called). A (previous) initial guess from WindowStartIndex outside the end of the new array of data points will always produce a (wrong) start index at the end of the array when calling XYAxisSeries.FindWindowStartIndex (for example from LineSeries.RenderPoints).

Alternatively one could perhaps fix XYAxisSeries.FindWindowStartIndex to be more tolerant with bad initial guess arguments for the start index.