### PR TITLE
Ensure temporary file for PNG export is written in a suitable folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Manipulation when using touch is not working in Windows (#1011)
+- Ensure a suitable folder is used when creating a temporary file for PNG export in Oxyplot.GtkSharp (#1034)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.GtkSharp/PngExporter.cs
+++ b/Source/OxyPlot.GtkSharp/PngExporter.cs
@@ -101,7 +101,7 @@ namespace OxyPlot.GtkSharp
                     model.Render(rc, this.Width, this.Height);
 
                     // write to a temporary file
-                    var tmp = Guid.NewGuid() + ".png";
+                    var tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".png");
                     bm.WriteToPng(tmp);
                     var bytes = File.ReadAllBytes(tmp);
 


### PR DESCRIPTION
Fixes #1034 .

### Checklist

- [ ] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- When a temporary file is created for use in PNG export in OxyPlot.GtkSharp, it will now be created in a suitable folder.

@oxyplot/admins

