### PR TITLE
RangeColorAxis is not rendered correctly if the axis is reversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Manipulation when using touch is not working in Windows (#1011)
 - Ensure a suitable folder is used when creating a temporary file for PNG export in Oxyplot.GtkSharp (#1034)
+- RangeColorAxis is not rendered correctly if the axis is reversed (#1035)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ David Wong <dvkwong0@gmail.com>
 DJDAS
 DNV GL AS
 Don Syme <donsyme@fastmail.fm>
+DotNetDoctor <dotnetdoctor@outlook.com>
 efontana2
 elliatab
 episage <tilosag@gmail.com>

--- a/Source/Examples/ExampleLibrary/Axes/RangeColorAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/RangeColorAxisExamples.cs
@@ -15,24 +15,41 @@ namespace ExampleLibrary
     [Examples("RangeColorAxis"), Tags("Axes")]
     public class RangeColorAxisExamples
     {
+        [Example("ScatterSeries with Reversed RangeColorAxis (Horizontal)")]
+        public static PlotModel ReversedHorizontalRangeColorAxis()
+        {
+            return RangeColorAxis(AxisPosition.Top, true);
+        }
+
+        [Example("ScatterSeries with Reversed  RangeColorAxis (Vertical)")]
+        public static PlotModel ReversedVerticalRangeColorAxis()
+        {
+            return RangeColorAxis(AxisPosition.Right, true);
+        }
+
         [Example("ScatterSeries with RangeColorAxis (Horizontal)")]
         public static PlotModel HorizontalRangeColorAxis()
         {
-            return RangeColorAxis(AxisPosition.Top);
+            return RangeColorAxis(AxisPosition.Top, false);
         }
 
         [Example("ScatterSeries with RangeColorAxis (Vertical)")]
         public static PlotModel VerticalRangeColorAxis()
         {
-            return RangeColorAxis(AxisPosition.Right);
+            return RangeColorAxis(AxisPosition.Right, false);
         }
 
-        private static PlotModel RangeColorAxis(AxisPosition position)
+        private static PlotModel RangeColorAxis(AxisPosition position, bool reverseAxis)
         {
             int n = 1000;
+
+            string modelTitle = reverseAxis
+                                    ? string.Format("ScatterSeries and Reversed RangeColorAxis (n={0})", n)
+                                    : string.Format("ScatterSeries and RangeColorAxis (n={0})", n);
+
             var model = new PlotModel
             {
-                Title = string.Format("ScatterSeries and RangeColorAxis (n={0})", n),
+                Title = modelTitle,
                 Background = OxyColors.LightGray
             };
 
@@ -42,6 +59,13 @@ namespace ExampleLibrary
             var rca = new RangeColorAxis { Position = position, Maximum = 2, Minimum = -2 };
             rca.AddRange(0, 0.5, OxyColors.Blue);
             rca.AddRange(-0.2, -0.1, OxyColors.Red);
+
+            if (reverseAxis)
+            {
+                rca.StartPosition = 1;
+                rca.EndPosition = 0;
+            }
+
             model.Axes.Add(rca);
 
             var s1 = new ScatterSeries { MarkerType = MarkerType.Square, MarkerSize = 6, };

--- a/Source/OxyPlot/Axes/RangeColorAxis.cs
+++ b/Source/OxyPlot/Axes/RangeColorAxis.cs
@@ -185,36 +185,37 @@ namespace OxyPlot.Axes
                         OxyColors.Undefined);
                 };
 
+                // if the axis is reversed then the min and max values need to be swapped.
+                double effectiveMaxY = this.Transform(this.IsReversed ? this.ActualMinimum : this.ActualMaximum);
+                double effectiveMinY = this.Transform(this.IsReversed ? this.ActualMaximum : this.ActualMinimum);
+
                 foreach (ColorRange range in this.ranges)
                 {
                     double ylow = this.Transform(range.LowerBound);
                     double yhigh = this.Transform(range.UpperBound);
 
-                    double ymax = this.Transform(this.ActualMaximum);
-                    double ymin = this.Transform(this.ActualMinimum);
-
                     if (this.IsHorizontal())
                     {
-                        if (ylow < ymin)
+                        if (ylow < effectiveMinY)
                         {
-                            ylow = ymin;
+                            ylow = effectiveMinY;
                         }
 
-                        if (yhigh > ymax)
+                        if (yhigh > effectiveMaxY)
                         {
-                            yhigh = ymax;
+                            yhigh = effectiveMaxY;
                         }
                     }
                     else
                     {
-                        if (ylow > ymin)
+                        if (ylow > effectiveMinY)
                         {
-                            ylow = ymin;
+                            ylow = effectiveMinY;
                         }
 
-                        if (yhigh < ymax)
+                        if (yhigh < effectiveMaxY)
                         {
-                            yhigh = ymax;
+                            yhigh = effectiveMaxY;
                         }
                     }
 


### PR DESCRIPTION
Fixes RangeColorAxis is not rendered correctly if the axis is reversed #1035 .

### Checklist

- [X ] I have included examples or tests
- [ X] I have updated the change log
- [ X] I am listed in the CONTRIBUTORS file
- [ X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Fixed RangeColorAxis not rendering correctly when reversed.
Added two examples to the the ExampleBrowser showing the RangeColorAxis Reversed (both horizontally and vertically).
-
-
-

@oxyplot/admins
