### PR TITLE
Add FontSize, FontWeight and FontFamily on Wpf.TextAnnotation #1023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Added Avalonia based renderer and control library (based off OxyPlot.Wpf).
 - New `InterpolationAlgorithm` property in LineSeries and PolylineAnnotation (#494)
 - Catmull-Rom spline interpolation algorithms (#494)
+- FontSize, FontWeight and FontFamily on Wpf.TextAnnotation (#1023)
 
 ### Changed
 - 

--- a/Source/Examples/WPF/WpfExamples/Examples/AnnotationDemo/MainWindow.xaml
+++ b/Source/Examples/WPF/WpfExamples/Examples/AnnotationDemo/MainWindow.xaml
@@ -115,8 +115,12 @@
                     <oxy:LinearAxis Position="Left" Minimum="0" Maximum="100" />
                 </oxy:Plot.Axes>
                 <oxy:Plot.Annotations>
-                    <oxy:TextAnnotation TextColor="Green" Text="Hello" TextPosition="{oxy:DataPoint 30,70}" />
-                    <oxy:TextAnnotation TextColor="Orange" Text="world!" TextRotation="20" TextPosition="{oxy:DataPoint 50,70}" />
+                    <oxy:TextAnnotation Text="Hello world!" TextPosition="{oxy:DataPoint 20,80}" />
+                    <oxy:TextAnnotation TextColor="Green" Text="TextColor" TextPosition="{oxy:DataPoint 30,50}" />
+                    <oxy:TextAnnotation Text="TextRotation" TextRotation="20" TextPosition="{oxy:DataPoint 60,50}" />
+                    <oxy:TextAnnotation FontFamily="Courier New" Text="Courier New" TextPosition="{oxy:DataPoint 30,20}" />
+                    <oxy:TextAnnotation FontSize="25" Text="FontSize=25" TextPosition="{oxy:DataPoint 50,20}" />
+                    <oxy:TextAnnotation FontWeight="Bold" Text="Bold" TextPosition="{oxy:DataPoint 80,20}" />
                 </oxy:Plot.Annotations>
             </oxy:Plot>
         </TabItem>

--- a/Source/OxyPlot.Wpf/Annotations/TextualAnnotation.cs
+++ b/Source/OxyPlot.Wpf/Annotations/TextualAnnotation.cs
@@ -62,6 +62,36 @@ namespace OxyPlot.Wpf
                 new UIPropertyMetadata(VerticalAlignment.Center, AppearanceChanged));
 
         /// <summary>
+        /// Identifies the <see cref="FontFamily"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty FontFamilyProperty =
+            DependencyProperty.Register(
+                "FontFamily",
+                typeof(FontFamily),
+                typeof(TextualAnnotation),
+                new UIPropertyMetadata(null, AppearanceChanged));
+
+        /// <summary>
+        /// Identifies the <see cref="FontWeight"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty FontWeightProperty =
+            DependencyProperty.Register(
+                "FontWeight",
+                typeof(FontWeight),
+                typeof(TextualAnnotation),
+                new UIPropertyMetadata(FontWeights.Normal, AppearanceChanged));
+
+        /// <summary>
+        /// Identifies the <see cref="FontSize"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty FontSizeProperty =
+            DependencyProperty.Register(
+                "FontSize",
+                typeof(double),
+                typeof(TextualAnnotation),
+                new UIPropertyMetadata(double.NaN, AppearanceChanged));
+        
+        /// <summary>
         /// Gets or sets the text.
         /// </summary>
         public string Text
@@ -153,6 +183,63 @@ namespace OxyPlot.Wpf
         }
 
         /// <summary>
+        /// Gets or sets the font family.
+        /// </summary>
+        /// <value>
+        /// The font family.
+        /// </value>
+        public FontFamily FontFamily
+        {
+            get
+            {
+                return (FontFamily)this.GetValue(FontFamilyProperty);
+            }
+
+            set
+            {
+                this.SetValue(FontFamilyProperty, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the font weight.
+        /// </summary>
+        /// <value>
+        /// The font weight.
+        /// </value>
+        public FontWeight FontWeight
+        {
+            get
+            {
+                return (FontWeight)this.GetValue(FontWeightProperty);
+            }
+
+            set
+            {
+                this.SetValue(FontWeightProperty, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the font.
+        /// </summary>
+        /// <value>
+        /// The size of the font.
+        /// </value>
+        public double FontSize
+        {
+            get
+            {
+                return (double)this.GetValue(FontSizeProperty);
+            }
+
+            set
+            {
+                this.SetValue(FontSizeProperty, value);
+            }
+        }
+
+        /// <summary>
         /// Synchronizes the properties.
         /// </summary>
         public override void SynchronizeProperties()
@@ -165,6 +252,9 @@ namespace OxyPlot.Wpf
             a.TextRotation = this.TextRotation;
             a.TextHorizontalAlignment = this.TextHorizontalAlignment.ToHorizontalAlignment();
             a.TextVerticalAlignment = this.TextVerticalAlignment.ToVerticalAlignment();
+            a.Font = this.FontFamily?.Source;
+            a.FontSize = this.FontSize;
+            a.FontWeight = this.FontWeight.ToOpenTypeWeight();
         }
     }
 }


### PR DESCRIPTION
Fixes #1023.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-

@oxyplot/admins
