### PR TITLE
Fix for #1071: Show PlotView control in ToolBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - RectangleSeries (#1060)
 
 ### Changed
-- 
+- Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)
 
 ### Deprecated
 - OxyPlot.WP8 package. Use OxyPlot.Windows instead (#996)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -105,3 +105,4 @@ vhoehn <veit.hoehn@hte-company.de>
 Vsevolod Kukol <sevo@sevo.org>
 Xavier <Xavier@xavier-PC.lsi>
 zur003 <Eric.Zurcher@csiro.au>
+Markus Ebner

--- a/Source/OxyPlot.GtkSharp/PlotView.cs
+++ b/Source/OxyPlot.GtkSharp/PlotView.cs
@@ -22,6 +22,7 @@ namespace OxyPlot.GtkSharp
     /// Represents a control that displays a <see cref="PlotModel" />.
     /// </summary>
     [Serializable]
+    [System.ComponentModel.ToolboxItem(true)]
     public partial class PlotView : Layout, IPlotView
     {
         /// <summary>


### PR DESCRIPTION
This should lead to the `PlotView` control showing up in the ToolBox of XamarinStudio and MonoDevelops Ui editors.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Let GTK# PlotView show up in Ui editor toolbox (MonoDevelop / XamarinSharp)

@oxyplot/admins
