### PR TITLE
Fix for #937, When Color property of LineSeries is set Markers are not…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Ensure a suitable folder is used when creating a temporary file for PNG export in Oxyplot.GtkSharp (#1034)
 - RangeColorAxis is not rendered correctly if the axis is reversed (#1035)
 - OxyMouseEvents not caught due to InvalidatePlot() in WPF (#382)
+- When Color Property of LineSeries is set Markers are not shown (#937)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,6 +85,7 @@ Piotr Warzocha <pw@piootr.pl>
 Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
 Senen Fernandez <senenf@gmail.com>
+Shankar Mathiah Nanjundan <shankar.ooty@hotmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>
 Soarc <gor.rustamyan@gmail.com>
 Stefan Rado <oxyplot@sradonia.net>

--- a/Source/Examples/ExampleLibrary/Series/LineSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/LineSeriesExamples.cs
@@ -336,6 +336,40 @@ namespace ExampleLibrary
             return plotModel;
         }
 
+        [Example("Marker color options")]
+        public static PlotModel MarkerColorOptions()
+        {
+            var result = CreateRandomPoints();
+
+            var model = new PlotModel { Title = "Marker color options" };
+
+            // Dont specify line or marker color. Defaults will be used.
+            var s1 = CreateExampleLineSeries(1);
+            s1.MarkerType = MarkerType.Circle;
+            model.Series.Add(s1);
+
+            // Specify line color but not marker color. Marker color should be the same as line color.
+            var s2 = CreateExampleLineSeries(4);
+            s2.MarkerType = MarkerType.Square;
+            s2.Color = OxyColors.LightBlue;
+            model.Series.Add(s2);
+
+            // Specify marker color but not line color. Default color should be used for line.
+            var s3 = CreateExampleLineSeries(13);
+            s3.MarkerType = MarkerType.Square;
+            s3.MarkerFill = OxyColors.Black;
+            model.Series.Add(s3);
+
+            // Specify line and marker color. Specified colors should be used.
+            var s4 = CreateExampleLineSeries(5);
+            s4.MarkerType = MarkerType.Square;
+            s4.MarkerFill = OxyColors.OrangeRed;
+            s4.Color = OxyColors.Orange;
+            model.Series.Add(s4);
+
+            return model;
+        }
+
         private static List<DataPoint> CreateRandomPoints(int numberOfPoints = 50)
         {
             var r = new Random(13);

--- a/Source/Examples/WPF/SimpleDemo/MainViewModel.cs
+++ b/Source/Examples/WPF/SimpleDemo/MainViewModel.cs
@@ -40,6 +40,7 @@ namespace SimpleDemo
             series2.Points.Add(new DataPoint(30, 25));
             series2.Points.Add(new DataPoint(40, 5));
 
+
             // Add the series to the plot model
             tmp.Series.Add(series1);
             tmp.Series.Add(series2);

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -392,11 +392,12 @@ namespace OxyPlot.Series
             if (this.Color.IsAutomatic())
             {
                 this.defaultColor = this.PlotModel.GetDefaultColor();
+            }
 
-                if (this.MarkerFill.IsAutomatic())
-                {
-                    this.defaultMarkerFill = this.defaultColor;
-                }
+            if (this.MarkerFill.IsAutomatic())
+            {
+                // No color was explicitly provided. Use the line color if it was set, else use default.
+                this.defaultMarkerFill = this.Color.IsAutomatic() ? this.defaultColor : this.Color;
             }
         }
 


### PR DESCRIPTION
… shown. In this fix, the marker color is set to the line color or default color if it was not set explicitly. Tested using a sample plot (included it in the fix)

Fixes #937 When Color property of LineSeries is set Markers are not shown

### Checklist

- [Y] I have included examples or tests
- [Y] I have updated the change log
- [Y] I am listed in the CONTRIBUTORS file
- [Y] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fixing the LineSeries. If the marker color is not explicitly set, use the color of line if set or use a default color.
- Updating the example line series app to include series which have Marker and Line color set/unset.

@oxyplot/admins
