### PR TITLE
Fix SharpDX DrawText passed degrees to Matrix3x2.Rotation that requir…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Ensure a suitable folder is used when creating a temporary file for PNG export in Oxyplot.GtkSharp (#1034)
 - RangeColorAxis is not rendered correctly if the axis is reversed (#1035)
 - OxyMouseEvents not caught due to InvalidatePlot() in WPF (#382)
+- SharpDX DrawText passed degrees to Matrix3x2.Rotation that requires radians (#1075)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ Choden Konigsmark <choden.konigsmark@gmail.com>
 classicboss302
 csabar <rumancsabi@gmail.com>
 Cyril Martin <cyril.martin.cm@gmail.com>
+Dan Aizenstros
 darrelbrown
 David Laundav <davelaundav@gmail.com>
 David Wong <dvkwong0@gmail.com>

--- a/Source/Examples/SharpDX.Wpf/SimpleDemo/MainViewModel.cs
+++ b/Source/Examples/SharpDX.Wpf/SimpleDemo/MainViewModel.cs
@@ -10,7 +10,7 @@
         {
             var model = new PlotModel { Title = "Hello SharpDX from WPF" };
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title="Left Axis Title" });
             var lineSeries = new LineSeries { Title = "LineSeries", MarkerType = MarkerType.Circle };
             lineSeries.Points.Add(new DataPoint(0, 0));
             lineSeries.Points.Add(new DataPoint(10, 18));

--- a/Source/OxyPlot.SharpDX/CacherRenderContext.cs
+++ b/Source/OxyPlot.SharpDX/CacherRenderContext.cs
@@ -411,7 +411,7 @@ namespace OxyPlot.SharpDX
                 dy = -size.Height;
             }
 
-            this.renderUnits.Add(new TextRenderUnit(layout, this.GetBrush(fill), Matrix3x2.Translation(dx, dy) * Matrix3x2.Rotation((float)rotate) * Matrix3x2.Translation(p.ToVector2())));
+            this.renderUnits.Add(new TextRenderUnit(layout, this.GetBrush(fill), Matrix3x2.Translation(dx, dy) * Matrix3x2.Rotation(MathUtil.DegreesToRadians((float)rotate)) * Matrix3x2.Translation(p.ToVector2())));
             format.Dispose();
         }
 


### PR DESCRIPTION
…es radians (#1075)

Fixes #1075 .

### Checklist

- [X] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Changes the DrawText function in Source\OxyPlot.SharpDX\CacherRenderContext.cs to properly rotate the text
-
-

@oxyplot/admins
