### PR TITLE
Added check to LineAnnotation.GetScreenPoints()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ All notable changes to this project will be documented in this file.
 - ListFiller (#705)
 
 ### Fixed
+- Added check to LineAnnotation.GetScreenPoints to check if ActualMaximumX==ActualMinimumX for non-curved lines. (#1029)
 - Incorrect placment of axis title of axes with AxisDistance (#1065)
 - SharpDX control not being rendered when loaded
 - SharpDX out of viewport scrolling.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Benoit Blanchon <>
 br
 brantheman
 Brannon King
+Bryan Freeman
 Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
 Carlos Anderson <carlosjanderson@gmail.com>

--- a/Source/OxyPlot/Annotations/LineAnnotation.cs
+++ b/Source/OxyPlot/Annotations/LineAnnotation.cs
@@ -92,23 +92,27 @@ namespace OxyPlot.Annotations
 
             if (!isCurvedLine)
             {
-                // we only need to calculate two points if it is a straight line
-                if (fx != null)
+                if (this.ActualMinimumX != this.ActualMaximumX)
                 {
-                    points.Add(new DataPoint(this.ActualMinimumX, fx(this.ActualMinimumX)));
-                    points.Add(new DataPoint(this.ActualMaximumX, fx(this.ActualMaximumX)));
-                }
-                else
-                {
-                    points.Add(new DataPoint(fy(this.ActualMinimumY), this.ActualMinimumY));
-                    points.Add(new DataPoint(fy(this.ActualMaximumY), this.ActualMaximumY));
-                }
+                    // we only need to calculate two points if it is a straight line
+                    if (fx != null)
+                    {
+                        points.Add(new DataPoint(this.ActualMinimumX, fx(this.ActualMinimumX)));
+                        points.Add(new DataPoint(this.ActualMaximumX, fx(this.ActualMaximumX)));
+                    }
+                    else
+                    {
+                        points.Add(new DataPoint(fy(this.ActualMinimumY), this.ActualMinimumY));
+                        points.Add(new DataPoint(fy(this.ActualMaximumY), this.ActualMaximumY));
+                    }
 
-                if (this.Type == LineAnnotationType.Horizontal || this.Type == LineAnnotationType.Vertical)
-                {
-                    // use aliased line drawing for horizontal and vertical lines
-                    this.Aliased = true;
+                    if (this.Type == LineAnnotationType.Horizontal || this.Type == LineAnnotationType.Vertical)
+                    {
+                        // use aliased line drawing for horizontal and vertical lines
+                        this.Aliased = true;
+                    }
                 }
+                
             }
             else
             {


### PR DESCRIPTION
 to check if ActualMaximumX==ActualMinimumX for non-curved lines.

Fixes #1029.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-

@oxyplot/admins
