### PR TITLE
Fix for #1067, Change from linear to logarithmic axis does not work. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - OxyMouseEvents not caught due to InvalidatePlot() in WPF (#382)
 - SharpDX DrawText passed degrees to Matrix3x2.Rotation that requires radians (#1075)
 - When Color Property of LineSeries is set Markers are not shown (#937)
+- Change from linear to logarithmic axis does not work (#1067)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.Tests/Axes/AxisTests.cs
+++ b/Source/OxyPlot.Tests/Axes/AxisTests.cs
@@ -662,5 +662,36 @@ namespace OxyPlot.Tests
             Assert.AreEqual(yaxis.AbsoluteMinimum + (yaxis.MaximumRange / 2), (plot.Axes[0].ActualMaximum + plot.Axes[0].ActualMinimum) / 2, 1e-6, "center");
             Assert.AreEqual(yaxis.AbsoluteMinimum + yaxis.MaximumRange, plot.Axes[0].ActualMaximum, 1e-6, "maximum");
         }
+
+        [Test]
+        public void Axis_Toggle_Between_Linear_And_Log_Axis()
+        {
+            // Setting up test data per repro steps for issue 1067.
+            // https://github.com/oxyplot/oxyplot/issues/1067
+
+            var plot = new PlotModel();
+            var linearAxis = new LinearAxis()
+            {
+                Position = AxisPosition.Left
+            };
+
+            plot.Axes.Add(linearAxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(0.005, 0.004));
+            series.Points.Add(new DataPoint(0.99, 0.98));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            // Now toggle from linear to log axis.
+            plot.Axes[0] = new LogarithmicAxis { Position = AxisPosition.Left };
+
+            ((IPlotModel)plot).Update(false);
+
+            // Changing the axis type should not cause the data minimum to be invalid.
+            Assert.AreEqual(0.004, plot.Axes[0].DataMinimum);
+        }
     }
 }

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -125,6 +125,9 @@ namespace OxyPlot.Axes
             this.AxisDistance = 0;
             this.AxisTitleDistance = 4;
             this.AxisTickToLabelDistance = 4;
+
+            this.DataMaximum = double.NaN;
+            this.DataMinimum = double.NaN;
         }
 
         /// <summary>


### PR DESCRIPTION
…In this fix, the members Axis.DataMinimum and Axis.DataMaximum are initialized to double.NaN. Added tests.

Fix #1067. Change from linear to logarithmic axis does not work.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Initialize Axis.DataMinimum and Axis.DataMaximum to double.NaN. 
- Added tests to verify the change.

@oxyplot/admins
