### PR TITLE
Fix for #1068 OxyPalette.Interpolate() throws exception when paletteS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - OxyMouseEvents not caught due to InvalidatePlot() in WPF (#382)
 - SharpDX DrawText passed degrees to Matrix3x2.Rotation that requires radians (#1075)
 - When Color Property of LineSeries is set Markers are not shown (#937)
+- OxyPalette.Interpolate() throws exception when paletteSize = 1 (#1068)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.Tests/Foundation/OxyPaletteTests.cs
+++ b/Source/OxyPlot.Tests/Foundation/OxyPaletteTests.cs
@@ -25,6 +25,39 @@ namespace OxyPlot.Tests
             Assert.AreEqual(OxyColors.White, palette.Colors[2]);
             Assert.AreEqual(OxyColor.FromRgb(255, 127, 127), palette.Colors[3]);
             Assert.AreEqual(OxyColors.Red, palette.Colors[4]);
+
+            // Try with some invalid values.
+            palette = null;
+            palette = OxyPalette.Interpolate(-9, OxyColors.Blue, OxyColors.White, OxyColors.Red);
+            Assert.AreEqual(0, palette.Colors.Count);
+
+            palette = null;
+            palette = OxyPalette.Interpolate(5, null);
+            Assert.AreEqual(0, palette.Colors.Count);
+
+            palette = null;
+            palette = OxyPalette.Interpolate(0, null);
+            Assert.AreEqual(0, palette.Colors.Count);
+
+            // Try corner cases.
+            palette = null;
+            palette = OxyPalette.Interpolate(1, OxyColors.Blue, OxyColors.White, OxyColors.Red);
+            Assert.AreEqual(1, palette.Colors.Count);
+            Assert.AreEqual(OxyColors.Blue, palette.Colors[0]);
+
+            palette = null;
+            palette = OxyPalette.Interpolate(2, OxyColors.Blue, OxyColors.White, OxyColors.Red);
+            Assert.AreEqual(2, palette.Colors.Count);
+            Assert.AreEqual(OxyColors.Blue, palette.Colors[0]);
+            Assert.AreEqual(OxyColors.Red, palette.Colors[1]);
+
+            palette = null;
+            palette = OxyPalette.Interpolate(4, OxyColors.Blue);
+            Assert.AreEqual(4, palette.Colors.Count);
+            Assert.AreEqual(OxyColors.Blue, palette.Colors[0]);
+            Assert.AreEqual(OxyColors.Blue, palette.Colors[1]);
+            Assert.AreEqual(OxyColors.Blue, palette.Colors[2]);
+            Assert.AreEqual(OxyColors.Blue, palette.Colors[3]);
         }
 
         [Test]

--- a/Source/OxyPlot/Rendering/OxyPalette.cs
+++ b/Source/OxyPlot/Rendering/OxyPalette.cs
@@ -57,10 +57,19 @@ namespace OxyPlot
         /// <returns>A palette.</returns>
         public static OxyPalette Interpolate(int paletteSize, params OxyColor[] colors)
         {
+            if (colors == null || colors.Length == 0 || paletteSize < 1)
+            {
+                // There is no color to interpolate or no color required.
+                return new OxyPalette(new OxyColor[0]);
+            }
+
             var palette = new OxyColor[paletteSize];
+
+            double incrementStepSize = (paletteSize == 1) ? 0 : (1.0d / (paletteSize - 1));
+
             for (int i = 0; i < paletteSize; i++)
             {
-                double y = (double)i / (paletteSize - 1);
+                double y = i * incrementStepSize;
                 double x = y * (colors.Length - 1);
                 int i0 = (int)x;
                 int i1 = i0 + 1 < colors.Length ? i0 + 1 : i0;


### PR DESCRIPTION
…ize = 1. In this fix, the input for OxyPalette.Interpolate is verified and corner cases are handled. Unit tests added.

Fix #1068  .OxyPalette.Interpolate() throws exception when paletteSize = 1.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Updating OxyPalette.Interpolate to handle corner cases.
- Added tests.

@oxyplot/admins
