### PR TITLE
Fix #1069, ArgumentNullException for line series with no items in ItemsSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - When Color Property of LineSeries is set Markers are not shown (#937)
 - Change from linear to logarithmic axis does not work (#1067)
 - OxyPalette.Interpolate() throws exception when paletteSize = 1 (#1068)
+- ArgumentNullException for line series with no items in ItemsSource (#1069)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Foundation\DataPointTests.cs" />
     <Compile Include="Foundation\OxyColorTests.cs" />
     <Compile Include="Foundation\OxySizeTests.cs" />
+    <Compile Include="Series\LineSeriesTests.cs" />
     <Compile Include="Utilities\ComparerHelperTests.cs" />
     <Compile Include="Utilities\ListBuilderTests.cs" />
     <Compile Include="Foundation\RenderingExtensionsTests.cs" />
@@ -134,9 +135,7 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Series\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\Examples\ExampleLibrary\ExampleLibrary.csproj">
       <Project>{facb89e5-53a5-4748-9f5b-e0714ebb37b2}</Project>

--- a/Source/OxyPlot.Tests/Series/LineSeriesTests.cs
+++ b/Source/OxyPlot.Tests/Series/LineSeriesTests.cs
@@ -1,0 +1,31 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LineSeriesTests.cs" company="OxyPlot">
+//   Copyright (c) 2017 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides unit tests for the <see cref="LineSeries" /> class.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Tests
+{
+    using NUnit.Framework;
+    using Series;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides unit tests for the <see cref="LineSeries" /> class.
+    /// </summary>
+    [TestFixture]
+    public class LineSeriesTests
+    {
+        [Test]
+        public void LineSeries_GetNearestPointInternal_No_points()
+        {
+            var ls = new LineSeries();
+
+            ls.ItemsSource = new List<DataPoint>();
+            Assert.IsNull(ls.GetNearestPoint(new ScreenPoint(10, 15), false));
+        }
+    }
+}

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -331,6 +331,11 @@ namespace OxyPlot.Series
         /// <remarks>The Text property of the result will not be set, since the formatting depends on the various series.</remarks>
         protected TrackerHitResult GetNearestPointInternal(IEnumerable<DataPoint> points, int startIdx, ScreenPoint point)
         {
+            if (this.XAxis == null || this.YAxis == null || points == null)
+            {
+                return null;
+            }
+
             var spn = default(ScreenPoint);
             var dpn = default(DataPoint);
             double index = -1;


### PR DESCRIPTION
Fixes #1069 . ArgumentNullException for line series with no items in ItemsSource.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add boundary conditions for XYAxisSeries.GetNearestPoint
- Added unit test.

@oxyplot/admins
