### PR TITLE
OverflowException when zooming in on LogarithmicAxis (#1090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Change from linear to logarithmic axis does not work (#1067)
 - OxyPalette.Interpolate() throws exception when paletteSize = 1 (#1068)
 - Infinite loop in LineAnnotation (#1029)
+- OverflowException when zoomed in on logarithmic axis (#1090)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -1853,6 +1853,20 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
+        /// <summary>
+        /// Creates a plot model as described in issue 1090.
+        /// </summary>
+        /// <returns>The plot model.</returns>
+        [Example("#1090: Overflow when zoomed in on logarithmic scale")]
+        public static PlotModel Issue1090()
+        {
+            var plotModel = new PlotModel();
+            plotModel.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, AbsoluteMinimum = 0 });
+            plotModel.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left });
+
+            return plotModel;
+        }
+
         /* NEW ISSUE TEMPLATE
            [Example("#123: Issue Description")]
            public static PlotModel IssueDescription()

--- a/Source/OxyPlot/Axes/LogarithmicAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicAxis.cs
@@ -17,7 +17,7 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Represents an axis with logarithmic scale.
     /// </summary>
-    /// <remarks>See http://en.wikipedia.org/wiki/Logarithmic_scale.</remarks>
+    /// <see href="http://en.wikipedia.org/wiki/Logarithmic_scale"/>
     public class LogarithmicAxis : Axis
     {
         /// <summary>
@@ -34,7 +34,7 @@ namespace OxyPlot.Axes
         /// Gets or sets the logarithmic base (normally 10).
         /// </summary>
         /// <value>The logarithmic base.</value>
-        /// <remarks>See http://en.wikipedia.org/wiki/Logarithm.</remarks>
+        /// <see href="http://en.wikipedia.org/wiki/Logarithm"/>
         public double Base { get; set; }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace OxyPlot.Axes
 
             var desiredNumberOfTicks = axisBandwidth / this.IntervalLength;
             var ticksPerDecade = desiredNumberOfTicks / logBandwidth;
-            var logDesiredStepSize = 1.0 / Convert.ToInt32(ticksPerDecade);
+            var logDesiredStepSize = 1.0 / Math.Floor(ticksPerDecade);
 
             var intBase = Convert.ToInt32(this.Base);
 
@@ -298,12 +298,18 @@ namespace OxyPlot.Axes
                 for (var exponent = Math.Ceiling(this.LogActualMinimum); exponent <= this.LogActualMaximum; exponent += step)
                 {
                     if (exponent <= last)
+                    {
                         break;
+                    }
+
                     last = exponent;
                     if (exponent >= this.LogActualMinimum)
+                    {
                         ret.Add(exponent);
+                    }
                 }
             }
+
             return ret;
         }
 


### PR DESCRIPTION
Added issue #1090 to example browser. Fixed issue #1090. Resolved StyleCop warnings in LogarithmicAxis.cs

Fixes #1090 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
