### PR TITLE
Support DateTime and TimeSpan in ScatterSeries

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -97,6 +97,7 @@ Steve Hoelzer <shoelzer@gmail.com>
 Surfin Bird <illvdg13@gmail.com>
 Sven Dummis
 Taldoras <taldoras@googlemail.com>
+Tandy Carmichael <tcarmichael@frontier.com>
 Thorsten Claff <tclaff@gmail.com>
 thepretender
 tephyrnex

--- a/Source/OxyPlot/Series/ScatterSeries.cs
+++ b/Source/OxyPlot/Series/ScatterSeries.cs
@@ -28,7 +28,7 @@ namespace OxyPlot.Series
             filler.Add(this.DataFieldSize, double.NaN);
             filler.Add(this.DataFieldValue, double.NaN);
             filler.Add(this.DataFieldTag, (object)null);
-            filler.FillT(this.ItemsSourcePoints, this.ItemsSource, args => new ScatterPoint(Convert.ToDouble(args[0]), Convert.ToDouble(args[1]), Convert.ToDouble(args[2]), Convert.ToDouble(args[3]), args[4]));
+            filler.FillT(this.ItemsSourcePoints, this.ItemsSource, args => new ScatterPoint(Axes.Axis.ToDouble(args[0]), Axes.Axis.ToDouble(args[1]), Axes.Axis.ToDouble(args[2]), Axes.Axis.ToDouble(args[3]), args[4]));
         }
     }
 }


### PR DESCRIPTION
Fixes #1132 .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use Axes.Axis.ToDouble instead of Convert.ToDouble to handle DateTime and TimeSpan

@oxyplot/admins
