### PR TITLE
Fixed behavior of GetAxisOrDefault and added GetAxis as a replacement

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,6 +99,7 @@ Surfin Bird <illvdg13@gmail.com>
 Sven Dummis
 Taldoras <taldoras@googlemail.com>
 Tandy Carmichael <tcarmichael@frontier.com>
+Tasos Stamadianos <tasos.a.stam@gmail.com>
 Thorsten Claff <tclaff@gmail.com>
 thepretender
 tephyrnex

--- a/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
@@ -185,7 +185,7 @@ namespace ExampleLibrary
         /// </summary>
         protected override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxisOrDefault(this.XAxisKey, this.PlotModel.DefaultXAxis);
+            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
@@ -185,7 +185,9 @@ namespace ExampleLibrary
         /// </summary>
         protected override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
+            this.XAxis = this.XAxisKey != null ?
+                         this.PlotModel.GetAxis(this.XAxisKey) :
+                         this.PlotModel.DefaultXAxis;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
@@ -342,7 +342,7 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
@@ -342,7 +342,9 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -2280,7 +2280,7 @@ namespace ExampleLibrary
             protected override void EnsureAxes()
             {
                 base.EnsureAxes();
-                this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as LinearColorAxis;
+                this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as LinearColorAxis;
             }
 
             /// <summary>

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -2280,7 +2280,9 @@ namespace ExampleLibrary
             protected override void EnsureAxes()
             {
                 base.EnsureAxes();
-                this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as LinearColorAxis;
+                this.ColorAxis = this.ColorAxisKey != null ?
+                                 this.PlotModel.GetAxis(this.ColorAxisKey) as LinearColorAxis :
+                                 this.PlotModel.DefaultColorAxis as LinearColorAxis;
             }
 
             /// <summary>

--- a/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
+++ b/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
@@ -177,5 +177,24 @@ namespace OxyPlot.Tests
             Assert.That(plot.ActualPlotMargins.Right, Is.EqualTo(plot.PlotMargins.Right), "right");
             Assert.That(plot.ActualPlotMargins.Bottom, Is.EqualTo(plot.PlotMargins.Bottom), "bottom");
         }
+
+        /// <summary>
+        /// When GetAxisOrDefault is called with an unknown key, the provided default value should
+        /// be returned.
+        /// </summary>
+        [Test]
+        public void GetAxisOrDefault()
+        {
+            var plot = new PlotModel { Title = "Get Axis Or Default" };
+            var verticalAxis = new LinearAxis { Key = "YAxis", Position = AxisPosition.Left };
+            var horizontalAxis = new LinearAxis { Key = "XAxis", Position = AxisPosition.Bottom };
+
+            plot.Axes.Add(verticalAxis);
+            plot.Axes.Add(horizontalAxis);
+
+            var defaultValue = new LinearAxis { Key = "DefaultAxis" };
+
+            Assert.That(plot.GetAxisOrDefault("ThisIsAnInvalidKey", defaultValue), Is.EqualTo(defaultValue));
+        }
     }
 }

--- a/Source/OxyPlot/Annotations/Annotation.cs
+++ b/Source/OxyPlot/Annotations/Annotation.cs
@@ -60,8 +60,13 @@ namespace OxyPlot.Annotations
         /// </summary>
         public void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
-            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
+            this.XAxis = this.XAxisKey != null ?
+                         this.PlotModel.GetAxis(this.XAxisKey) :
+                         this.PlotModel.DefaultXAxis;
+
+            this.YAxis = this.YAxisKey != null ?
+                         this.PlotModel.GetAxis(this.YAxisKey) :
+                         this.PlotModel.DefaultYAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Annotations/Annotation.cs
+++ b/Source/OxyPlot/Annotations/Annotation.cs
@@ -60,8 +60,8 @@ namespace OxyPlot.Annotations
         /// </summary>
         public void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxisOrDefault(this.XAxisKey, this.PlotModel.DefaultXAxis);
-            this.YAxis = this.PlotModel.GetAxisOrDefault(this.YAxisKey, this.PlotModel.DefaultYAxis);
+            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
+            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
         }
 
         /// <summary>

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -1117,8 +1117,8 @@ namespace OxyPlot
         /// <param name="key">The axis key.</param>
         /// <param name="defaultAxis">The default axis.</param>
         /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
-         public Axis GetAxisOrDefault(string key, Axis defaultAxis)
-         {
+        public Axis GetAxisOrDefault(string key, Axis defaultAxis)
+        {
             if (key != null)
             {
                 var axis = this.Axes.FirstOrDefault(a => a.Key == key);                

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -1094,19 +1094,35 @@ namespace OxyPlot
         /// </summary>
         /// <param name="key">The axis key.</param>
         /// <param name="defaultAxis">The default axis.</param>
-        /// <returns>The axis, or the defaultAxis if the key is not specified.</returns>
+        /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
         /// <exception cref="System.InvalidOperationException">Cannot find axis with the specified key.</exception>
-        public Axis GetAxisOrDefault(string key, Axis defaultAxis)
+        public Axis GetAxis(string key)
         {
+            if (key == null)
+            {
+                throw new ArgumentException("Axis key cannot be null.");
+            }
+
+            var axis = this.Axes.FirstOrDefault(a => a.Key == key);
+            if (axis == null)
+            {
+                throw new InvalidOperationException(string.Format("Cannot find axis with Key = \"{0}\"", key));
+            }
+            return axis;
+        }
+
+        /// <summary>
+        /// Gets the axis for the specified key, or returns a default value.
+        /// </summary>
+        /// <param name="key">The axis key.</param>
+        /// <param name="defaultAxis">The default axis.</param>
+        /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
+         public Axis GetAxisOrDefault(string key, Axis defaultAxis)
+         {
             if (key != null)
             {
-                var axis = this.Axes.FirstOrDefault(a => a.Key == key);
-                if (axis == null)
-                {
-                    throw new InvalidOperationException(string.Format("Cannot find axis with Key = \"{0}\"", key));
-                }
-
-                return axis;
+                var axis = this.Axes.FirstOrDefault(a => a.Key == key);                
+                return axis != null ? axis : defaultAxis;
             }
 
             return defaultAxis;

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -447,8 +447,9 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis =
-                this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -448,7 +448,7 @@ namespace OxyPlot.Series
             base.EnsureAxes();
 
             this.ColorAxis =
-                this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+                this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -311,7 +311,7 @@
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -311,7 +311,9 @@
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -492,7 +492,9 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -492,7 +492,7 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -164,8 +164,8 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxisOrDefault(this.XAxisKey, this.PlotModel.DefaultXAxis);
-            this.YAxis = this.PlotModel.GetAxisOrDefault(this.YAxisKey, this.PlotModel.DefaultYAxis);
+            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
+            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -164,8 +164,13 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
-            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
+            this.XAxis = this.XAxisKey != null ?
+                         this.PlotModel.GetAxis(this.XAxisKey) :
+                         this.PlotModel.DefaultXAxis;
+
+            this.YAxis = this.YAxisKey != null ?
+                         this.PlotModel.GetAxis(this.YAxisKey) :
+                         this.PlotModel.DefaultYAxis;
         }
 
         /// <summary>


### PR DESCRIPTION
- GetAxisOrDefault will no longer throw an exception if the key does not exist.
- Added GetAxis to replicate the old functionality of GetAxisOrDefault
- Replaced instances of GetAxisOrDefault with GetAxis

Fixes #1137.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- A new function named 'GetAxis' has been introduced which throws when its key argument is not found. Calls to GetAxisOrDefault --primarily in functions named 'EnsureAxis-- were replaced with GetAxis so their behaviour remains the same.

@oxyplot/admins
