### PR TITLE
Fix SVG export ignoring text element alpha

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@
 Oystein Bjorke <oystein.bjorke@gmail.com>
 DNV GL AS
 LECO® Corporation
+TrainerRoad, LLC <lorentz@trainerroad.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Infinite loop in LineAnnotation (#1029)
 - OverflowException when zoomed in on logarithmic axis (#1090)
 - ScatterSeries with DateTimeAxis/TimeSpanAxis (#1132)
+- Exporting TextAnnotation with TextColor having 255 alpha to SVG produces opaque text (#1160)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
 Carlos Anderson <carlosjanderson@gmail.com>
 Carlos Teixeira <karlmtc@gmail.com>
+Chase Long <chaselfromal@gmail.com>
 Choden Konigsmark <choden.konigsmark@gmail.com>
 classicboss302
 csabar <rumancsabi@gmail.com>

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -1903,6 +1903,45 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
+        [Example("#1160: Exporting TextAnnotation with transparent TextColor to SVG produces opaque text")]
+        public static PlotModel ExportTransparentTextAnnotationToSvg()
+        {
+            var plot = new PlotModel();
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            plot.Background = OxyColors.Black;
+            plot.Annotations.Add(new TextAnnotation
+            {
+                TextPosition = new DataPoint(25, 0),
+                Text = "Opaque",
+                TextColor = OxyColor.FromRgb(255, 0, 0),
+                FontSize = 10,
+            });
+            plot.Annotations.Add(new TextAnnotation
+            {
+                TextPosition = new DataPoint(25, 20),
+                Text = "Semi transparent",
+                TextColor = OxyColor.FromArgb(125, 255, 0, 0),
+                FontSize = 10,
+            });
+            plot.Annotations.Add(new TextAnnotation
+            {
+                TextPosition = new DataPoint(25, 40),
+                Text = "Transparent1",
+                TextColor = OxyColor.FromArgb(0, 255, 0, 0),
+                FontSize = 10,
+            });
+            plot.Annotations.Add(new TextAnnotation
+            {
+                TextPosition = new DataPoint(25, 60),
+                Text = "Transparent2",
+                TextColor = OxyColors.Transparent,
+                FontSize = 10,
+            });
+
+            return plot;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }

--- a/Source/OxyPlot/Svg/SvgWriter.cs
+++ b/Source/OxyPlot/Svg/SvgWriter.cs
@@ -421,7 +421,19 @@ namespace OxyPlot
                 this.WriteAttributeString("font-weight", fontWeight);
             }
 
-            this.WriteAttributeString("fill", this.ColorToString(fill));
+            if (fill.IsInvisible())
+            {
+                this.WriteAttributeString("fill", "none");
+            }
+            else
+            {
+                this.WriteAttributeString("fill", this.ColorToString(fill));
+                if (fill.A != 0xFF)
+                {
+                    this.WriteAttributeString("fill-opacity", fill.A / 255.0);
+                }
+            }
+
             this.WriteClipPathAttribute();
 
             // WriteAttributeString("style", style);


### PR DESCRIPTION
Fixes #1160.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add support for rendering transparent and semitransparent text to `SvgWriter.WriteText`. `SvgWriter.WriteText` will now use `fill="none"` for transparent text and `fill-opacity` alongside `fill` for fill colors with nonzero alpha. The logic is adapted from [`SvgWriter.CreateStyle`](https://github.com/trainerroad/oxyplot/blob/95f714e0708958773fc607483b2399adc25bbc6b/Source/OxyPlot/Svg/SvgWriter.cs#L109)

@oxyplot/admins
