### PR TITLE
Make comparison match intended semantics and possibly fix unconfirmed bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@
 Oystein Bjorke <oystein.bjorke@gmail.com>
 DNV GL AS
 LECO® Corporation
+TrainerRoad, LLC <lorentz@trainerroad.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
 Carlos Anderson <carlosjanderson@gmail.com>
 Carlos Teixeira <karlmtc@gmail.com>
+Chase Long <chaselfromal@gmail.com>
 Choden Konigsmark <choden.konigsmark@gmail.com>
 classicboss302
 csabar <rumancsabi@gmail.com>

--- a/Source/OxyPlot/Axes/TimeSpanAxis.cs
+++ b/Source/OxyPlot/Axes/TimeSpanAxis.cs
@@ -100,7 +100,7 @@ namespace OxyPlot.Axes
                 }
 
                 double nextInterval = goodIntervals.FirstOrDefault(i => i > interval);
-                if (Math.Abs(nextInterval) < double.Epsilon)
+                if (nextInterval == default(double))
                 {
                     nextInterval = interval * 2;
                 }


### PR DESCRIPTION
[An old commit](https://github.com/trainerroad/oxyplot/commit/8dca8dd0515aedc3278c03a97080e515962be4b1) in TrainerRoad's `oxyplot` fork claims that a comparison incorrectly returns `false` when it should return `true` on some old iOS devices, specifically iPhone 4 and possibly 5th gen iPod touch. I have not tested this. However, I investigated and saw that the comparison doesn't really match the intent of the code, so I changed the comparison to make the intent more obvious and (hopefully) fix the comparison issue (if there is one) on affected devices.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use a direct comparison to `default(double)` to check if an item was not found in an array. The existing code checks if a LINQ `FirstOrDefault` call's return value is `< double.Epsilon`. The only possible values of the call are `default(double)` and any of the items in the array. The smallest element in the array is `1.0`, so the `if` predicate should evaluate to `true` when the `FirstOrDefault` call doesn't find anything.

@oxyplot/admins
