### PR TITLE
Mitigate unsightly gaps when using HeatMapRenderMethod.Rectangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - OverflowException when zoomed in on logarithmic axis (#1090)
 - ScatterSeries with DateTimeAxis/TimeSpanAxis (#1132)
 - Exporting TextAnnotation with TextColor having 255 alpha to SVG produces opaque text (#1160)
+- Change method used to render Rectanges in HeatmapSeries to prevent unsightly gaps when rendering (#1191)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -324,7 +324,8 @@ namespace OxyPlot.Series
                         var pointb = this.Orientate(new ScreenPoint(s00.X + ((i + 1) * sdx), s00.Y + ((j + 1) * sdy))); // re-orientate
                         var rectrect = new OxyRect(pointa, pointb);
 
-                        rc.DrawClippedRectangle(clip, rectrect, rectcolor, OxyColors.Undefined, 0);
+                        // stroke is necessary to ensure there is no rendered gap between rectangles
+                        rc.DrawClippedRectangleAsPolygon(clip, rectrect, rectcolor, rectcolor, 1);
                     }
                 }
             }


### PR DESCRIPTION
This has the effect of preventing unsightly gaps appearing with some rendering methods (e.g. WPF/exported PDF (PDFs being the original use-case for this Heatmap rendering method)).

Fixes #1191 

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request

 - Changes the method of rendering rectangles from `rc.DrawClippedRectangle` to `rc.DrawClippedRectangleAsPolygon`, with a stroke the same colour as the rectangle of width `1.0`. Evidence of the change can be observed when viewing the "Logarithmic X, discrete rectangles" example from the WPF Example Browser.

### Undesirable side effects

 - Has an observable (negative) performance impact when rendering Heatmaps with WPF.
 - Can create anti-aliasing artefacts on the edges of the Heatmap owing to overlapping stroke rendering (a somewhat liberal width of 1.0 was chosen, as gaps were observable with widths between 0.001 and 0.1; it is possible that a better understanding of the rendering routines could identify a better choice of width if these present a future concern)

@oxyplot/admins