### PR TITLE
Extended polar plot to full plot area, including Examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- New PolarPlot filling the full plot area (#1056)
+
+### Added
 - Added Avalonia based renderer and control library (based off OxyPlot.Wpf).
 - New `InterpolationAlgorithm` property in LineSeries and PolylineAnnotation (#494)
 - Catmull-Rom spline interpolation algorithms (#494)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,6 +69,7 @@ Levi Botelho <levi_botelho@hotmail.com>
 Linquize
 lsowen
 Luka B
+Nils Haferkemper <nils@haferkemper.de>
 Matt Williams
 Matthew Leibowitz <mattleibow@live.com>
 Memphisch <memphis@machzwo.de>

--- a/Source/Examples/ExampleLibrary/Axes/PolarPlotExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/PolarPlotExamples.cs
@@ -243,5 +243,76 @@ namespace ExampleLibrary
             model.Series.Add(new FunctionSeries(x => Math.Sin(x / 180 * Math.PI), t => t, 0, 180, 0.01));
             return model;
         }
+
+        [Example("Semi-circle full plot area")]
+        public static PlotModel SemiCircleFullPlotArea()
+        {
+            var model = new PlotModel
+            {
+                Title = "Semi-circle polar plot filling the plot area",
+                Subtitle = "The center can be move using the right mouse button",
+                PlotType = PlotType.Polar,
+                PlotAreaBorderThickness = new OxyThickness(1),
+                PlotMargins = new OxyThickness(60, 20, 4, 40)
+            };
+            model.Axes.Add(
+                new AngleAxisFullPlotArea
+                {
+                    Minimum = 0,
+                    Maximum = 180,
+                    MajorStep = 45,
+                    MinorStep = 9,
+                    StartAngle = 0,
+                    EndAngle = 180,
+                    MajorGridlineStyle = LineStyle.Solid,
+                    MinorGridlineStyle = LineStyle.Solid
+                });
+            model.Axes.Add(new MagnitudeAxisFullPlotArea
+            {
+                Minimum = 0,
+                Maximum = 1,
+                MidshiftH = 0,
+                MidshiftV = 0.9d,
+                MajorGridlineStyle = LineStyle.Solid,
+                MinorGridlineStyle = LineStyle.Solid
+            });
+            model.Series.Add(new FunctionSeries(x => Math.Sin(x / 180 * Math.PI), t => t, 0, 180, 0.01));
+            return model;
+        }
+
+        [Example("Spiral full plot area")]
+        public static PlotModel ArchimedeanSpiralFullPlotArea()
+        {
+            var model = new PlotModel
+            {
+                Title = "Polar plot filling the plot area",
+                Subtitle = "The center can be move using the right mouse button",
+                PlotType = PlotType.Polar,
+                PlotAreaBorderThickness = new OxyThickness(1),
+                PlotMargins = new OxyThickness(60, 20, 4, 40)
+            };
+            model.Axes.Add(
+                new AngleAxisFullPlotArea
+                {
+                    MajorStep = Math.PI / 4,
+                    MinorStep = Math.PI / 16,
+                    MajorGridlineStyle = LineStyle.Solid,
+                    MinorGridlineStyle = LineStyle.Solid,
+                    FormatAsFractions = true,
+                    FractionUnit = Math.PI,
+                    FractionUnitSymbol = "π",
+                    Minimum = 0,
+                    Maximum = 2 * Math.PI
+                });
+            model.Axes.Add(new MagnitudeAxisFullPlotArea
+            {
+                MidshiftH = -0.1d,
+                MidshiftV = -0.25d,
+                MajorGridlineStyle = LineStyle.Solid,
+                MinorGridlineStyle = LineStyle.Solid
+            });
+            model.Series.Add(new FunctionSeries(t => t, t => t, 0, Math.PI * 6, 0.01));
+            return model;
+        }
     }
 }

--- a/Source/OxyPlot/Axes/AngleAxisFullPlotArea.cs
+++ b/Source/OxyPlot/Axes/AngleAxisFullPlotArea.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OxyPlot.Axes
+{
+    public class AngleAxisFullPlotArea : AngleAxis
+    {
+        /// <summary>
+        /// Renders the axis on the specified render context.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="pass">The pass.</param>
+        public override void Render(IRenderContext rc, int pass)
+        {
+            var r = new AngleAxisFullPlotAreaRenderer(rc, this.PlotModel);
+            r.Render(this, pass);
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/MagnitudeAxisFullPlotArea.cs
+++ b/Source/OxyPlot/Axes/MagnitudeAxisFullPlotArea.cs
@@ -1,0 +1,185 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MagnitudeAxisFullPlotArea.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Represents a magnitude axis for polar plots.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public class MagnitudeAxisFullPlotArea : MagnitudeAxis
+    {
+        private double _midshiftH = 0;
+        /// <summary>
+        /// Portion to shift the center in horizontal direction relative to the plot area size (from -0.5 to +0.5 meaning +-50% of the width)
+        /// </summary>
+        public double MidshiftH
+        {
+            get { return _midshiftH; }
+            set
+            {
+                _midshiftH = value;
+                _midshiftH = Math.Max(_midshiftH, -0.5d);
+                _midshiftH = Math.Min(_midshiftH, 0.5d);
+            }
+        }
+
+        private double _midshiftV = 0d;
+        /// <summary>
+        /// Portion to shift the center in vertical direction relative to the plot area size (from -0.5 to +0.5 meaning +-50% of the height)
+        /// </summary>
+        public double MidshiftV
+        {
+            get { return _midshiftV; }
+            set
+            {
+                _midshiftV = value;
+                _midshiftV = Math.Max(_midshiftV, -0.5d);
+                _midshiftV = Math.Min(_midshiftV, 0.5d);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MagnitudeAxis" /> class.
+        /// </summary>
+        public MagnitudeAxisFullPlotArea()
+        {
+            this.Position = AxisPosition.None;
+            this.IsPanEnabled = true;
+            this.IsZoomEnabled = false;
+
+            this.MajorGridlineStyle = LineStyle.Solid;
+            this.MinorGridlineStyle = LineStyle.Solid;
+        }
+
+        ///// <summary>
+        ///// Inverse transform the specified screen point.
+        ///// </summary>
+        ///// <param name="x">The x coordinate.</param>
+        ///// <param name="y">The y coordinate.</param>
+        ///// <param name="yaxis">The y-axis.</param>
+        ///// <returns>The data point.</returns>
+        //public override DataPoint InverseTransform(double x, double y, Axis yaxis)
+        //{
+        //    var angleAxis = yaxis as AngleAxis;
+        //    if (angleAxis == null)
+        //    {
+        //        throw new InvalidOperationException("Polar angle axis not defined!");
+        //    }
+
+        //    x -= this.MidPoint.x;
+        //    y -= this.MidPoint.y;
+        //    y *= -1;
+        //    double th = Math.Atan2(y, x);
+        //    double r = Math.Sqrt((x * x) + (y * y));
+        //    x = (r / this.Scale) + this.Offset;
+        //    y = (th / angleAxis.Scale) + angleAxis.Offset;
+        //    return new DataPoint(x, y);
+        //}
+
+        /// <summary>
+        /// Renders the axis on the specified render context.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="pass">The rendering pass.</param>
+        public override void Render(IRenderContext rc, int pass)
+        {
+            var r = new MagnitudeAxisFullPlotAreaRenderer(rc, this.PlotModel);
+            r.Render(this, pass);
+        }
+
+        ///// <summary>
+        ///// Transforms the specified point to screen coordinates.
+        ///// </summary>
+        ///// <param name="x">The x value (for the current axis).</param>
+        ///// <param name="y">The y value.</param>
+        ///// <param name="yaxis">The y axis.</param>
+        ///// <returns>The transformed point.</returns>
+        //public override ScreenPoint Transform(double x, double y, Axis yaxis)
+        //{
+        //    var angleAxis = yaxis as AngleAxis;
+        //    if (angleAxis == null)
+        //    {
+        //        throw new InvalidOperationException("Polar angle axis not defined!");
+        //    }
+
+        //    var r = (x - this.Offset) * this.Scale;
+        //    var theta = (y - angleAxis.Offset) * angleAxis.Scale;
+
+        //    return new ScreenPoint(this.MidPoint.x + (r * Math.Cos(theta / 180 * Math.PI)), this.MidPoint.y - (r * Math.Sin(theta / 180 * Math.PI)));
+        //}
+
+        /// <summary>
+        /// Updates the scale and offset properties of the transform from the specified boundary rectangle.
+        /// </summary>
+        /// <param name="bounds">The bounds.</param>
+        internal override void UpdateTransform(OxyRect bounds)
+        {
+            double x0 = bounds.Left;
+            double x1 = bounds.Right;
+            double y0 = bounds.Bottom;
+            double y1 = bounds.Top;
+
+            this.ScreenMin = new ScreenPoint(x0, y1);
+            this.ScreenMax = new ScreenPoint(x1, y0);
+
+            this.MidPoint = new ScreenPoint((x0 + x1) / 2 + this.MidshiftH * bounds.Width, (y0 + y1) / 2 + this.MidshiftV * bounds.Height); //new ScreenPoint((x0 + x1) / 2, (y0 + y1) / 2);
+            //this.ShiftedMidPoint = new ScreenPoint((x0 + x1) / 2 + this.MidshiftH * bounds.Width, (y0 + y1) / 2 + this.MidshiftV * bounds.Height);
+
+            // this.ActualMinimum = 0;
+            double r = Math.Min(Math.Abs(x1 - x0), Math.Abs(y1 - y0));
+            this.SetTransform(0.5 * r / (this.ActualMaximum - this.ActualMinimum), this.ActualMinimum);
+        }
+
+        /// <summary>
+        /// Pans the specified axis.
+        /// </summary>
+        /// <param name="ppt">The previous point (screen coordinates).</param>
+        /// <param name="cpt">The current point (screen coordinates).</param>
+        public override void Pan(ScreenPoint ppt, ScreenPoint cpt)
+        {
+            if (!this.IsPanEnabled)
+            {
+                return;
+            }
+
+            bool isHorizontal = this.IsHorizontal();
+
+            double dsx = cpt.X - ppt.X;
+            double dsy = cpt.Y - ppt.Y;
+
+            double dsxp = dsx / this.PlotModel.PlotArea.Width;
+            double dsyp = dsy / this.PlotModel.PlotArea.Height;
+
+            this.MidshiftH += dsxp;
+            this.MidshiftV += dsyp;
+
+            //double d = isHorizontal ? cpt.X - ppt.X : cpt.Y - ppt.Y;
+            //this.Pan(d);
+
+            this.OnAxisChanged(new AxisChangedEventArgs(AxisChangeTypes.Pan, 0, 0));
+        }
+
+        /// <summary>
+        /// Zooms the axis at the specified coordinate.
+        /// </summary>
+        /// <param name="factor">The zoom factor.</param>
+        /// <param name="x">The coordinate to zoom at.</param>
+        public override void ZoomAt(double factor, double x)
+        {
+            if (!this.IsZoomEnabled)
+            {
+                return;
+            }
+
+            base.ZoomAt(factor, 0);
+            return;
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
@@ -1,0 +1,219 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="AngleAxisFullPlotAreaRenderer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides functionality to render with the plot area filled completely <see cref="AngleAxis" />.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Provides functionality to render <see cref="AngleAxis" /> using the full plot area.
+    /// </summary>
+    public class AngleAxisFullPlotAreaRenderer : AxisRendererBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleAxisFullPlotAreaRenderer" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        public AngleAxisFullPlotAreaRenderer(IRenderContext rc, PlotModel plot)
+            : base(rc, plot)
+        {
+        }
+
+        /// <summary>
+        /// Renders the specified axis.
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="pass">The render pass.</param>
+        /// <exception cref="System.InvalidOperationException">Magnitude axis not defined.</exception>
+        public override void Render(Axis axis, int pass)
+        {
+            var angleAxis = (AngleAxis)axis;
+
+            base.Render(axis, pass);
+
+            var magnitudeAxis = this.Plot.DefaultMagnitudeAxis;
+
+            if (magnitudeAxis == null)
+            {
+                throw new InvalidOperationException("Magnitude axis not defined.");
+            }
+
+            var scaledStartAngle = angleAxis.StartAngle / angleAxis.Scale;
+            var scaledEndAngle = angleAxis.EndAngle / angleAxis.Scale;
+
+            var axisLength = Math.Abs(scaledEndAngle - scaledStartAngle);
+            var eps = axis.MinorStep * 1e-3;
+            if (this.MinorPen != null)
+            {
+                var tickCount = Math.Abs((int)(axisLength / axis.ActualMinorStep));
+
+                var screenPoints = this.MinorTickValues
+                            .Where(x => x > Math.Min(scaledStartAngle, scaledEndAngle) - eps &&
+                                   x < Math.Max(scaledStartAngle, scaledEndAngle) + eps &&
+                                   !this.MajorTickValues.Contains(x))
+                            .Take(tickCount + 1)
+                            .Select(x => TransformToClientRectangle(magnitudeAxis.ActualMaximum, x, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint));
+
+                foreach (var screenPoint in screenPoints)
+                {
+                    this.RenderContext.DrawLine(magnitudeAxis.MidPoint.x, magnitudeAxis.MidPoint.y, screenPoint.x, screenPoint.y, this.MinorPen, false);
+                }
+            }
+
+            var isFullCircle = Math.Abs(Math.Abs(Math.Max(angleAxis.EndAngle, angleAxis.StartAngle) - Math.Min(angleAxis.StartAngle, angleAxis.EndAngle)) - 360) < 1e-3;
+            var majorTickCount = (int)(axisLength / axis.ActualMajorStep);
+            if (!isFullCircle)
+            {
+                majorTickCount++;
+            }
+
+            if (this.MajorPen != null)
+            {
+                var screenPoints = this.MajorTickValues
+                                .Where(x => x > Math.Min(scaledStartAngle, scaledEndAngle) - eps && x < Math.Max(scaledStartAngle, scaledEndAngle) + eps)
+                                .Take(majorTickCount)
+                                .Select(x => TransformToClientRectangle(magnitudeAxis.ActualMaximum, x, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint))
+                                .ToArray();
+
+                foreach (var point in screenPoints)
+                {
+                    this.RenderContext.DrawLine(magnitudeAxis.MidPoint.x, magnitudeAxis.MidPoint.y, point.x, point.y, this.MajorPen, false);
+                }
+            }
+
+            //Text rendering
+            foreach (var value in this.MajorLabelValues.Take(majorTickCount))
+            {
+                ScreenPoint pt = TransformToClientRectangle(magnitudeAxis.ActualMaximum, value, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint);
+
+                var angle = Math.Atan2(pt.y - magnitudeAxis.MidPoint.y, pt.x - magnitudeAxis.MidPoint.x);
+
+                double degree = Math.PI / 180d;
+                // Convert to degrees
+                angle /= degree;
+
+                var text = axis.FormatValue(value);
+
+                var ha = HorizontalAlignment.Center;
+                var va = VerticalAlignment.Middle;
+                OxyRect plotrect = this.Plot.PlotArea;
+
+                //check on which side of the plotarea it is
+                //top
+                if (pt.Y <= plotrect.Top)
+                {
+                    ha = HorizontalAlignment.Center;
+                    va = VerticalAlignment.Top;
+                    // add some margin
+                    pt.y += axis.AxisTickToLabelDistance;
+                }
+                //bottom
+                else if (pt.Y >= plotrect.Bottom)
+                {
+                    ha = HorizontalAlignment.Center;
+                    va = VerticalAlignment.Bottom;
+                    pt.y -= axis.AxisTickToLabelDistance;
+                }
+                //left
+                else if (pt.X <= plotrect.Left)
+                {
+                    ha = HorizontalAlignment.Left;
+                    va = VerticalAlignment.Middle;
+                    pt.x += axis.AxisTickToLabelDistance;
+                }
+                //right
+                else if (pt.X >= plotrect.Right)
+                {
+                    ha = HorizontalAlignment.Right;
+                    va = VerticalAlignment.Middle;
+                    pt.x -= axis.AxisTickToLabelDistance;
+                }
+                else
+                {
+
+                }
+
+                if (Math.Abs(Math.Abs(angle) - 90) < 10)
+                {
+                    //ha = HorizontalAlignment.Center;
+                    //va = angle >= 90 ? VerticalAlignment.Top : VerticalAlignment.Bottom;
+                    angle = 0;
+                }
+                else if (angle > 90 || angle < -90)
+                {
+                    angle -= 180;
+                    //ha = HorizontalAlignment.Right;
+                    //va = VerticalAlignment.Middle;
+                }
+
+                ScreenPoint outsideposition = pt;
+                this.RenderContext.DrawMathText(
+                    outsideposition, text, axis.ActualTextColor, axis.ActualFont, axis.ActualFontSize, axis.ActualFontWeight, 0, ha, va);
+            }
+        }
+
+        /// <summary>
+        /// Transforms the specified point to screen coordinates.
+        /// </summary>
+        /// <param name="actualMaximum"></param>
+        /// <param name="x"></param>
+        /// <param name="axis"></param>
+        /// <param name="plotArea"></param>
+        /// <param name="midPoint"></param>
+        /// <returns></returns>
+        public ScreenPoint TransformToClientRectangle(double actualMaximum, double x, Axis axis, OxyRect plotArea, ScreenPoint midPoint)
+        {
+            ScreenPoint result = new ScreenPoint();
+            //I think the key is to NOT compute the axis scaled value of the angle, BUT to just draw it from the Midpoint to the end of the PlotView
+            //For each MinorTickValue, compute an intersection point within the client area
+            double width_to_height = plotArea.Width / plotArea.Height;
+
+
+            double theta = (x - axis.Offset) * axis.Scale;
+            theta %= 360.0d;
+            double theta_rad = theta / 180.0d * Math.PI;
+
+            double _x = Math.Cos(theta_rad);
+            //y is negative because it is from top to bottom
+            double _y = -Math.Sin(theta_rad);
+            //compute intersections with right or lefth side
+
+            if (_x != 0)
+            {
+                double delta_x = 0;
+                if (_x > 0)
+                    delta_x = plotArea.Right - midPoint.X;
+                else if (_x < 0)
+                    delta_x = plotArea.Left - midPoint.X;
+
+                double x_portion = delta_x / _x;
+                double lineend_x = x_portion * _x;
+                double lineend_y = x_portion * _y;
+                if (lineend_y + midPoint.Y > plotArea.Bottom || lineend_y + midPoint.Y < plotArea.Top)
+                {
+                    double delta_y = 0;
+                    if (_y > 0)
+                        delta_y = plotArea.Bottom - midPoint.Y;
+                    else
+                        delta_y = plotArea.Top - midPoint.Y;
+
+                    double y_portion = delta_y / _y;
+                    lineend_x = y_portion * _x;
+                    lineend_y = y_portion * _y;
+                    result = new ScreenPoint((y_portion * _x) + midPoint.X, (y_portion * _y) + midPoint.Y);
+                }
+                else
+                    result = new ScreenPoint(lineend_x + midPoint.X, lineend_y + midPoint.Y);
+            }
+            return result;
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
@@ -1,0 +1,419 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MagnitudeAxisFullPlotAreaRenderer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides functionality to render <see cref="MagnitudeAxis" /> using the full plot area.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Provides functionality to render <see cref="MagnitudeAxis" /> using the full plot area.
+    /// </summary>
+    public class MagnitudeAxisFullPlotAreaRenderer : AxisRendererBase
+    {
+        /// <summary>
+        /// constants to simplify angular calculations
+        /// </summary>
+        const double degree = 180.0d / Math.PI;
+        const double rad = Math.PI / 180.0d;
+
+        /// <summary>
+        /// this constant limit the number of segments to draw a tick arc
+        /// </summary>
+        const double MaxSegments = 180.0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MagnitudeAxisFullPlotAreaRenderer" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        public MagnitudeAxisFullPlotAreaRenderer(IRenderContext rc, PlotModel plot)
+            : base(rc, plot)
+        {
+        }
+
+        /// <summary>
+        /// Renders the specified axis.
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="pass">The pass.</param>
+        /// <exception cref="System.NullReferenceException">Angle axis should not be <c>null</c>.</exception>
+        public override void Render(Axis axis, int pass)
+        {
+            base.Render(axis, pass);
+
+            var angleAxis = this.Plot.DefaultAngleAxis;
+            var magnitudeAxis = this.Plot.DefaultMagnitudeAxis;
+
+            if (angleAxis == null)
+            {
+                throw new NullReferenceException("Angle axis should not be null.");
+            }
+
+            angleAxis.UpdateActualMaxMin();
+
+            double topdistance = Math.Abs(axis.PlotModel.PlotArea.Top - magnitudeAxis.MidPoint.Y);
+            double bottomdistance = Math.Abs(axis.PlotModel.PlotArea.Bottom - magnitudeAxis.MidPoint.Y);
+            double leftdistance = Math.Abs(axis.PlotModel.PlotArea.Left - magnitudeAxis.MidPoint.X);
+            double rightdistance = Math.Abs(axis.PlotModel.PlotArea.Right - magnitudeAxis.MidPoint.X);
+
+            double maxtick_right = axis.InverseTransform(rightdistance);
+            double maxtick_left = axis.InverseTransform(leftdistance);
+            double maxtick_top = axis.InverseTransform(topdistance);
+            double maxtick_bottom = axis.InverseTransform(bottomdistance);
+
+
+            double cornerangle_topright = degree * Math.Atan(topdistance / rightdistance);
+            double cornerangle_topleft = 180 - degree * Math.Atan(topdistance / leftdistance);
+            double cornerangle_bottomleft = 180 + degree * Math.Atan(bottomdistance / leftdistance);
+            double cornerangle_bottomright = 360 - degree * Math.Atan(bottomdistance / rightdistance);
+
+            double cornerdistance_topright = Math.Sqrt(Math.Pow(topdistance, 2) + Math.Pow(rightdistance, 2));
+            double cornerdistance_topleft = Math.Sqrt(Math.Pow(topdistance, 2) + Math.Pow(leftdistance, 2));
+            double cornerdistance_bottomleft = Math.Sqrt(Math.Pow(bottomdistance, 2) + Math.Pow(leftdistance, 2));
+            double cornerdistance_bottomright = Math.Sqrt(Math.Pow(bottomdistance, 2) + Math.Pow(rightdistance, 2));
+
+            double maxtick_topright = axis.InverseTransform(cornerdistance_topright);
+            double maxtick_topleft = axis.InverseTransform(cornerdistance_topleft);
+            double maxtick_bottomleft = axis.InverseTransform(cornerdistance_bottomleft);
+            double maxtick_bottomright = axis.InverseTransform(cornerdistance_bottomright);
+
+            double maxdistance = Math.Max(cornerdistance_topright, Math.Max(cornerdistance_topleft, Math.Max(cornerdistance_bottomleft, cornerdistance_bottomright)));
+            double maxtick = Math.Max(maxtick_topright, Math.Max(maxtick_topleft, Math.Max(maxtick_bottomleft, maxtick_bottomright)));
+            double mintick = Math.Min(maxtick_topright, Math.Min(maxtick_topleft, Math.Min(maxtick_bottomleft, maxtick_bottomright)));
+
+            List<double> majorticks = new List<double>();
+            majorticks.AddRange(this.MajorTickValues);
+            ExtendTickList(ref majorticks, maxtick);
+
+            List<double> minorticks = new List<double>();
+            minorticks.AddRange(this.MinorTickValues);
+            ExtendTickList(ref minorticks, maxtick);
+
+            List<double> textticks = new List<double>();
+            textticks.AddRange(this.MajorTickValues);
+            ExtendTickList(ref textticks, maxtick);
+
+            var majorTicks = majorticks.Where(x => x > axis.ActualMinimum && x <= maxtick).ToArray();
+
+            if (pass == 0 && this.MinorPen != null)
+            {
+                OxyPen pen = this.MinorPen;
+                //var minorTicks = this.MinorTickValues.Where(x => x >= axis.ActualMinimum && x <= axis.ActualMaximum && !majorTicks.Contains(x)).ToArray();
+                var minorTicks = minorticks.Where(x => x >= axis.ActualMinimum && x <= maxtick && !majorTicks.Contains(x)).ToArray();
+
+                foreach (var tickValue in minorTicks)
+                {
+                    //a circle consists - in this case - of 4 arcs
+                    //the start and end of each arc has to be computed
+
+                    double r = axis.Transform(tickValue);
+
+                    //this works by putting the limits of the plotarea into the circular equation and solving it to gain t for each intersection
+
+                    //y=r*sin(t)+ym
+                    //t=asin((y-ym)/r)
+                    //x=r*cos(t)+xm
+                    //t=acos((x-xm)/r)
+
+                    double startangle_0_90 = 0;
+                    double endangle_0_90 = 90;
+                    double startangle_90_180 = 90;
+                    double endangle_90_180 = 180;
+                    double startangle_180_270 = 180;
+                    double endangle_180_270 = 270;
+                    double startangle_270_360 = 270;
+                    double endangle_270_360 = 360;
+
+                    double rightportion = rightdistance / r;
+                    double topportion = topdistance / r;
+                    double leftportion = leftdistance / r;
+                    double bottomportion = bottomdistance / r;
+
+                    if (r > rightdistance)
+                    {
+                        //will hit the right bound
+                        endangle_270_360 = 360 - degree * Math.Acos(rightportion);
+                        startangle_0_90 = degree * Math.Acos(rightportion);
+                    }
+                    if (r > topdistance)
+                    {
+                        //will hit the top bound
+                        endangle_0_90 = degree * Math.Asin(topportion);
+                        startangle_90_180 = 180 - degree * Math.Asin(topportion);
+                    }
+                    if (r > leftdistance)
+                    {
+                        //will hit the left bound
+                        endangle_90_180 = 180 - degree * Math.Acos(leftportion);
+                        startangle_180_270 = 180 + degree * Math.Acos(leftportion);
+                    }
+                    if (r > bottomdistance)
+                    {
+                        //will hit the bottom bound
+                        endangle_180_270 = 180 + degree * Math.Asin(bottomportion);
+                        startangle_270_360 = 360 - degree * Math.Asin(bottomportion);
+                    }
+
+                    //Top right
+                    if (startangle_0_90 < cornerangle_topright)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (startangle_0_90 + angleAxis.Offset), (cornerangle_topright + angleAxis.Offset));
+                    if (cornerangle_topright < endangle_0_90)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (cornerangle_topright + angleAxis.Offset), (endangle_0_90 + angleAxis.Offset));
+
+                    //Top left
+                    if (startangle_90_180 < cornerangle_topleft)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_90_180 + angleAxis.Offset, cornerangle_topleft + angleAxis.Offset);
+                    if (cornerangle_topleft < endangle_90_180)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_topleft + angleAxis.Offset, endangle_90_180 + angleAxis.Offset);
+
+                    //Bottom left
+                    if (startangle_180_270 < cornerangle_bottomleft)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_180_270 + angleAxis.Offset, cornerangle_bottomleft + angleAxis.Offset);
+                    if (cornerangle_bottomleft < endangle_180_270)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomleft + angleAxis.Offset, endangle_180_270 + angleAxis.Offset);
+
+                    //Bottom right
+                    if (startangle_270_360 < cornerangle_bottomright)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_270_360 + angleAxis.Offset, cornerangle_bottomright + angleAxis.Offset);
+                    if (cornerangle_bottomright < endangle_270_360)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomright + angleAxis.Offset, endangle_270_360 + angleAxis.Offset);
+                }
+            }
+
+            if (pass == 0 && this.MajorPen != null)
+            {
+                OxyPen pen = this.MajorPen;
+                foreach (var tickValue in majorTicks)
+                {
+                    //a circle consists - in this case - of 4 arcs
+                    //the start and end of each arc has to be computed
+
+                    double r = axis.Transform(tickValue);
+
+                    //this works by putting the limits of the plotarea into the circular equation and solving it to gain t for each intersection
+
+                    //y=r*sin(t)+ym
+                    //t=asin((y-ym)/r)
+                    //x=r*cos(t)+xm
+                    //t=acos((x-xm)/r)
+
+                    double startangle_0_90 = 0;
+                    double endangle_0_90 = 90;
+                    double startangle_90_180 = 90;
+                    double endangle_90_180 = 180;
+                    double startangle_180_270 = 180;
+                    double endangle_180_270 = 270;
+                    double startangle_270_360 = 270;
+                    double endangle_270_360 = 360;
+
+                    double rightportion = rightdistance / r;
+                    double topportion = topdistance / r;
+                    double leftportion = leftdistance / r;
+                    double bottomportion = bottomdistance / r;
+
+                    if (r > rightdistance)
+                    {
+                        //will hit the right bound
+                        endangle_270_360 = 360 - degree * Math.Acos(rightportion);
+                        startangle_0_90 = degree * Math.Acos(rightportion);
+                    }
+                    if (r > topdistance)
+                    {
+                        //will hit the top bound
+                        endangle_0_90 = degree * Math.Asin(topportion);
+                        startangle_90_180 = 180 - degree * Math.Asin(topportion);
+                    }
+                    if (r > leftdistance)
+                    {
+                        //will hit the left bound
+                        endangle_90_180 = 180 - degree * Math.Acos(leftportion);
+                        startangle_180_270 = 180 + degree * Math.Acos(leftportion);
+                    }
+                    if (r > bottomdistance)
+                    {
+                        //will hit the bottom bound
+                        endangle_180_270 = 180 + degree * Math.Asin(bottomportion);
+                        startangle_270_360 = 360 - degree * Math.Asin(bottomportion);
+                    }
+
+                    //Top right
+                    if (startangle_0_90 < cornerangle_topright)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (startangle_0_90 + angleAxis.Offset), (cornerangle_topright + angleAxis.Offset));
+                    if (cornerangle_topright < endangle_0_90)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (cornerangle_topright + angleAxis.Offset), (endangle_0_90 + angleAxis.Offset));
+
+                    //Top left
+                    if (startangle_90_180 < cornerangle_topleft)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_90_180 + angleAxis.Offset, cornerangle_topleft + angleAxis.Offset);
+                    if (cornerangle_topleft < endangle_90_180)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_topleft + angleAxis.Offset, endangle_90_180 + angleAxis.Offset);
+
+                    //Bottom left
+                    if (startangle_180_270 < cornerangle_bottomleft)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_180_270 + angleAxis.Offset, cornerangle_bottomleft + angleAxis.Offset);
+                    if (cornerangle_bottomleft < endangle_180_270)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomleft + angleAxis.Offset, endangle_180_270 + angleAxis.Offset);
+
+                    //Bottom right
+                    if (startangle_270_360 < cornerangle_bottomright)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_270_360 + angleAxis.Offset, cornerangle_bottomright + angleAxis.Offset);
+                    if (cornerangle_bottomright < endangle_270_360)
+                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomright + angleAxis.Offset, endangle_270_360 + angleAxis.Offset);
+                }
+            }
+
+            if (pass == 1)
+            {
+                foreach (double tickValue in textticks)
+                {
+                    this.RenderTickText(axis, tickValue, angleAxis);
+                }
+            }
+        }
+
+        private void ExtendTickList(ref List<double> ticks, double maximum)
+        {
+            double tickdelta = ticks[ticks.Count - 1] - ticks[ticks.Count - 2];
+            while (ticks.Last() < maximum)
+            {
+                ticks.Add(ticks.Last() + tickdelta);
+            }
+            ticks.Remove(ticks.Last());
+        }
+
+        /// <summary>
+        /// Returns the angle (in radian) of the axis line in screen coordinate
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="angleAxis">The angle axis.</param>
+        /// <returns>The angle (in radians).</returns>
+        private static double GetActualAngle(Axis axis, Axis angleAxis)
+        {
+            var a = axis.Transform(0, angleAxis.Angle, angleAxis);
+            var b = axis.Transform(1, angleAxis.Angle, angleAxis);
+            return Math.Atan2(b.y - a.y, b.x - a.x);
+        }
+
+        /// <summary>
+        /// Choose the most appropriate alignment for tick text
+        /// </summary>
+        /// <param name="actualAngle">The actual angle.</param>
+        /// <param name="ha">The horizontal alignment.</param>
+        /// <param name="va">The vertical alignment.</param>
+        private static void GetTickTextAligment(double actualAngle, out HorizontalAlignment ha, out VerticalAlignment va)
+        {
+            //top
+            if (actualAngle > 3 * Math.PI / 4 || actualAngle < -3 * Math.PI / 4)
+            {
+                ha = HorizontalAlignment.Center;
+                va = VerticalAlignment.Top;
+            }
+            //right
+            else if (actualAngle < -Math.PI / 4)
+            {
+                ha = HorizontalAlignment.Right;
+                va = VerticalAlignment.Middle;
+            }
+            //left
+            else if (actualAngle > Math.PI / 4)
+            {
+                ha = HorizontalAlignment.Left;
+                va = VerticalAlignment.Middle;
+            }
+            //bottom
+            else
+            {
+                ha = HorizontalAlignment.Center;
+                va = VerticalAlignment.Bottom;
+            }
+        }
+
+        /// <summary>
+        /// Renders a tick by drawing an lot of segments
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="angleAxis">The angle axis.</param>
+        /// <param name="x">The x-value.</param>
+        /// <param name="pen">The pen.</param>
+        private void RenderTickArc(Axis axis, AngleAxis angleAxis, double x, OxyPen pen, double startangle, double endangle)
+        {
+            if(startangle>endangle)
+            {
+
+            }
+            // caution: make sure angleAxis.UpdateActualMaxMin(); has been called
+
+            // number of segment to draw a full circle
+            // - decrease if you want get more speed
+            // - increase if you want more detail
+            // (making a public property of it would be a great idea)
+
+            // compute the actual number of segments
+            var segmentCount = (int)(MaxSegments * Math.Abs(endangle - startangle) / 360.0);
+            if (angleAxis.FractionUnit == Math.PI || angleAxis.ActualMaximum == 2 * Math.PI)
+            {
+                segmentCount = (int)(MaxSegments * Math.Abs(endangle - startangle) / (2 * Math.PI));
+                startangle *= rad;
+                endangle *= rad;
+            }
+
+            segmentCount = Math.Max(segmentCount, 2);
+            segmentCount = Math.Min(segmentCount, (int)MaxSegments);
+            var angleStep = Math.Abs(endangle - startangle) / (segmentCount - 1);
+
+            var points = new List<ScreenPoint>();
+
+            for (var i = 0; i < segmentCount; i++)
+            {
+                var angle = startangle + (i * angleStep);
+                ScreenPoint toadd = axis.Transform(x, angle, angleAxis);
+                points.Add(toadd);
+            }
+
+            this.RenderContext.DrawLine(points, pen.Color, pen.Thickness, pen.ActualDashArray);
+        }
+
+        /// <summary>
+        /// Renders major tick text
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="x">The x-value.</param>
+        /// <param name="angleAxis">The angle axis.</param>
+        private void RenderTickText(Axis axis, double x, Axis angleAxis)
+        {
+            var actualAngle = GetActualAngle(axis, angleAxis);
+            var dx = axis.AxisTickToLabelDistance * Math.Sin(actualAngle);
+            var dy = -axis.AxisTickToLabelDistance * Math.Cos(actualAngle);
+
+            HorizontalAlignment ha;
+            VerticalAlignment va;
+            GetTickTextAligment(actualAngle, out ha, out va);
+
+            var pt = axis.Transform(x, angleAxis.Angle, angleAxis);
+            pt = new ScreenPoint(pt.X + dx, pt.Y + dy);
+
+            //check if point is outside the plot area
+
+            string text = axis.FormatValue(x);
+            this.RenderContext.DrawMathText(
+                pt,
+                text,
+                axis.ActualTextColor,
+                axis.ActualFont,
+                axis.ActualFontSize,
+                axis.ActualFontWeight,
+                axis.Angle,
+                ha,
+                va);
+        }
+    }
+}


### PR DESCRIPTION
This new style for polar plots is connected to issue #1056 and uses specific renderers and axis. Two examples derived from former polar plot examples were added in degrees and radians.
So far, just moving the plot center is enabled by right mouse button, but zooming in is still causing some unwanted effects. I hope this is useful and I'm looking forward on feedback.