### PR TITLE
SVG dominant-baseline Vertical Alignment Workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - RectangleSeries (#1060)
 - InvalidNumberColor on Wpf.LinearColorAxis (#1087)
 - ContinuousHistogramSeries (#1145)
+- Multiline text support for PortableDocumentFont (#1146)
+- Workaround for text vertical alignment in SVG Export to accomodate viewers which don't support dominant-baseline (#459, #1198)
 
 ### Changed
 - Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)

--- a/Source/OxyPlot/Pdf/PortableDocumentFont.cs
+++ b/Source/OxyPlot/Pdf/PortableDocumentFont.cs
@@ -9,6 +9,8 @@
 
 namespace OxyPlot
 {
+    using System.Text.RegularExpressions;
+
     /// <summary>
     /// Represents a font that can be used in a <see cref="PortableDocument" />.
     /// </summary>
@@ -102,21 +104,35 @@ namespace OxyPlot
         /// <param name="height">The height of the text.</param>
         public void Measure(string text, double fontSize, out double width, out double height)
         {
-            int w = 0;
+            int wmax = 0;
 
-            for (int i = 0; i < text.Length; i++)
+            var lines = Regex.Split(text, "\r\n");
+
+            int lineCount = lines.Length;
+
+            foreach (string line in lines)
             {
-                var c = text[i];
-                if (c >= this.FirstChar + this.Widths.Length)
+                int w = 0;
+
+                for (int i = 0; i < line.Length; i++)
                 {
-                    continue;
+                    var c = line[i];
+                    if (c >= this.FirstChar + this.Widths.Length)
+                    {
+                        continue;
+                    }
+
+                    w += this.Widths[c - this.FirstChar];
                 }
 
-                w += this.Widths[text[i] - this.FirstChar];
+                if (w > wmax)
+                {
+                    wmax = w;
+                }
             }
 
-            width = w * fontSize / 1000;
-            height = (this.Ascent - this.Descent) * fontSize / 1000;
+            width = wmax * fontSize / 1000;
+            height = lineCount * (this.Ascent - this.Descent) * fontSize / 1000;
         }
     }
 }

--- a/Source/OxyPlot/Svg/SvgExporter.cs
+++ b/Source/OxyPlot/Svg/SvgExporter.cs
@@ -40,6 +40,11 @@ namespace OxyPlot
         /// Gets or sets a value indicating whether the xml headers should be included.
         /// </summary>
         public bool IsDocument { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether to use a workaround for vertical text alignment to support renderers with limited support for the dominate-baseline attribute.
+        /// </summary>
+        public bool UseVerticalTextAlignmentWorkaround { get; set; }
 
         /// <summary>
         /// Gets or sets the text measurer.
@@ -55,14 +60,15 @@ namespace OxyPlot
         /// <param name="height">The height (points).</param>
         /// <param name="isDocument">if set to <c>true</c>, the xml headers will be included (?xml and !DOCTYPE).</param>
         /// <param name="textMeasurer">The text measurer.</param>
-        public static void Export(IPlotModel model, Stream stream, double width, double height, bool isDocument, IRenderContext textMeasurer = null)
+        /// <param name="useVerticalTextAlignmentWorkaround">Whether to use the workaround for vertical text alignment</param>
+        public static void Export(IPlotModel model, Stream stream, double width, double height, bool isDocument, IRenderContext textMeasurer = null, bool useVerticalTextAlignmentWorkaround = false)
         {
             if (textMeasurer == null)
             {
                 textMeasurer = new PdfRenderContext(width, height, model.Background);
             }
 
-            using (var rc = new SvgRenderContext(stream, width, height, true, textMeasurer, model.Background))
+            using (var rc = new SvgRenderContext(stream, width, height, true, textMeasurer, model.Background, useVerticalTextAlignmentWorkaround))
             {
                 model.Update(true);
                 model.Render(rc, width, height);
@@ -80,12 +86,13 @@ namespace OxyPlot
         /// <param name="isDocument">if set to <c>true</c>, the xml headers will be included (?xml and !DOCTYPE).</param>
         /// <param name="textMeasurer">The text measurer.</param>
         /// <returns>The plot as an <c>SVG</c> string.</returns>
-        public static string ExportToString(IPlotModel model, double width, double height, bool isDocument, IRenderContext textMeasurer = null)
+        /// <param name="useVerticalTextAlignmentWorkaround">Whether to use the workaround for vertical text alignment</param>
+        public static string ExportToString(IPlotModel model, double width, double height, bool isDocument, IRenderContext textMeasurer = null, bool useVerticalTextAlignmentWorkaround = false)
         {
             string svg;
             using (var ms = new MemoryStream())
             {
-                Export(model, ms, width, height, isDocument, textMeasurer);
+                Export(model, ms, width, height, isDocument, textMeasurer, useVerticalTextAlignmentWorkaround);
                 ms.Flush();
                 ms.Position = 0;
                 var sr = new StreamReader(ms);
@@ -102,7 +109,7 @@ namespace OxyPlot
         /// <param name="stream">The target stream.</param>
         public void Export(IPlotModel model, Stream stream)
         {
-            Export(model, stream, this.Width, this.Height, this.IsDocument, this.TextMeasurer);
+            Export(model, stream, this.Width, this.Height, this.IsDocument, this.TextMeasurer, this.UseVerticalTextAlignmentWorkaround);
         }
 
         /// <summary>
@@ -112,7 +119,7 @@ namespace OxyPlot
         /// <returns>the SVG content as a string.</returns>
         public string ExportToString(IPlotModel model)
         {
-            return ExportToString(model, this.Width, this.Height, this.IsDocument, this.TextMeasurer);
+            return ExportToString(model, this.Width, this.Height, this.IsDocument, this.TextMeasurer, this.UseVerticalTextAlignmentWorkaround);
         }
     }
 }


### PR DESCRIPTION
Fixes #1146, #459 (#1198).

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Multi-line text support for `PortableDocumentFont`, the default text measurer for `SvgExporter` (#1146)
- A workaround (enabled by Boolean flag) for manual vertical text alignment in `SvgExporter`, to accommodate viewers which do not support the `dominant-baseline` attribute, such as Microsoft Internet Explorer & Edge (#549).

### Outstanding concerns

 - Though a workaround is never ideal, the age and steady reoccurrence of this issue as well as the fact that no good solution exists (that I am aware of) suggests to me that this might be an acceptable change. If not, perhaps an alternative method of exposing the functionality could be agreed.

 - The Boolean flag on the static method `OxyPlot.SvgExporter.Export` is a binary breaking chance, but without it using the workaround would require manually assembling a `SvgRenderContext` and `SvgExporter`, which may be perfectly acceptable given this is a workaround. Other such default parameters also constitute binary breaking changes; if the default parameter for `OxyPlot.SvgExporter.Export` is undesirable, then these too should surely go. I'd be in favour of removing these, but I'd appreciate feedback to this effect.

 - Example outputs can be found in #549

@oxyplot/admins
