### PR TITLE
Fix issue #1245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this project will be documented in this file.
 - ScatterSeries with DateTimeAxis/TimeSpanAxis (#1132)
 - Exporting TextAnnotation with TextColor having 255 alpha to SVG produces opaque text (#1160)
 - Chart is not updated when top and bottom are not visible (#1219)
+- Candle overlap each candle (#623)
+- CandleStick is overlapped when item.open == item.close in the CandleStickAndVolumeSeries (#1245)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -116,3 +116,4 @@ Xavier <Xavier@xavier-PC.lsi>
 zur003 <Eric.Zurcher@csiro.au>
 Markus Ebner
 Duncan Robertson <duncanjacobrobertson@gmail.com>
+LauXjpn <laucomm@gmail.com>

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
@@ -315,13 +315,22 @@ namespace OxyPlot.Series
 
                 // Body
                 var openLeft = open + new ScreenVector(-candlewidth * 0.5, 0);
-                var rect = new OxyRect(openLeft.X, min.Y, candlewidth, max.Y - min.Y);
-                rc.DrawClippedRectangleAsPolygon(
-                    clippingBar,
-                    rect,
-                    fillColor,
-                    lineColor,
-                    this.StrokeThickness);
+
+                if (max.Y - min.Y < 1.0)
+                {
+                    var leftPoint = new ScreenPoint(openLeft.X - this.StrokeThickness, min.Y);
+                    var rightPoint = new ScreenPoint(openLeft.X + this.StrokeThickness + candlewidth, min.Y);
+                    rc.DrawClippedLine(clippingBar, new[] { leftPoint, rightPoint }, leftPoint.DistanceToSquared(rightPoint), lineColor, this.StrokeThickness, null, LineJoin.Miter, true);
+
+                    leftPoint = new ScreenPoint(openLeft.X - this.StrokeThickness, max.Y);
+                    rightPoint = new ScreenPoint(openLeft.X + this.StrokeThickness + candlewidth, max.Y);
+                    rc.DrawClippedLine(clippingBar, new[] { leftPoint, rightPoint }, leftPoint.DistanceToSquared(rightPoint), lineColor, this.StrokeThickness, null, LineJoin.Miter, true);
+                }
+                else
+                {
+                    var rect = new OxyRect(openLeft.X, min.Y, candlewidth, max.Y - min.Y);
+                    rc.DrawClippedRectangleAsPolygon(clippingBar, rect, fillColor, lineColor, this.StrokeThickness);
+                }
 
                 // Volume Part
                 if (this.VolumeAxis == null || this.VolumeStyle == VolumeStyle.None)

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
@@ -159,8 +159,22 @@ namespace OxyPlot.Series
 
                 // Body
                 var openLeft = open + new ScreenVector(-candlewidth * 0.5, 0);
-                var rect = new OxyRect(openLeft.X, min.Y, candlewidth, max.Y - min.Y);
-                rc.DrawClippedRectangleAsPolygon(clippingRect, rect, fillColor, lineColor, this.StrokeThickness);
+
+                if (max.Y - min.Y < 1.0)
+                {
+                    var leftPoint = new ScreenPoint(openLeft.X - this.StrokeThickness, min.Y);
+                    var rightPoint = new ScreenPoint(openLeft.X + this.StrokeThickness + candlewidth, min.Y);
+                    rc.DrawClippedLine(clippingRect, new[] { leftPoint, rightPoint }, leftPoint.DistanceToSquared(rightPoint), lineColor, this.StrokeThickness, null, LineJoin.Miter, true);
+
+                    leftPoint = new ScreenPoint(openLeft.X - this.StrokeThickness, max.Y);
+                    rightPoint = new ScreenPoint(openLeft.X + this.StrokeThickness + candlewidth, max.Y);
+                    rc.DrawClippedLine(clippingRect, new[] { leftPoint, rightPoint }, leftPoint.DistanceToSquared(rightPoint), lineColor, this.StrokeThickness, null, LineJoin.Miter, true);
+                }
+                else
+                {
+                    var rect = new OxyRect(openLeft.X, min.Y, candlewidth, max.Y - min.Y);
+                    rc.DrawClippedRectangleAsPolygon(clippingRect, rect, fillColor, lineColor, this.StrokeThickness);
+                }
             }
         }
 


### PR DESCRIPTION
Workaround for rendering issue with doji candles (candles with bodies so small, they are just represented by a line). It seems that WPF falsely renders these rectangles with their left coordinates adjusted to the left by the rectangles width (which effectively draws a line double it's intended size). In these edge cases, let's just draw a line (or two) instead of a polygon.

This issue was addressed here:
[https://stackoverflow.com/questions/33130300/oxyplot-candle-overlap-each-candle](url)

It was also reported just a couple of hours ago as #1245.
It might also fix #623 (hard to tell, because the images of the issue are missing).

Before the fix:
![doji-before](https://user-images.githubusercontent.com/14178357/46899108-beb55480-ce8f-11e8-9ad2-93987112f58b.png)

After the fix:
![doji-after](https://user-images.githubusercontent.com/14178357/46899334-66338680-ce92-11e8-8ff5-dd03f2cb0258.png)

Just before i realized another issue was reported, i provided the solution for CandleStickSeries within pull request #1246 .
This current pull request contains both, the fix for CandleStickSeries and CandleStickAndVolumeSeries and the older pull request might be disregarded.

### Checklist

- [y] I have included examples or tests
- [y] I have updated the change log
- [y] I am listed in the CONTRIBUTORS file
- [y] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
