### PR TITLE
Change TrackerControl to reuse existing ContentControls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Place label below negative ColumnSeries (#1119)
 - Use PackageReference instead of packages.config
 - Migrated NUnit v2 to v3 and added test adapter
+- TrackerControl reuses existing ContentControl when a new hit tracker result uses the same template as the currently shown tracker (#1281)
 
 ### Deprecated
 - OxyPlot.WP8 package. Use OxyPlot.Windows instead (#996)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ csabar <rumancsabi@gmail.com>
 Curt Mullin <curt.mullin@gmail.com>
 Cyril Martin <cyril.martin.cm@gmail.com>
 Dan Aizenstros
+danpaul88 <danpaul88@users.noreply.github.com>
 darrelbrown
 David Laundav <davelaundav@gmail.com>
 David Wong <dvkwong0@gmail.com>

--- a/Source/OxyPlot.Wpf/PlotBase.cs
+++ b/Source/OxyPlot.Wpf/PlotBase.cs
@@ -52,6 +52,11 @@ namespace OxyPlot.Wpf
         private FrameworkElement currentTracker;
 
         /// <summary>
+        /// The current tracker template.
+        /// </summary>
+        private ControlTemplate currentTrackerTemplate;
+
+        /// <summary>
         /// The grid.
         /// </summary>
         private Grid grid;
@@ -181,6 +186,7 @@ namespace OxyPlot.Wpf
             {
                 this.overlays.Children.Remove(this.currentTracker);
                 this.currentTracker = null;
+                this.currentTrackerTemplate = null;
             }
         }
 
@@ -341,14 +347,15 @@ namespace OxyPlot.Wpf
                 return;
             }
 
-            var tracker = new ContentControl { Template = trackerTemplate };
-
             // ReSharper disable once RedundantNameQualifier
-            if (!object.ReferenceEquals(tracker, this.currentTracker))
+            if (!object.ReferenceEquals(trackerTemplate, this.currentTrackerTemplate))
             {
                 this.HideTracker();
+
+                var tracker = new ContentControl { Template = trackerTemplate };
                 this.overlays.Children.Add(tracker);
                 this.currentTracker = tracker;
+                this.currentTrackerTemplate = trackerTemplate;
             }
 
             if (this.currentTracker != null)


### PR DESCRIPTION
Fixes #1281 .

### Checklist

- [ ] I have included examples or tests (*see notes*)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

The tracker control has an additional private member variable to track the template which was assigned to the current content control. When `ShowTracker` is called whilst a tracker is currently active AND the template choice is the same as the currently active tracker (default or series specific) then it will simply update the data context of the existing content control rather than creating a new one.

I believe the changes are stylecop compliant but as I'm not a regular user of it I'm unsure if I'm using it correctly - please advise if any changes are required.

As this is an optimisation rather than a UI visible change, I'm not sure what to provide as an example?

@oxyplot/admins