### PR TITLE
Fix Catmull-Rom Splines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - FontSize, FontWeight and FontFamily on Wpf.TextAnnotation (#1023)
 - RectangleSeries (#1060)
 - InvalidNumberColor on Wpf.LinearColorAxis (#1087)
+- ContinuousHistogramSeries (#1145)
 
 ### Changed
 - Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - OverflowException when zoomed in on logarithmic axis (#1090)
 - ScatterSeries with DateTimeAxis/TimeSpanAxis (#1132)
 - Exporting TextAnnotation with TextColor having 255 alpha to SVG produces opaque text (#1160)
+- Out of memory exception and performance issue with Catmull-Rom Spline (#1237)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -100,6 +100,7 @@ Surfin Bird <illvdg13@gmail.com>
 Sven Dummis
 Taldoras <taldoras@googlemail.com>
 Tandy Carmichael <tcarmichael@frontier.com>
+Tasos Stamadianos <tasos.a.stam@gmail.com>
 Thorsten Claff <tclaff@gmail.com>
 thepretender
 tephyrnex

--- a/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
@@ -185,7 +185,7 @@ namespace ExampleLibrary
         /// </summary>
         protected override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxisOrDefault(this.XAxisKey, this.PlotModel.DefaultXAxis);
+            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
@@ -185,7 +185,9 @@ namespace ExampleLibrary
         /// </summary>
         protected override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
+            this.XAxis = this.XAxisKey != null ?
+                         this.PlotModel.GetAxis(this.XAxisKey) :
+                         this.PlotModel.DefaultXAxis;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
@@ -342,7 +342,7 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
@@ -342,7 +342,9 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -2280,7 +2280,7 @@ namespace ExampleLibrary
             protected override void EnsureAxes()
             {
                 base.EnsureAxes();
-                this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as LinearColorAxis;
+                this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as LinearColorAxis;
             }
 
             /// <summary>

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -2280,7 +2280,9 @@ namespace ExampleLibrary
             protected override void EnsureAxes()
             {
                 base.EnsureAxes();
-                this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as LinearColorAxis;
+                this.ColorAxis = this.ColorAxisKey != null ?
+                                 this.PlotModel.GetAxis(this.ColorAxisKey) as LinearColorAxis :
+                                 this.PlotModel.DefaultColorAxis as LinearColorAxis;
             }
 
             /// <summary>

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -1,0 +1,104 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HistogramSeriesExamples.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Creates example histograms
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ExampleLibrary
+{
+    using System;
+
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
+    using System.Collections.Generic;
+
+    [Examples("HistogramSeries"), Tags("Series")]
+    public class HistogramSeriesExamples
+    {
+        [Example("Exponential Distribution")]
+        public static PlotModel ExponentialDistribution()
+        {
+            return CreateExponentialDistribution();
+        }
+
+        [Example("Custom Bins")]
+        public static PlotModel CustomBins()
+        {
+            return CreateExponentialDistributionCustomBins();
+        }
+
+        [Example("Disconnected Bins")]
+        public static PlotModel DisconnectedBins()
+        {
+            return CreateDisconnectedBins();
+        }
+
+        public static PlotModel CreateExponentialDistribution(double mean = 1, int n = 10000)
+        {
+            var model = new PlotModel { Title = "Exponential Distribution", Subtitle = "Uniformly distributed bins (" + n + " samples)" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Frequency" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "x" });
+
+            Random rnd = new Random();
+
+            HistogramSeries chs = new HistogramSeries();
+            chs.Items.AddRange(HistogramHelpers.Collect(SampleExps(rnd, 1.0, n), 0, 5, 15, true));
+            chs.StrokeThickness = 1;
+            model.Series.Add(chs);
+
+            return model;
+        }
+
+        public static PlotModel CreateExponentialDistributionCustomBins(double mean = 1, int n = 50000)
+        {
+            var model = new PlotModel { Title = "Exponential Distribution", Subtitle = "Custom bins (" + n + " samples)" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Frequency" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "x" });
+
+            Random rnd = new Random();
+
+            HistogramSeries chs = new HistogramSeries();
+
+            chs.Items.AddRange(HistogramHelpers.Collect(SampleExps(rnd, 1.0, n), new double[] { 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0 }, true));
+            chs.StrokeThickness = 1;
+            chs.FillColor = OxyColors.Purple;
+            model.Series.Add(chs);
+
+            return model;
+        }
+
+        public static PlotModel CreateDisconnectedBins()
+        {
+            var model = new PlotModel { Title = "Disconnected Bins" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Representation" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "x" });
+
+            Random rnd = new Random();
+
+            HistogramSeries chs = new HistogramSeries();
+            chs.Items.AddRange(new[] { new HistogramItem(0, 0.5, 10), new HistogramItem(0.75, 1.0, 10) });
+            chs.LabelFormatString = "{0:0.00}";
+            chs.LabelPlacement = LabelPlacement.Middle;
+            model.Series.Add(chs);
+
+            return model;
+        }
+        
+        private static IEnumerable<double> SampleExps(Random rnd, double mean, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return SampleExp(rnd, mean);
+            }
+        }
+
+        private static double SampleExp(Random rnd, double mean)
+        {
+            return Math.Log(1.0 - rnd.NextDouble()) / -mean;
+        }
+    }
+}

--- a/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
+++ b/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
@@ -177,5 +177,24 @@ namespace OxyPlot.Tests
             Assert.That(plot.ActualPlotMargins.Right, Is.EqualTo(plot.PlotMargins.Right), "right");
             Assert.That(plot.ActualPlotMargins.Bottom, Is.EqualTo(plot.PlotMargins.Bottom), "bottom");
         }
+
+        /// <summary>
+        /// When GetAxisOrDefault is called with an unknown key, the provided default value should
+        /// be returned.
+        /// </summary>
+        [Test]
+        public void GetAxisOrDefault()
+        {
+            var plot = new PlotModel { Title = "Get Axis Or Default" };
+            var verticalAxis = new LinearAxis { Key = "YAxis", Position = AxisPosition.Left };
+            var horizontalAxis = new LinearAxis { Key = "XAxis", Position = AxisPosition.Bottom };
+
+            plot.Axes.Add(verticalAxis);
+            plot.Axes.Add(horizontalAxis);
+
+            var defaultValue = new LinearAxis { Key = "DefaultAxis" };
+
+            Assert.That(plot.GetAxisOrDefault("ThisIsAnInvalidKey", defaultValue), Is.EqualTo(defaultValue));
+        }
     }
 }

--- a/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
+++ b/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
@@ -179,6 +179,22 @@ namespace OxyPlot.Tests
         }
 
         /// <summary>
+        /// When GetAxis is called with an unknown key, an InvalidOperationException should be thrown.
+        /// </summary>
+        [Test]
+        public void GetAxis()
+        {
+            var plot = new PlotModel { Title = "Get Axis Or Default" };
+            var verticalAxis = new LinearAxis { Key = "YAxis", Position = AxisPosition.Left };
+            var horizontalAxis = new LinearAxis { Key = "XAxis", Position = AxisPosition.Bottom };
+
+            plot.Axes.Add(verticalAxis);
+            plot.Axes.Add(horizontalAxis);
+
+            Assert.That(() => plot.GetAxis("ThisIsAnInvalidKey"), Throws.InvalidOperationException);
+        }
+
+        /// <summary>
         /// When GetAxisOrDefault is called with an unknown key, the provided default value should
         /// be returned.
         /// </summary>

--- a/Source/OxyPlot/Annotations/Annotation.cs
+++ b/Source/OxyPlot/Annotations/Annotation.cs
@@ -60,8 +60,13 @@ namespace OxyPlot.Annotations
         /// </summary>
         public void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
-            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
+            this.XAxis = this.XAxisKey != null ?
+                         this.PlotModel.GetAxis(this.XAxisKey) :
+                         this.PlotModel.DefaultXAxis;
+
+            this.YAxis = this.YAxisKey != null ?
+                         this.PlotModel.GetAxis(this.YAxisKey) :
+                         this.PlotModel.DefaultYAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Annotations/Annotation.cs
+++ b/Source/OxyPlot/Annotations/Annotation.cs
@@ -60,8 +60,8 @@ namespace OxyPlot.Annotations
         /// </summary>
         public void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxisOrDefault(this.XAxisKey, this.PlotModel.DefaultXAxis);
-            this.YAxis = this.PlotModel.GetAxisOrDefault(this.YAxisKey, this.PlotModel.DefaultYAxis);
+            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
+            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
         }
 
         /// <summary>

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -1093,8 +1093,7 @@ namespace OxyPlot
         /// Gets the axis for the specified key.
         /// </summary>
         /// <param name="key">The axis key.</param>
-        /// <param name="defaultAxis">The default axis.</param>
-        /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
+        /// <returns>The axis that corresponds with the key.</returns>
         /// <exception cref="System.InvalidOperationException">Cannot find axis with the specified key.</exception>
         public Axis GetAxis(string key)
         {
@@ -1106,7 +1105,7 @@ namespace OxyPlot
             var axis = this.Axes.FirstOrDefault(a => a.Key == key);
             if (axis == null)
             {
-                throw new InvalidOperationException(string.Format("Cannot find axis with Key = \"{0}\"", key));
+                throw new InvalidOperationException($"Cannot find axis with Key = \"{key}\"");
             }
             return axis;
         }

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -1117,8 +1117,8 @@ namespace OxyPlot
         /// <param name="key">The axis key.</param>
         /// <param name="defaultAxis">The default axis.</param>
         /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
-         public Axis GetAxisOrDefault(string key, Axis defaultAxis)
-         {
+        public Axis GetAxisOrDefault(string key, Axis defaultAxis)
+        {
             if (key != null)
             {
                 var axis = this.Axes.FirstOrDefault(a => a.Key == key);                

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -1094,19 +1094,35 @@ namespace OxyPlot
         /// </summary>
         /// <param name="key">The axis key.</param>
         /// <param name="defaultAxis">The default axis.</param>
-        /// <returns>The axis, or the defaultAxis if the key is not specified.</returns>
+        /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
         /// <exception cref="System.InvalidOperationException">Cannot find axis with the specified key.</exception>
-        public Axis GetAxisOrDefault(string key, Axis defaultAxis)
+        public Axis GetAxis(string key)
         {
+            if (key == null)
+            {
+                throw new ArgumentException("Axis key cannot be null.");
+            }
+
+            var axis = this.Axes.FirstOrDefault(a => a.Key == key);
+            if (axis == null)
+            {
+                throw new InvalidOperationException(string.Format("Cannot find axis with Key = \"{0}\"", key));
+            }
+            return axis;
+        }
+
+        /// <summary>
+        /// Gets the axis for the specified key, or returns a default value.
+        /// </summary>
+        /// <param name="key">The axis key.</param>
+        /// <param name="defaultAxis">The default axis.</param>
+        /// <returns>defaultAxis if key is empty or does not exist; otherwise, the axis that corresponds with the key.</returns>
+         public Axis GetAxisOrDefault(string key, Axis defaultAxis)
+         {
             if (key != null)
             {
-                var axis = this.Axes.FirstOrDefault(a => a.Key == key);
-                if (axis == null)
-                {
-                    throw new InvalidOperationException(string.Format("Cannot find axis with Key = \"{0}\"", key));
-                }
-
-                return axis;
+                var axis = this.Axes.FirstOrDefault(a => a.Key == key);                
+                return axis != null ? axis : defaultAxis;
             }
 
             return defaultAxis;

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -447,8 +447,9 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis =
-                this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -448,7 +448,7 @@ namespace OxyPlot.Series
             base.EnsureAxes();
 
             this.ColorAxis =
-                this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+                this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/HistogramHelpers.cs
+++ b/Source/OxyPlot/Series/HistogramHelpers.cs
@@ -1,0 +1,117 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HistogramHelpers.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides methods to collect data samples into bins for use with a <see cref="HistogramSeries" />.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Series
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    
+    /// <summary>
+    /// Provides methods to collect data samples into bins for use with a <see cref="HistogramSeries" />.
+    /// </summary>
+    public static class HistogramHelpers
+    {
+        /// <summary>
+        /// Collects samples into <paramref name="binCount"/> bins (<see cref="HistogramItem" />), uniformly distributed between <paramref name="start"/> and <paramref name="end"/>.
+        /// </summary>
+        /// <param name="samples">The samples to collect into bins.</param>
+        /// <param name="start">The inclusive lower-bound of the first bin.</param>
+        /// <param name="end">The exclusive upper-bound of the last bin.</param>
+        /// <param name="binCount">The number of bins to create.</param>
+        /// <param name="countUnplaced">A value indicating whether items not placed in bins should be considered when computing frequencies.</param>
+        /// <returns>An enumeration of <see cref="HistogramItem" /> corresponding to uniformly generated bins with heights computed from the proportion of samples placed within.</returns>
+        public static IEnumerable<HistogramItem> Collect(IEnumerable<double> samples, double start, double end, int binCount, bool countUnplaced)
+        {
+            if (binCount < 1)
+            {
+                throw new ArgumentException("Bin Count cannot be less than one.", nameof(binCount));
+            }
+
+            if (end <= start)
+            {
+                throw new ArgumentException("End cannot be less than or equal to Start.", nameof(end));
+            }
+            
+            List<double> binBreaks = new List<double>(binCount);
+
+            for (int i = 0; i <= binCount; i++)
+            {
+                binBreaks.Add(start + (((end - start) / binCount) * i));
+            }
+
+            return Collect(samples, binBreaks, countUnplaced);
+        }
+
+        /// <summary>
+        /// Collects samples into tightly packed bins (<see cref="HistogramItem" />) defined by <paramref name="binBreaks"/>.
+        /// </summary>
+        /// <param name="samples">The samples to collect into bins.</param>
+        /// <param name="binBreaks">The start and end values for the bins.</param>
+        /// <param name="countUnplaced">A value indicating whether items not placed in bins should be considered when computing frequencies.</param>
+        /// <returns>An enumerations of <see cref="HistogramItem" /> corresponding to the generated bins with heights computed from the proportion of samples placed within.</returns>
+        public static IEnumerable<HistogramItem> Collect(IEnumerable<double> samples, IReadOnlyList<double> binBreaks, bool countUnplaced)
+        {
+            // determin ranges
+            double[] orderedBreaks = binBreaks.Distinct().OrderBy(b => b).ToArray();
+
+            // count samples
+            List<int> counts = new List<int>();
+            long total = 0;
+            
+            for (int i = 0; i < binBreaks.Count - 1; i++)
+            {
+                counts.Add(0);
+            }
+
+            foreach (double sample in samples)
+            {
+                int idx = System.Array.BinarySearch(orderedBreaks, sample);
+
+                bool placed = false;
+                
+                if (idx >= 0)
+                {
+                    // exact match, place in the corresponding bin (exclude last bin)
+                    if (idx < counts.Count)
+                    {
+                        counts[idx] += 1;
+                        placed = true;
+                    }
+                }
+                else
+                {
+                    // inexact match, place in lower bin
+                    idx = ~idx - 1;
+                    
+                    if (idx >= 0 && idx < counts.Count)
+                    {
+                        counts[idx] += 1;
+                        placed = true;
+                    }
+                }
+
+                if (placed || countUnplaced)
+                {
+                    total++;
+                }
+            }
+
+            // create items
+            List<HistogramItem> items = new List<HistogramItem>(counts.Count);
+            
+            for (int i = 0; i < binBreaks.Count - 1; i++)
+            {
+                items.Add(new HistogramItem(binBreaks[i], binBreaks[i + 1], (double)counts[i] / total));
+            }
+
+            return items;
+        }
+    }
+}

--- a/Source/OxyPlot/Series/HistogramItem.cs
+++ b/Source/OxyPlot/Series/HistogramItem.cs
@@ -1,0 +1,107 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HistogramItem.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Represents an item in a HistogramSeries.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Series
+{
+    /// <summary>
+    /// Represents an item in a <see cref="HistogramSeries" />, a bin (range) and its area.
+    /// </summary>
+    public class HistogramItem : ICodeGenerating
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HistogramItem" /> class.
+        /// </summary>
+        /// <param name="rangeStart">The range start.</param>
+        /// <param name="rangeEnd">The range end.</param>
+        /// <param name="area">The area.</param>
+        public HistogramItem(double rangeStart, double rangeEnd, double area)
+        {
+            this.RangeStart = rangeStart;
+            this.RangeEnd = rangeEnd;
+            this.Area = area;
+        }
+
+        /// <summary>
+        /// Gets or sets the range start.
+        /// </summary>
+        /// <value>The range start.</value>
+        public double RangeStart { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the range end.
+        /// </summary>
+        /// <value>The range end.</value>
+        public double RangeEnd { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the area.
+        /// </summary>
+        /// <value>The area.</value>
+        public double Area { get; set; }
+
+        /// <summary>
+        /// Gets the computed width of the item.
+        /// </summary>
+        public double Width => this.RangeEnd - this.RangeStart;
+        
+        /// <summary>
+        /// Gets the computed height of the item.
+        /// </summary>
+        /// <value>The computed height of the item</value>
+        public double Height => this.Area / this.Width;
+        
+        /// <summary>
+        /// Gets the value of the item. Equivalent to the Height;
+        /// </summary>
+        /// <value>The value of the item.</value>
+        public double Value => this.Height;
+
+        /// <summary>
+        /// Determines whether the specified point lies within the boundary of the <see cref="HistogramItem" />.
+        /// </summary>
+        /// <param name="p">The DataPoint to determine whether or not lies within the boundary of the <see cref="HistogramItem" />.</param>
+        /// <returns><c>true</c> if the value of the <param name="p"/> parameter is inside the bounds of this instance.</returns>
+        public bool Contains(DataPoint p)
+        {
+            // height is taken as one Y value, the other is 0
+            if (this.Height < 0)
+            {
+                return (p.X <= this.RangeEnd && p.X >= this.RangeStart && p.Y >= this.Height && p.Y <= 0) ||
+                       (p.X <= this.RangeStart && p.X >= this.RangeEnd && p.Y >= this.Height && p.Y <= 0);
+            }
+            else
+            {
+                return (p.X <= this.RangeEnd && p.X >= this.RangeStart && p.Y <= this.Height && p.Y >= 0) ||
+                       (p.X <= this.RangeStart && p.X >= this.RangeEnd && p.Y <= this.Height && p.Y >= 0);
+            }
+        }
+        
+        /// <summary>
+        /// Returns C# code that generates this instance.
+        /// </summary>
+        /// <returns>The to code.</returns>
+        public string ToCode()
+        {
+            return CodeGenerator.FormatConstructor(this.GetType(), "{0},{1},{2}", this.RangeStart, this.RangeEnd, this.Area);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        public override string ToString()
+        {
+            return string.Format(
+                "{0} {1} {2}",
+                this.RangeStart,
+                this.RangeEnd,
+                this.Area);
+        }
+    }
+}

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -1,0 +1,556 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HistogramSeries.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Represents a series that can be bound to a collection of HistogramItems representing bins from a Histogram.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Series
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Axes;
+
+    /// <summary>
+    /// Represents a series that can be bound to a collection of <see cref="HistogramItem"/>.
+    /// </summary>
+    public class HistogramSeries : XYAxisSeries
+    {
+        /// <summary>
+        /// The default tracker format string
+        /// </summary>
+        public new const string DefaultTrackerFormatString = "Start: {5}\nEnd: {6}\nValue: {7}\nArea: {8}";
+        
+        /// <summary>
+        /// The default fill color.
+        /// </summary>
+        private OxyColor defaultFillColor;
+
+        /// <summary>
+        /// The items originating from the items source.
+        /// </summary>
+        private List<HistogramItem> actualItems;
+
+        /// <summary>
+        /// Specifies if the <see cref="actualItems" /> list can be modified.
+        /// </summary>
+        private bool ownsActualItems;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HistogramSeries" /> class.
+        /// </summary>
+        public HistogramSeries()
+        {
+            this.FillColor = OxyColors.Automatic;
+            this.NegativeFillColor = OxyColors.Undefined;
+            this.StrokeColor = OxyColors.Black;
+            this.StrokeThickness = 0;
+            this.TrackerFormatString = DefaultTrackerFormatString;
+            this.LabelFormatString = null;
+            this.LabelFontSize = 0;
+            this.LabelPlacement = LabelPlacement.Outside;
+        }
+        
+        /// <summary>
+        /// Gets or sets the color of the interior of the bars.
+        /// </summary>
+        /// <value>The color.</value>
+        public OxyColor FillColor { get; set; }
+
+        /// <summary>
+        /// Gets the actual fill color.
+        /// </summary>
+        /// <value>The actual color.</value>
+        public OxyColor ActualFillColor
+        {
+            get { return this.FillColor.GetActualColor(this.defaultFillColor); }
+        }
+        
+        /// <summary>
+        /// Gets or sets the color of the interior of the bars when the value is negative.
+        /// </summary>
+        /// <value>The color.</value>
+        public OxyColor NegativeFillColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the border around the bars.
+        /// </summary>
+        /// <value>The color of the stroke.</value>
+        public OxyColor StrokeColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the thickness of the bar border strokes.
+        /// </summary>
+        /// <value>The stroke thickness.</value>
+        public double StrokeThickness { get; set; }
+
+        /// <summary>
+        /// Gets the minimum value of the dataset.
+        /// </summary>
+        public double MinValue { get; private set; }
+
+        /// <summary>
+        /// Gets the maximum value of the dataset.
+        /// </summary>
+        public double MaxValue { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the format string for the cell labels. The default value is <c>0.00</c>.
+        /// </summary>
+        /// <value>The format string.</value>
+        /// <remarks>The label format string is only used when <see cref="LabelFontSize" /> is greater than 0.</remarks>
+        public string LabelFormatString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the font size of the labels. The default value is <c>0</c> (labels not visible).
+        /// </summary>
+        /// <value>The font size relative to the cell height.</value>
+        public double LabelFontSize { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the label margins.
+        /// </summary>
+        public double LabelMargin { get; set; }
+
+        /// <summary>
+        /// Gets or sets label placements.
+        /// </summary>
+        public LabelPlacement LabelPlacement { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the tracker can interpolate points.
+        /// </summary>
+        public bool CanTrackerInterpolatePoints { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the delegate used to map from <see cref="ItemsSeries.ItemsSource" /> to <see cref="HistogramSeries" />. The default is <c>null</c>.
+        /// </summary>
+        /// <value>The mapping.</value>
+        /// <remarks>Example: series1.Mapping = item => new HistogramItem((double)item.BinStart, (double)item.BinStart + item.BinWidth, (double)item.Count);</remarks>
+        public Func<object, HistogramItem> Mapping { get; set; }
+
+        /// <summary>
+        /// Gets the list of <see cref="HistogramItem" />.
+        /// </summary>
+        /// <value>A list of <see cref="HistogramItem" />. This list is used if <see cref="ItemsSeries.ItemsSource" /> is not set.</value>
+        public List<HistogramItem> Items { get; } = new List<HistogramItem>();
+
+        /// <summary>
+        /// Gets the list of <see cref="HistogramItem" /> that should be rendered.
+        /// </summary>
+        /// <value>A list of <see cref="RectangleItem" />.</value>
+        protected List<HistogramItem> ActualItems => this.ItemsSource != null ? this.actualItems : this.Items;
+        
+        /// <summary>
+        /// Transforms data space coordinates to orientated screen space coordinates.
+        /// </summary>
+        /// <param name="x">The x coordinate.</param>
+        /// <param name="y">The y coordinate.</param>
+        /// <returns>The transformed point.</returns>
+        public new ScreenPoint Transform(double x, double y)
+        {
+            return this.Orientate(base.Transform(x, y));
+        }
+
+        /// <summary>
+        /// Transforms data space coordinates to orientated screen space coordinates.
+        /// </summary>
+        /// <param name="point">The point to transform.</param>
+        /// <returns>The transformed point.</returns>
+        public new ScreenPoint Transform(DataPoint point)
+        {
+            return this.Orientate(base.Transform(point));
+        }
+
+        /// <summary>
+        /// Transforms orientated screen space coordinates to data space coordinates.
+        /// </summary>
+        /// <param name="point">The point to inverse transform.</param>
+        /// <returns>The inverse transformed point.</returns>
+        public new DataPoint InverseTransform(ScreenPoint point)
+        {
+            return base.InverseTransform(this.Orientate(point));
+        }
+
+        /// <summary>
+        /// Renders the series on the specified rendering context.
+        /// </summary>
+        /// <param name="rc">The rendering context.</param>
+        public override void Render(IRenderContext rc)
+        {
+            var actualBins = this.ActualItems;
+
+            this.VerifyAxes();
+
+            var clippingRect = this.GetClippingRect();
+            rc.SetClip(clippingRect);
+
+            this.RenderBins(rc, clippingRect, actualBins);
+
+            rc.ResetClip();
+        }
+
+        /// <summary>
+        /// Gets the point on the series that is nearest the specified point.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="interpolate">Interpolate the series if this flag is set to <c>true</c>.</param>
+        /// <returns>A TrackerHitResult for the current hit.</returns>
+        public override TrackerHitResult GetNearestPoint(ScreenPoint point, bool interpolate)
+        {
+            var p = this.InverseTransform(point);
+
+            if (!this.IsPointInRange(p))
+            {
+                return null;
+            }
+            
+            if (this.ActualItems != null)
+            {
+                // iterate through the DataRects and return the first one that contains the point
+                foreach (var item in this.ActualItems)
+                {
+                    if (item.Contains(p))
+                    {
+                        return new TrackerHitResult
+                        {
+                            Series = this,
+                            DataPoint = p,
+                            Position = point,
+                            Item = null,
+                            Index = -1,
+                            Text = StringHelper.Format(
+                            this.ActualCulture,
+                            this.TrackerFormatString,
+                            null,
+                            this.Title,
+                            this.XAxis.Title ?? DefaultXAxisTitle,
+                            this.XAxis.GetValue(p.X),
+                            this.YAxis.Title ?? DefaultYAxisTitle,
+                            this.YAxis.GetValue(p.Y),
+                            item.RangeStart,
+                            item.RangeEnd,
+                            item.Value,
+                            item.Area)
+                        };
+                    }
+                }
+            }
+
+            // if no HistogramItems contain the point, return null
+            return null;
+        }
+        
+        /// <summary>
+        /// Renders the legend symbol on the specified rendering context.
+        /// </summary>
+        /// <param name="rc">The rendering context.</param>
+        /// <param name="legendBox">The legend rectangle.</param>
+        public override void RenderLegend(IRenderContext rc, OxyRect legendBox)
+        {
+            var xmid = (legendBox.Left + legendBox.Right) / 2;
+            var ymid = (legendBox.Top + legendBox.Bottom) / 2;
+            var height = (legendBox.Bottom - legendBox.Top) * 0.8;
+            var width = height;
+            rc.DrawRectangleAsPolygon(
+                new OxyRect(xmid - (0.5 * width), ymid - (0.5 * height), width, height),
+                this.GetSelectableColor(this.ActualFillColor),
+                this.StrokeColor,
+                this.StrokeThickness);
+        }
+
+        /// <summary>
+        /// Updates the data.
+        /// </summary>
+        protected internal override void UpdateData()
+        {
+            if (this.ItemsSource == null)
+            {
+                return;
+            }
+
+            this.UpdateActualItems();
+        }
+
+        /// <summary>
+        /// Sets the default values.
+        /// </summary>
+        protected internal override void SetDefaultValues()
+        {
+            if (this.FillColor.IsAutomatic())
+            {
+                this.defaultFillColor = this.PlotModel.GetDefaultColor();
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the axes of the series is defined.
+        /// </summary>
+        protected internal override void EnsureAxes()
+        {
+            base.EnsureAxes();
+        }
+
+        /// <summary>
+        /// Updates the maximum and minimum values of the series for the x and y dimensions only.
+        /// </summary>
+        protected internal void UpdateMaxMinXY()
+        {
+            if (this.ActualItems != null && this.ActualItems.Count > 0)
+            {
+                this.MinX = Math.Min(this.ActualItems.Min(r => r.RangeStart), this.ActualItems.Min(r => r.RangeEnd));
+                this.MaxX = Math.Max(this.ActualItems.Max(r => r.RangeStart), this.ActualItems.Max(r => r.RangeEnd));
+                this.MinY = Math.Min(this.ActualItems.Min(r => 0), this.ActualItems.Min(r => r.Height));
+                this.MaxY = Math.Max(this.ActualItems.Max(r => 0), this.ActualItems.Max(r => r.Height));
+            }
+        }
+
+        /// <summary>
+        /// Updates the maximum and minimum values of the series.
+        /// </summary>
+        protected internal override void UpdateMaxMin()
+        {
+            base.UpdateMaxMin();
+
+            var allDataPoints = new List<DataPoint>();
+            allDataPoints.AddRange(this.ActualItems.Select(item => new DataPoint(item.RangeStart, 0.0)));
+            allDataPoints.AddRange(this.ActualItems.Select(item => new DataPoint(item.RangeEnd, item.Height)));
+            this.InternalUpdateMaxMin(allDataPoints);
+
+            this.UpdateMaxMinXY();
+
+            if (this.ActualItems != null && this.ActualItems.Count > 0)
+            {
+                this.MinValue = this.ActualItems.Min(r => r.Value);
+                this.MaxValue = this.ActualItems.Max(r => r.Value);
+            }
+        }
+
+        /// <summary>
+        /// Updates the axes to include the max and min of this series.
+        /// </summary>
+        protected internal override void UpdateAxisMaxMin()
+        {
+            base.UpdateAxisMaxMin();
+        }
+
+        /// <summary>
+        /// Gets the label for the specified cell.
+        /// </summary>
+        /// <param name="v">The value of the cell.</param>
+        /// <param name="i">The first index.</param>
+        /// <param name="j">The second index.</param>
+        /// <returns>The label string.</returns>
+        protected virtual string GetLabel(double v, int i, int j)
+        {
+            return v.ToString(this.LabelFormatString, this.ActualCulture);
+        }
+        
+        /// <summary>
+        /// Gets the item at the specified index.
+        /// </summary>
+        /// <param name="i">The index of the item.</param>
+        /// <returns>The item of the index.</returns>
+        protected override object GetItem(int i)
+        {
+            var items = this.ActualItems;
+            if (this.ItemsSource == null && items != null && i < items.Count)
+            {
+                return items[i];
+            }
+
+            return base.GetItem(i);
+        }
+
+        /// <summary>
+        /// Renders the points as line, broken line and markers.
+        /// </summary>
+        /// <param name="rc">The rendering context.</param>
+        /// <param name="clippingRect">The clipping rectangle.</param>
+        /// <param name="items">The Items to render.</param>
+        protected void RenderBins(IRenderContext rc, OxyRect clippingRect, ICollection<HistogramItem> items)
+        {
+            foreach (var item in items)
+            {
+                // Get the color of the item
+                var actualFillColor = this.ActualFillColor;
+                if (item.Value < 0 && !this.NegativeFillColor.IsUndefined())
+                {
+                    actualFillColor = this.NegativeFillColor;
+                }
+
+                // transform the data points to screen points
+                var s00 = this.Transform(item.RangeStart, 0);
+                var s11 = this.Transform(item.RangeEnd, item.Height);
+
+                var pointa = new ScreenPoint(s00.X, s00.Y);
+                var pointb = new ScreenPoint(s11.X, s11.Y);
+                var rectrect = new OxyRect(pointa, pointb);
+
+                rc.DrawClippedRectangleAsPolygon(clippingRect, rectrect, actualFillColor, this.StrokeColor, this.StrokeThickness);
+                
+                if (this.LabelFormatString != null)
+                {
+                    this.RenderLabel(rc, clippingRect, rectrect, item.Value, item);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the clipping rectangle, transposed if the X axis is vertically orientated.
+        /// </summary>
+        /// <returns>The clipping rectangle.</returns>
+        protected new OxyRect GetClippingRect()
+        {
+            double minX = Math.Min(this.XAxis.ScreenMin.X, this.XAxis.ScreenMax.X);
+            double minY = Math.Min(this.YAxis.ScreenMin.Y, this.YAxis.ScreenMax.Y);
+            double maxX = Math.Max(this.XAxis.ScreenMin.X, this.XAxis.ScreenMax.X);
+            double maxY = Math.Max(this.YAxis.ScreenMin.Y, this.YAxis.ScreenMax.Y);
+
+            if (this.XAxis.IsVertical())
+            {
+                return new OxyRect(minY, minX, maxY - minY, maxX - minX);
+            }
+
+            return new OxyRect(minX, minY, maxX - minX, maxY - minY);
+        }
+        
+        /// <summary>
+        /// Draws the label.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="clippingRect">The clipping rectangle.</param>
+        /// <param name="rect">The column rectangle.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="item">The item.</param>
+        protected void RenderLabel(IRenderContext rc, OxyRect clippingRect, OxyRect rect, double value, object item)
+        {
+            var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, value);
+            ScreenPoint pt;
+            VerticalAlignment va;
+            switch (this.LabelPlacement)
+            {
+                case LabelPlacement.Inside:
+                    pt = new ScreenPoint((rect.Left + rect.Right) / 2, rect.Top + this.LabelMargin);
+                    va = VerticalAlignment.Top;
+                    break;
+                case LabelPlacement.Middle:
+                    pt = new ScreenPoint((rect.Left + rect.Right) / 2, (rect.Bottom + rect.Top) / 2);
+                    va = VerticalAlignment.Middle;
+                    break;
+                case LabelPlacement.Base:
+                    pt = new ScreenPoint((rect.Left + rect.Right) / 2, rect.Bottom - this.LabelMargin);
+                    va = VerticalAlignment.Bottom;
+                    break;
+                default: // outside
+                    // Puts label below for negative series, above for positive
+                    if (value < 0)
+                    {
+                        pt = new ScreenPoint((rect.Left + rect.Right) / 2, rect.Bottom + this.LabelMargin);
+                        va = VerticalAlignment.Top;
+                    }
+                    else
+                    {
+                        pt = new ScreenPoint((rect.Left + rect.Right) / 2, rect.Top - this.LabelMargin);
+                        va = VerticalAlignment.Bottom;
+                    }
+
+                    break;
+            }
+
+            rc.DrawClippedText(
+                clippingRect,
+                pt,
+                s,
+                this.ActualTextColor,
+                this.ActualFont,
+                this.ActualFontSize,
+                this.ActualFontWeight,
+                0,
+                HorizontalAlignment.Center,
+                va);
+        }
+
+        /// <summary>
+        /// Transposes the ScreenPoint if the X axis is vertically orientated
+        /// </summary>
+        /// <param name="point">The <see cref="ScreenPoint" /> to orientate.</param>
+        /// <returns>The oriented point.</returns>
+        private ScreenPoint Orientate(ScreenPoint point)
+        {
+            if (this.XAxis.IsVertical())
+            {
+                point = new ScreenPoint(point.Y, point.X);
+            }
+
+            return point;
+        }
+
+        /// <summary>
+        /// Tests if a <see cref="DataPoint" /> is inside the heat map
+        /// </summary>
+        /// <param name="p">The <see cref="DataPoint" /> to test.</param>
+        /// <returns><c>True</c> if the point is inside the heat map.</returns>
+        private bool IsPointInRange(DataPoint p)
+        {
+            this.UpdateMaxMinXY();
+
+            return p.X >= this.MinX && p.X <= this.MaxX && p.Y >= this.MinY && p.Y <= this.MaxY;
+        }
+        
+        /// <summary>
+        /// Clears or creates the <see cref="actualItems"/> list.
+        /// </summary>
+        private void ClearActualItems()
+        {
+            if (!this.ownsActualItems || this.actualItems == null)
+            {
+                this.actualItems = new List<HistogramItem>();
+            }
+            else
+            {
+                this.actualItems.Clear();
+            }
+
+            this.ownsActualItems = true;
+        }
+
+        /// <summary>
+        /// Updates the points from the <see cref="ItemsSeries.ItemsSource" />.
+        /// </summary>
+        private void UpdateActualItems()
+        {
+            // Use the Mapping property to generate the points
+            if (this.Mapping != null)
+            {
+                this.ClearActualItems();
+                foreach (var item in this.ItemsSource)
+                {
+                    this.actualItems.Add(this.Mapping(item));
+                }
+
+                return;
+            }
+
+            var sourceAsListOfDataRects = this.ItemsSource as List<HistogramItem>;
+            if (sourceAsListOfDataRects != null)
+            {
+                this.actualItems = sourceAsListOfDataRects;
+                this.ownsActualItems = false;
+                return;
+            }
+
+            this.ClearActualItems();
+
+            var sourceAsEnumerableDataRects = this.ItemsSource as IEnumerable<HistogramItem>;
+            if (sourceAsEnumerableDataRects != null)
+            {
+                this.actualItems.AddRange(sourceAsEnumerableDataRects);
+            }
+        }
+    }
+}

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -311,7 +311,7 @@
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -311,7 +311,9 @@
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -492,7 +492,9 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
+            this.ColorAxis = this.ColorAxisKey != null ?
+                             this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis :
+                             this.PlotModel.DefaultColorAxis as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -492,7 +492,7 @@ namespace OxyPlot.Series
         {
             base.EnsureAxes();
 
-            this.ColorAxis = this.PlotModel.GetAxisOrDefault(this.ColorAxisKey, (Axis)this.PlotModel.DefaultColorAxis) as IColorAxis;
+            this.ColorAxis = this.PlotModel.GetAxis(this.ColorAxisKey) as IColorAxis;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -164,8 +164,8 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxisOrDefault(this.XAxisKey, this.PlotModel.DefaultXAxis);
-            this.YAxis = this.PlotModel.GetAxisOrDefault(this.YAxisKey, this.PlotModel.DefaultYAxis);
+            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
+            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -164,8 +164,13 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal override void EnsureAxes()
         {
-            this.XAxis = this.PlotModel.GetAxis(this.XAxisKey);
-            this.YAxis = this.PlotModel.GetAxis(this.YAxisKey);
+            this.XAxis = this.XAxisKey != null ?
+                         this.PlotModel.GetAxis(this.XAxisKey) :
+                         this.PlotModel.DefaultXAxis;
+
+            this.YAxis = this.YAxisKey != null ?
+                         this.PlotModel.GetAxis(this.YAxisKey) :
+                         this.PlotModel.DefaultYAxis;
         }
 
         /// <summary>


### PR DESCRIPTION
Catmull-Rom splines: Changed default segments to 100 from 1000, made segment count settable by user. Fixed integer overflows causing infinite iterations.

Fixes #1237 
Should also fix #476 in all cases where this spline type is used

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
