### PR TITLE
Catmull-Rom splines fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 - Chart is not updated when top and bottom are not visible (#1219)
 - Candle overlap each candle (#623)
 - CandleStick is overlapped when item.open == item.close in the CandleStickAndVolumeSeries (#1245)
+- Out of memory exception and performance issue with Catmull-Rom Spline (#1237)
 
 ## [1.0.0] - 2016-09-11
 ### Added


### PR DESCRIPTION
Catmull-Rom splines: Changed default segments to 100 from 1000, made segment count settable by user. Fixed integer overflows causing infinite iterations.

Fixes #1237 
Should also fix #476 in all cases where this spline type is used

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
