### PR TITLE
Brushdisposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - Candle overlap each candle (#623)
 - CandleStick is overlapped when item.open == item.close in the CandleStickAndVolumeSeries (#1245)
 - Out of memory exception and performance issue with Catmull-Rom Spline (#1237)
+- Cache and Dispose Brush and Pen objects used by GraphicsRenderContext (#1230)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.WindowsForms/GraphicsPenDescription.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsPenDescription.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OxyPlot.WindowsForms
+{
+    /// <summary>
+    /// Describes a GDI+ Pen.
+    /// </summary>
+    public class GraphicsPenDescription
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphicsPenDescription" /> class.
+        /// </summary>
+        /// <param name="color">The color.</param>
+        /// <param name="thickness">The thickness.</param>
+        /// <param name="dashArray">The dash array.</param>
+        /// <param name="lineJoin">The line join.</param>
+        public GraphicsPenDescription(OxyColor color, double thickness, double[] dashArray = null, OxyPlot.LineJoin lineJoin = OxyPlot.LineJoin.Miter)
+        {
+            Color = color;
+            Thickness = thickness;
+            DashArray = dashArray;
+            LineJoin = lineJoin;
+
+            cachedHashCode = ComputeHashCode();
+        }
+        
+        /// <summary>
+        /// Gets the color of the pen.
+        /// </summary>
+        /// <value>The color.</value>
+        public OxyColor Color { get; }
+        
+        /// <summary>
+        /// Gets the line thickness.
+        /// </summary>
+        /// <value>The line thickness.</value>
+        public double Thickness { get; }
+        
+        /// <summary>
+        /// Gets the dash array.
+        /// </summary>
+        /// <value>The dash array.</value>
+        public double[] DashArray { get; }
+        
+        /// <summary>
+        /// Gets the line join type.
+        /// </summary>
+        /// <value>The line join type.</value>
+        public LineJoin LineJoin { get; }
+
+        /// <summary>
+        /// The HashCode of the <see cref="GraphicsPenDescription" /> instance, as computed in the constructor.
+        /// </summary>
+        private readonly int cachedHashCode;
+        
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c> .</returns>
+        public override bool Equals(object obj)
+        {
+            var description = obj as GraphicsPenDescription;
+
+            return description != null &&
+                   Color.Equals(description.Color) &&
+                   Thickness == description.Thickness &&
+                   DashArraysEquals(DashArray, description.DashArray) &&
+                   LineJoin == description.LineJoin;
+        }
+        
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        public override int GetHashCode()
+        {
+            return cachedHashCode;
+        }
+
+        /// <summary>
+        /// Computes the HashCode for the instance.
+        /// </summary>
+        /// <returns>The HashCode for the instance.</returns>
+        private int ComputeHashCode()
+        {
+            var hashCode = 754997215;
+            
+            unchecked
+            {
+                hashCode = hashCode * -1521134295 + Color.GetHashCode();
+                hashCode = hashCode * -1521134295 + Thickness.GetHashCode();
+                hashCode = hashCode * -1521134295 + ComputeDashArrayHashCode(DashArray);
+                hashCode = hashCode * -1521134295 + LineJoin.GetHashCode();
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a HashCode for the given array based on every element in the array.
+        /// </summary>
+        /// <param name="array">The array</param>
+        /// <returns>A HashCode</returns>
+        private static int ComputeDashArrayHashCode(double[] array)
+        {
+            if (array == null)
+            {
+                return -1;
+            }
+
+            int hashCode = array.Length;
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                unchecked
+                {
+                    hashCode = hashCode * 31 + array[i].GetHashCode();
+                }
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Determines whether two arrays are equivalent.
+        /// </summary>
+        /// <param name="l">The left array.</param>
+        /// <param name="r">The right array.</param>
+        /// <returns><c>true</c> if the arrays are the same array, are both null, or have the same elements; otherwise <c>false</c></returns>
+        private static bool DashArraysEquals(double[] l, double[] r)
+        {
+            if (l == r)
+            {
+                return true;
+            }
+
+            if (l == null || r == null)
+            {
+                return false;
+            }
+
+            if (l.Length != r.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < l.Length; i++)
+            {
+                if (l[i] != r[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -46,6 +46,11 @@ namespace OxyPlot.WindowsForms
         private readonly Dictionary<OxyColor, Brush> brushes = new Dictionary<OxyColor, Brush>();
 
         /// <summary>
+        /// The pen cache.
+        /// </summary>
+        private readonly Dictionary<GraphicsPenDescription, Pen> pens = new Dictionary<GraphicsPenDescription, Pen>();
+
+        /// <summary>
         /// The string format.
         /// </summary>
         private readonly StringFormat stringFormat;
@@ -105,12 +110,10 @@ namespace OxyPlot.WindowsForms
             {
                 return;
             }
-
-            using (var pen = this.CreatePen(stroke, thickness))
-            {
-                this.g.SmoothingMode = SmoothingMode.HighQuality;
-                this.g.DrawEllipse(pen, (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
-            }
+            
+            var pen = this.GetCachedPen(stroke, thickness);
+            this.g.SmoothingMode = SmoothingMode.HighQuality;
+            this.g.DrawEllipse(pen, (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
         }
 
         /// <summary>
@@ -136,10 +139,8 @@ namespace OxyPlot.WindowsForms
             }
 
             this.g.SmoothingMode = aliased ? SmoothingMode.None : SmoothingMode.HighQuality;
-            using (var pen = this.CreatePen(stroke, thickness, dashArray, lineJoin))
-            {
-                this.g.DrawLines(pen, this.ToPoints(points));
-            }
+            var pen = this.GetCachedPen(stroke, thickness, dashArray, lineJoin);
+            this.g.DrawLines(pen, this.ToPoints(points));
         }
 
         /// <summary>
@@ -179,27 +180,8 @@ namespace OxyPlot.WindowsForms
                 return;
             }
 
-            using (var pen = this.CreatePen(stroke, thickness))
-            {
-                if (dashArray != null)
-                {
-                    pen.DashPattern = this.ToFloatArray(dashArray);
-                }
-
-                switch (lineJoin)
-                {
-                    case OxyPlot.LineJoin.Round:
-                        pen.LineJoin = System.Drawing.Drawing2D.LineJoin.Round;
-                        break;
-                    case OxyPlot.LineJoin.Bevel:
-                        pen.LineJoin = System.Drawing.Drawing2D.LineJoin.Bevel;
-                        break;
-
-                    // The default LineJoin is Miter
-                }
-
-                this.g.DrawPolygon(pen, pts);
-            }
+            var pen = this.GetCachedPen(stroke, thickness, dashArray, lineJoin);
+            this.g.DrawPolygon(pen, pts);
         }
 
         /// <summary>
@@ -222,10 +204,8 @@ namespace OxyPlot.WindowsForms
                 return;
             }
 
-            using (var pen = this.CreatePen(stroke, thickness))
-            {
-                this.g.DrawRectangle(pen, (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
-            }
+            var pen = this.GetCachedPen(stroke, thickness);
+            this.g.DrawRectangle(pen, (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
         }
 
         /// <summary>
@@ -437,6 +417,7 @@ namespace OxyPlot.WindowsForms
             {
                 i.Value.Dispose();
             }
+            this.imageCache.Clear();
 
             // dispose pens, brushes etc.
             this.stringFormat.Dispose();
@@ -445,6 +426,13 @@ namespace OxyPlot.WindowsForms
             {
                 brush.Dispose();
             }
+            this.brushes.Clear();
+
+            foreach (var pen in this.pens.Values)
+            {
+                pen.Dispose();
+            }
+            this.pens.Clear();
         }
 
         /// <summary>
@@ -509,7 +497,28 @@ namespace OxyPlot.WindowsForms
         }
 
         /// <summary>
-        /// Gets a cached pen.
+        /// Gets the cached pen.
+        /// </summary>
+        /// <param name="stroke">The stroke color.</param>
+        /// <param name="thickness">The thickness.</param>
+        /// <param name="dashArray">The dash array.</param>
+        /// <param name="lineJoin">The line join.</param>
+        /// <returns>A <see cref="Pen" />.</returns>
+        private Pen GetCachedPen(OxyColor stroke, double thickness, double[] dashArray = null, OxyPlot.LineJoin lineJoin = OxyPlot.LineJoin.Miter)
+        {
+            GraphicsPenDescription description = new GraphicsPenDescription(stroke, thickness, dashArray, lineJoin);
+
+            Pen pen;
+            if (this.pens.TryGetValue(description, out pen))
+            {
+                return pen;
+            }
+
+            return this.pens[description] = CreatePen(stroke, thickness, dashArray, lineJoin);
+        }
+
+        /// <summary>
+        /// Creates a pen.
         /// </summary>
         /// <param name="stroke">The stroke.</param>
         /// <param name="thickness">The thickness.</param>
@@ -519,6 +528,7 @@ namespace OxyPlot.WindowsForms
         private Pen CreatePen(OxyColor stroke, double thickness, double[] dashArray = null, OxyPlot.LineJoin lineJoin = OxyPlot.LineJoin.Miter)
         {
             var pen = new Pen(stroke.ToColor(), (float)thickness);
+
             if (dashArray != null)
             {
                 pen.DashPattern = this.ToFloatArray(dashArray);
@@ -532,7 +542,7 @@ namespace OxyPlot.WindowsForms
                 case OxyPlot.LineJoin.Bevel:
                     pen.LineJoin = System.Drawing.Drawing2D.LineJoin.Bevel;
                     break;
-                //// The default LineJoin is Miter
+                // The default LineJoin is Miter
             }
 
             return pen;

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -171,7 +171,7 @@ namespace OxyPlot.WindowsForms
             var pts = this.ToPoints(points);
             if (fill.IsVisible())
             {
-                this.g.FillPolygon(fill.ToBrush(), pts);
+                this.g.FillPolygon(this.GetCachedBrush(fill), pts);
             }
 
             if (stroke.IsInvisible() || thickness <= 0)
@@ -214,7 +214,7 @@ namespace OxyPlot.WindowsForms
             if (fill.IsVisible())
             {
                 this.g.FillRectangle(
-                    fill.ToBrush(), (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
+                    this.GetCachedBrush(fill), (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
             }
 
             if (stroke.IsInvisible() || thickness <= 0)
@@ -304,18 +304,18 @@ namespace OxyPlot.WindowsForms
                 var graphicsState = this.g.Save();
 
                 this.g.TranslateTransform((float)p.X, (float)p.Y);
-                
+
                 var layoutRectangle = new RectangleF(0, 0, size.Width, size.Height);
                 if (Math.Abs(rotate) > double.Epsilon)
                 {
                     this.g.RotateTransform((float)rotate);
-                    
+
                     layoutRectangle.Height += (float)(fontSize / 18.0);
                 }
 
                 this.g.TranslateTransform(dx, dy);
 
-                this.g.DrawString(text, font, fill.ToBrush(), layoutRectangle, this.stringFormat);
+                this.g.DrawString(text, font, this.GetCachedBrush(fill), layoutRectangle, this.stringFormat);
 
                 this.g.Restore(graphicsState);
             }

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -52,6 +52,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ExporterExtensions.cs" />
+    <Compile Include="GraphicsPenDescription.cs" />
     <Compile Include="PlotView.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/Source/OxyPlot.WindowsForms/PlotView.cs
+++ b/Source/OxyPlot.WindowsForms/PlotView.cs
@@ -316,7 +316,7 @@ namespace OxyPlot.WindowsForms
 
             this.trackerLabel.Text = data.ToString();
             this.trackerLabel.Top = (int)data.Position.Y - this.trackerLabel.Height;
-            this.trackerLabel.Left = (int)data.Position.X - this.trackerLabel.Width / 2;
+            this.trackerLabel.Left = (int)data.Position.X - (this.trackerLabel.Width / 2);
             this.trackerLabel.Visible = true;
         }
 
@@ -504,12 +504,34 @@ namespace OxyPlot.WindowsForms
         }
 
         /// <summary>
+        /// Disposes the PlotView.
+        /// </summary>
+        /// <param name="disposing">Whether to dispose managed resources or not.</param>
+        protected override void Dispose(bool disposing)
+        {
+            bool disposed = this.IsDisposed;
+
+            base.Dispose(disposing);
+
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                this.renderContext.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Gets the current modifier keys.
         /// </summary>
         /// <returns>A <see cref="OxyModifierKeys" /> value.</returns>
         private static OxyModifierKeys GetModifiers()
         {
             var modifiers = OxyModifierKeys.None;
+
             // ReSharper disable once RedundantNameQualifier
             if ((Control.ModifierKeys & Keys.Shift) == Keys.Shift)
             {


### PR DESCRIPTION
Fixes #1230 concerning Brush disposal in `GraphicsRenderContext` and related issues with Pens and Images.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash) (maintained 2 separate commits, one for brushes, one for pens)

### Changes proposed in this pull request:

- Unify usage of `GetCachedBrush` so that all brushes are cached
- Adds the `GraphicsPenDescription` class, which describes a GDI+ solid-color pen
- Introduce corresponding `GetCachedPen`, and use everywhere so that all pens are cached
- Correctly dispose Brushes, Pens, and Images in `GraphicsRenderContext`
- Correctly dispose `GraphicsRenderContext` in `Oxyplot.WindowsForms.PlotView`

@oxyplot/admins
