### PR TITLE
Fix AxisChangedEventArgs.DeltaMaximum in Axes.Reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - CandleStick is overlapped when item.open == item.close in the CandleStickAndVolumeSeries (#1245)
 - Out of memory exception and performance issue with Catmull-Rom Spline (#1237)
 - Cache and Dispose Brush and Pen objects used by GraphicsRenderContext (#1230)
+- Fix AxisChangedEventArgs.DeltaMaximum in Axes.Reset (#1306)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -964,7 +964,7 @@ namespace OxyPlot.Axes
         public virtual void Reset()
         {
             var oldMinimum = this.ActualMinimum;
-            var oldMaximum = this.ActualMinimum;
+            var oldMaximum = this.ActualMaximum;
 
             this.ViewMinimum = double.NaN;
             this.ViewMaximum = double.NaN;


### PR DESCRIPTION
Fixes #1306

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change the computation of the `AxisChangedEventArgs.DeltaMaximum` value provided by `Axis.Reset` to depend upon the previous maximum, rather than previous minimum.

@oxyplot/admins
