### PR TITLE
Fix references to RectangleItem in HistogramSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - CandleStick is overlapped when item.open == item.close in the CandleStickAndVolumeSeries (#1245)
 - Out of memory exception and performance issue with Catmull-Rom Spline (#1237)
 - Cache and Dispose Brush and Pen objects used by GraphicsRenderContext (#1230)
+- Fixed references to RectangleItem in HistogramSeries
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -142,7 +142,7 @@ namespace OxyPlot.Series
         /// <summary>
         /// Gets the list of <see cref="HistogramItem" /> that should be rendered.
         /// </summary>
-        /// <value>A list of <see cref="RectangleItem" />.</value>
+        /// <value>A list of <see cref="HistogramItem" />.</value>
         protected List<HistogramItem> ActualItems => this.ItemsSource != null ? this.actualItems : this.Items;
         
         /// <summary>
@@ -211,7 +211,7 @@ namespace OxyPlot.Series
             
             if (this.ActualItems != null)
             {
-                // iterate through the DataRects and return the first one that contains the point
+                // iterate through the HistogramItems and return the first one that contains the point
                 foreach (var item in this.ActualItems)
                 {
                     if (item.Contains(p))
@@ -536,20 +536,20 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var sourceAsListOfDataRects = this.ItemsSource as List<HistogramItem>;
-            if (sourceAsListOfDataRects != null)
+            var sourceAsListOfHistogramItems = this.ItemsSource as List<HistogramItem>;
+            if (sourceAsListOfHistogramItems != null)
             {
-                this.actualItems = sourceAsListOfDataRects;
+                this.actualItems = sourceAsListOfHistogramItems;
                 this.ownsActualItems = false;
                 return;
             }
 
             this.ClearActualItems();
 
-            var sourceAsEnumerableDataRects = this.ItemsSource as IEnumerable<HistogramItem>;
-            if (sourceAsEnumerableDataRects != null)
+            var sourceAsEnumerableHistogramItems = this.ItemsSource as IEnumerable<HistogramItem>;
+            if (sourceAsEnumerableHistogramItems != null)
             {
-                this.actualItems.AddRange(sourceAsEnumerableDataRects);
+                this.actualItems.AddRange(sourceAsEnumerableHistogramItems);
             }
         }
     }


### PR DESCRIPTION
Fixes some mistakes in comments relating to `HistogramItem` which currently read `RectangleItem` (a consequence of the former being based on the later)

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change multiple instances of `RectangleItem` to `HistogramItem` in HistogramSeries.cs

@oxyplot/admins
