### PR TITLE
Add example of Annotations rendering incorrectly with LineStyle.None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - ContinuousHistogramSeries (#1145)
 - Multiline text support for PortableDocumentFont (#1146)
 - Workaround for text vertical alignment in SVG Export to accomodate viewers which don't support dominant-baseline (#459, #1198)
+- Issues Example demonstrating the rendering of Line and Arrow annotations with all LineStyles (#1312)
 
 ### Changed
 - Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -1942,6 +1942,57 @@ namespace ExampleLibrary
             return plot;
         }
 
+        [Example("#1312: Annotations ignore LineStyle.None and draw as if Solid")]
+        public static PlotModel DrawArrowAnnotationsWithDifferentLineStyles()
+        {
+            LineStyle[] lineStyles = new []
+            {
+                LineStyle.Solid,
+                LineStyle.Dash,
+                LineStyle.Dot,
+                LineStyle.DashDot,
+                LineStyle.DashDashDot,
+                LineStyle.DashDotDot,
+                LineStyle.DashDashDotDot,
+                LineStyle.LongDash,
+                LineStyle.LongDashDotDot,
+                LineStyle.None,
+                LineStyle.Automatic
+            };
+
+            var plot = new PlotModel() { Title = "Annotation Line Styles", Subtitle = "'None' should produce nothing" };
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = 0, Maximum = lineStyles.Length * 10 + 10 });
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 100 });
+            
+            double y = 10;
+            foreach (var lineStyle in lineStyles)
+            {
+                plot.Annotations.Add(new LineAnnotation()
+                    {
+                        LineStyle = lineStyle,
+                        Type = LineAnnotationType.Horizontal,
+                        Y = y,
+                        MinimumX = 10,
+                        MaximumX = 45
+                    });
+                
+                plot.Annotations.Add(new ArrowAnnotation()
+                    {
+                        LineStyle = lineStyle,
+                        Text = lineStyle.ToString(),
+                        TextHorizontalAlignment = HorizontalAlignment.Center,
+                        TextVerticalAlignment = VerticalAlignment.Bottom,
+                        TextPosition = new DataPoint(50, y),
+                        StartPoint = new DataPoint(55, y),
+                        EndPoint = new DataPoint(90, y)
+                    });
+
+                y += 10;
+            }
+
+            return plot;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }


### PR DESCRIPTION
Demonstrates #1312

The `LineStyle.None` annotations should not appear, but presently are rendered the same as if they had `LineStyle.Solid`. This is due to the semantic meaning use of `null` meaning the same as 'solid lines' for dash-arrays, and a lack of checks in the Annotation rendering methods, which should explicitly check for `LineStyle.None`.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add a new 'Issue' example, which plots annotations with every line-style, to demonstrate that the `None` line-style is incorrectly handled by annotations.

@oxyplot/admins
