### PR TITLE
Add checks for non-positive StrokeThickness and LineStyle.None in various places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - CandleStick is overlapped when item.open == item.close in the CandleStickAndVolumeSeries (#1245)
 - Out of memory exception and performance issue with Catmull-Rom Spline (#1237)
 - Cache and Dispose Brush and Pen objects used by GraphicsRenderContext (#1230)
+- Add checks for non-positive StrokeThickess and LineStyle.None in various places (#1312)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/Examples/ExampleLibrary/CustomSeries/LineSegmentSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/LineSegmentSeries.cs
@@ -82,8 +82,15 @@ namespace ExampleLibrary
                 }
             }
 
-            rc.DrawClippedLineSegments(clippingRect, screenPoints, this.ActualColor, this.StrokeThickness, this.LineStyle.GetDashArray(), this.LineJoin, false);
-            rc.DrawClippedLineSegments(clippingRect, verticalLines, this.ActualColor, this.StrokeThickness / 3, LineStyle.Dash.GetDashArray(), this.LineJoin, false);
+            if (this.StrokeThickness > 0)
+            {
+                if (this.LineStyle != LineStyle.None)
+                {
+                    rc.DrawClippedLineSegments(clippingRect, screenPoints, this.ActualColor, this.StrokeThickness, this.LineStyle.GetDashArray(), this.LineJoin, false);
+                }
+
+                rc.DrawClippedLineSegments(clippingRect, verticalLines, this.ActualColor, this.StrokeThickness / 3, LineStyle.Dash.GetDashArray(), this.LineJoin, false);
+            }
 
             rc.DrawMarkers(screenPoints, clippingRect, this.MarkerType, null, this.MarkerSize, this.MarkerFill, this.MarkerStroke, this.MarkerStrokeThickness);
         }

--- a/Source/OxyPlot/Annotations/ArrowAnnotation.cs
+++ b/Source/OxyPlot/Annotations/ArrowAnnotation.cs
@@ -128,22 +128,25 @@ namespace OxyPlot.Annotations
 
             var dashArray = this.LineStyle.GetDashArray();
 
-            rc.DrawClippedLine(
-                clippingRectangle,
-                new[] { this.screenStartPoint, p4 },
-                MinimumSegmentLength * MinimumSegmentLength,
-                this.GetSelectableColor(this.Color),
-                this.StrokeThickness,
-                dashArray,
-                this.LineJoin,
-                false);
+            if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
+            {
+                rc.DrawClippedLine(
+                    clippingRectangle,
+                    new[] { this.screenStartPoint, p4 },
+                    MinimumSegmentLength * MinimumSegmentLength,
+                    this.GetSelectableColor(this.Color),
+                    this.StrokeThickness,
+                    dashArray,
+                    this.LineJoin,
+                    false);
 
-            rc.DrawClippedPolygon(
-                clippingRectangle,
-                new[] { p3, this.screenEndPoint, p2, p4 },
-                MinimumSegmentLength * MinimumSegmentLength,
-                this.GetSelectableColor(this.Color),
-                OxyColors.Undefined);
+                rc.DrawClippedPolygon(
+                    clippingRectangle,
+                    new[] { p3, this.screenEndPoint, p2, p4 },
+                    MinimumSegmentLength * MinimumSegmentLength,
+                    this.GetSelectableColor(this.Color),
+                    OxyColors.Undefined);
+            }
 
             if (!string.IsNullOrEmpty(this.Text))
             {

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -189,17 +189,20 @@ namespace OxyPlot.Annotations
             var clippedPoints = new List<ScreenPoint>();
             var dashArray = this.LineStyle.GetDashArray();
 
-            rc.DrawClippedLine(
-               clippingRectangle,
-               this.screenPoints,
-               MinimumSegmentLength * MinimumSegmentLength,
-               this.GetSelectableColor(this.Color),
-               this.StrokeThickness,
-               dashArray,
-               this.LineJoin,
-               this.Aliased,
-               null,
-               clippedPoints.AddRange);
+            if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
+            {
+                rc.DrawClippedLine(
+                   clippingRectangle,
+                   this.screenPoints,
+                   MinimumSegmentLength * MinimumSegmentLength,
+                   this.GetSelectableColor(this.Color),
+                   this.StrokeThickness,
+                   dashArray,
+                   this.LineJoin,
+                   this.Aliased,
+                   null,
+                   clippedPoints.AddRange);
+            }
 
             ScreenPoint position;
             double angle;

--- a/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
+++ b/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
@@ -351,6 +351,11 @@ namespace OxyPlot
             LineJoin lineJoin = LineJoin.Miter,
             bool aliased = false)
         {
+            if (lineStyle == LineStyle.None)
+            {
+                return;
+            }
+
             // TODO: minDistSquared should be implemented or removed
             if (rc.SetClip(clippingRectangle))
             {

--- a/Source/OxyPlot/Series/AreaSeries.cs
+++ b/Source/OxyPlot/Series/AreaSeries.cs
@@ -334,8 +334,12 @@ namespace OxyPlot.Series
             var pts = new List<ScreenPoint>();
             pts.AddRange(pts0);
             pts.AddRange(pts1);
-            rc.DrawLine(pts0, this.GetSelectableColor(this.ActualColor), this.StrokeThickness, this.ActualLineStyle.GetDashArray());
-            rc.DrawLine(pts1, this.GetSelectableColor(this.ActualColor2), this.StrokeThickness, this.ActualLineStyle.GetDashArray());
+
+            if (this.StrokeThickness > 0 && this.ActualLineStyle != LineStyle.None)
+            {
+                rc.DrawLine(pts0, this.GetSelectableColor(this.ActualColor), this.StrokeThickness, this.ActualLineStyle.GetDashArray());
+                rc.DrawLine(pts1, this.GetSelectableColor(this.ActualColor2), this.StrokeThickness, this.ActualLineStyle.GetDashArray());
+            }
             rc.DrawPolygon(pts, this.GetSelectableFillColor(this.ActualFill), OxyColors.Undefined);
         }
 

--- a/Source/OxyPlot/Series/BoxPlotSeries.cs
+++ b/Source/OxyPlot/Series/BoxPlotSeries.cs
@@ -321,24 +321,28 @@ namespace OxyPlot.Series
                 var topWhiskerBottom = this.Transform(item.X, item.BoxTop);
                 var bottomWhiskerTop = this.Transform(item.X, item.BoxBottom);
                 var bottomWhiskerBottom = this.Transform(item.X, item.LowerWhisker);
-                rc.DrawClippedLine(
-                    clippingRect,
-                    new[] { topWhiskerTop, topWhiskerBottom },
-                    0,
-                    strokeColor,
-                    this.StrokeThickness,
-                    dashArray,
-                    LineJoin.Miter,
-                    true);
-                rc.DrawClippedLine(
-                    clippingRect,
-                    new[] { bottomWhiskerTop, bottomWhiskerBottom },
-                    0,
-                    strokeColor,
-                    this.StrokeThickness,
-                    dashArray,
-                    LineJoin.Miter,
-                    true);
+
+                if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
+                {
+                    rc.DrawClippedLine(
+                        clippingRect,
+                        new[] { topWhiskerTop, topWhiskerBottom },
+                        0,
+                        strokeColor,
+                        this.StrokeThickness,
+                        dashArray,
+                        LineJoin.Miter,
+                        true);
+                    rc.DrawClippedLine(
+                        clippingRect,
+                        new[] { bottomWhiskerTop, bottomWhiskerBottom },
+                        0,
+                        strokeColor,
+                        this.StrokeThickness,
+                        dashArray,
+                        LineJoin.Miter,
+                        true);
+                }
 
                 // Draw the whiskers
                 if (this.WhiskerWidth > 0)

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickAndVolumeSeries.cs
@@ -390,34 +390,37 @@ namespace OxyPlot.Series
                 }
             }
 
-            // draw volume & bar separation line
-            if (this.VolumeStyle != VolumeStyle.None)
+            if (this.SeparatorStrokeThickness > 0 && this.SeparatorLineStyle != LineStyle.None)
             {
-                var ysep = (clippingSep.Bottom + clippingSep.Top) / 2.0;
-                rc.DrawClippedLine(
-                    clippingSep,
-                    new[] { new ScreenPoint(clippingSep.Left, ysep), new ScreenPoint(clippingSep.Right, ysep) },
-                    0,
-                    this.SeparatorColor,
-                    this.SeparatorStrokeThickness,
-                    this.SeparatorLineStyle.GetDashArray(),
-                    LineJoin.Miter,
-                    true);
-            }
+                // draw volume & bar separation line
+                if (this.VolumeStyle != VolumeStyle.None)
+                {
+                    var ysep = (clippingSep.Bottom + clippingSep.Top) / 2.0;
+                    rc.DrawClippedLine(
+                        clippingSep,
+                        new[] { new ScreenPoint(clippingSep.Left, ysep), new ScreenPoint(clippingSep.Right, ysep) },
+                        0,
+                        this.SeparatorColor,
+                        this.SeparatorStrokeThickness,
+                        this.SeparatorLineStyle.GetDashArray(),
+                        LineJoin.Miter,
+                        true);
+                }
 
-            // draw volume y=0 line
-            if (this.VolumeAxis != null && this.VolumeStyle == VolumeStyle.PositiveNegative)
-            {
-                var y0 = this.VolumeAxis.Transform(0);
-                rc.DrawClippedLine(
-                    clippingVol,
-                    new[] { new ScreenPoint(clippingVol.Left, y0), new ScreenPoint(clippingVol.Right, y0) },
-                    0,
-                    OxyColors.Goldenrod,
-                    this.SeparatorStrokeThickness,
-                    this.SeparatorLineStyle.GetDashArray(),
-                    LineJoin.Miter,
-                    true);
+                // draw volume y=0 line
+                if (this.VolumeAxis != null && this.VolumeStyle == VolumeStyle.PositiveNegative)
+                {
+                    var y0 = this.VolumeAxis.Transform(0);
+                    rc.DrawClippedLine(
+                        clippingVol,
+                        new[] { new ScreenPoint(clippingVol.Left, y0), new ScreenPoint(clippingVol.Right, y0) },
+                        0,
+                        OxyColors.Goldenrod,
+                        this.SeparatorStrokeThickness,
+                        this.SeparatorLineStyle.GetDashArray(),
+                        LineJoin.Miter,
+                        true);
+                }
             }
         }
 
@@ -442,19 +445,22 @@ namespace OxyPlot.Series
                 legendBox.Width,
                 this.XAxis.Transform(this.data[0].X + datacandlewidth) - this.XAxis.Transform(this.data[0].X));
 
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
-                lineUp,
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
+            if (this.StrokeThickness > 0)
+            {
+                rc.DrawLine(
+                    new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
+                    lineUp,
+                    this.StrokeThickness,
+                    dashArray,
+                    LineJoin.Miter,
+                    true);
 
-            rc.DrawRectangleAsPolygon(
-                new OxyRect(xmid - (candlewidth * 0.5), yclose, candlewidth, yopen - yclose),
-                fillUp,
-                lineUp,
-                this.StrokeThickness);
+                rc.DrawRectangleAsPolygon(
+                    new OxyRect(xmid - (candlewidth * 0.5), yclose, candlewidth, yopen - yclose),
+                    fillUp,
+                    lineUp,
+                    this.StrokeThickness);
+            }
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
@@ -135,27 +135,30 @@ namespace OxyPlot.Series
                 var max = new ScreenPoint(open.X, Math.Max(open.Y, close.Y));
                 var min = new ScreenPoint(open.X, Math.Min(open.Y, close.Y));
 
-                // Upper extent
-                rc.DrawClippedLine(
-                    clippingRect,
-                    new[] { high, min },
-                    0,
-                    lineColor,
-                    this.StrokeThickness,
-                    dashArray,
-                    this.LineJoin,
-                    true);
+                if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
+                {
+                    // Upper extent
+                    rc.DrawClippedLine(
+                        clippingRect,
+                        new[] { high, min },
+                        0,
+                        lineColor,
+                        this.StrokeThickness,
+                        dashArray,
+                        this.LineJoin,
+                        true);
 
-                // Lower extent
-                rc.DrawClippedLine(
-                    clippingRect,
-                    new[] { max, low },
-                    0,
-                    lineColor,
-                    this.StrokeThickness,
-                    dashArray,
-                    this.LineJoin,
-                    true);
+                    // Lower extent
+                    rc.DrawClippedLine(
+                        clippingRect,
+                        new[] { max, low },
+                        0,
+                        lineColor,
+                        this.StrokeThickness,
+                        dashArray,
+                        this.LineJoin,
+                        true);
+                }
 
                 // Body
                 var openLeft = open + new ScreenVector(-candlewidth * 0.5, 0);
@@ -196,13 +199,16 @@ namespace OxyPlot.Series
                 legendBox.Width,
                 this.XAxis.Transform(this.Items[0].X + datacandlewidth) - this.XAxis.Transform(this.Items[0].X));
 
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
-                this.GetSelectableColor(this.ActualColor),
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
+            if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
+            {
+                rc.DrawLine(
+                    new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
+                    this.GetSelectableColor(this.ActualColor),
+                    this.StrokeThickness,
+                    dashArray,
+                    LineJoin.Miter,
+                    true);
+            }
 
             rc.DrawRectangleAsPolygon(
                 new OxyRect(xmid - (candlewidth * 0.5), yclose, candlewidth, yopen - yclose),

--- a/Source/OxyPlot/Series/FinancialSeries/HighLowSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/HighLowSeries.cs
@@ -302,27 +302,31 @@ namespace OxyPlot.Series
             double yclose = legendBox.Top + ((legendBox.Bottom - legendBox.Top) * 0.3);
             double[] dashArray = this.LineStyle.GetDashArray();
             var color = this.GetSelectableColor(this.ActualColor);
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
-                color,
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid - this.TickLength, yopen), new ScreenPoint(xmid, yopen) },
-                color,
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid + this.TickLength, yclose), new ScreenPoint(xmid, yclose) },
-                color,
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
+
+            if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
+            {
+                rc.DrawLine(
+                    new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
+                    color,
+                    this.StrokeThickness,
+                    dashArray,
+                    LineJoin.Miter,
+                    true);
+                rc.DrawLine(
+                    new[] { new ScreenPoint(xmid - this.TickLength, yopen), new ScreenPoint(xmid, yopen) },
+                    color,
+                    this.StrokeThickness,
+                    dashArray,
+                    LineJoin.Miter,
+                    true);
+                rc.DrawLine(
+                    new[] { new ScreenPoint(xmid + this.TickLength, yclose), new ScreenPoint(xmid, yclose) },
+                    color,
+                    this.StrokeThickness,
+                    dashArray,
+                    LineJoin.Miter,
+                    true);
+            }
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/FinancialSeries/OldCandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/OldCandleStickSeries.cs
@@ -196,36 +196,40 @@ namespace OxyPlot.Series
             double yopen = legendBox.Top + ((legendBox.Bottom - legendBox.Top) * 0.7);
             double yclose = legendBox.Top + ((legendBox.Bottom - legendBox.Top) * 0.3);
             double[] dashArray = this.LineStyle.GetDashArray();
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
-                this.GetSelectableColor(this.ActualColor),
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
 
-            // Shadow ends
-            if (this.ShadowEndColor.IsVisible() && this.ShadowEndLength > 0)
+            if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
             {
-                var highLeft = new ScreenPoint(xmid - (this.CandleWidth * 0.5 * this.ShadowEndLength) - 1, legendBox.Top);
-                var highRight = new ScreenPoint(xmid + (this.CandleWidth * 0.5 * this.ShadowEndLength), legendBox.Top);
                 rc.DrawLine(
-                     new[] { highLeft, highRight },
-                     this.GetSelectableColor(this.ShadowEndColor),
-                     this.StrokeThickness,
-                     dashArray,
-                     this.LineJoin,
-                     true);
-
-                var lowLeft = new ScreenPoint(xmid - (this.CandleWidth * 0.5 * this.ShadowEndLength) - 1, legendBox.Bottom);
-                var lowRight = new ScreenPoint(xmid + (this.CandleWidth * 0.5 * this.ShadowEndLength), legendBox.Bottom);
-                rc.DrawLine(
-                    new[] { lowLeft, lowRight },
-                    this.GetSelectableColor(this.ShadowEndColor),
+                    new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
+                    this.GetSelectableColor(this.ActualColor),
                     this.StrokeThickness,
                     dashArray,
-                    this.LineJoin,
+                    LineJoin.Miter,
                     true);
+
+                // Shadow ends
+                if (this.ShadowEndColor.IsVisible() && this.ShadowEndLength > 0)
+                {
+                    var highLeft = new ScreenPoint(xmid - (this.CandleWidth * 0.5 * this.ShadowEndLength) - 1, legendBox.Top);
+                    var highRight = new ScreenPoint(xmid + (this.CandleWidth * 0.5 * this.ShadowEndLength), legendBox.Top);
+                    rc.DrawLine(
+                         new[] { highLeft, highRight },
+                         this.GetSelectableColor(this.ShadowEndColor),
+                         this.StrokeThickness,
+                         dashArray,
+                         this.LineJoin,
+                         true);
+
+                    var lowLeft = new ScreenPoint(xmid - (this.CandleWidth * 0.5 * this.ShadowEndLength) - 1, legendBox.Bottom);
+                    var lowRight = new ScreenPoint(xmid + (this.CandleWidth * 0.5 * this.ShadowEndLength), legendBox.Bottom);
+                    rc.DrawLine(
+                        new[] { lowLeft, lowRight },
+                        this.GetSelectableColor(this.ShadowEndColor),
+                        this.StrokeThickness,
+                        dashArray,
+                        this.LineJoin,
+                        true);
+                }
             }
 
             rc.DrawRectangleAsPolygon(

--- a/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
@@ -296,17 +296,20 @@ namespace OxyPlot.Series
                 }
             }
 
-            // draw volume y=0 line
-            var intercept = this.YAxis.Transform(0);
-            rc.DrawClippedLine(
-                clipping,
-                new[] { new ScreenPoint(clipping.Left, intercept), new ScreenPoint(clipping.Right, intercept) },
-                0,
-                this.InterceptColor,
-                this.InterceptStrokeThickness,
-                this.InterceptLineStyle.GetDashArray(),
-                LineJoin.Miter,
-                true);
+            if (this.InterceptStrokeThickness > 0 && this.InterceptLineStyle != LineStyle.None)
+            {
+                // draw volume y=0 line
+                var intercept = this.YAxis.Transform(0);
+                rc.DrawClippedLine(
+                    clipping,
+                    new[] { new ScreenPoint(clipping.Left, intercept), new ScreenPoint(clipping.Right, intercept) },
+                    0,
+                    this.InterceptColor,
+                    this.InterceptStrokeThickness,
+                    this.InterceptLineStyle.GetDashArray(),
+                    LineJoin.Miter,
+                    true);
+            }
         }
 
         /// <summary>
@@ -330,19 +333,22 @@ namespace OxyPlot.Series
                 this.XAxis.Transform(this.data[0].X + datacandlewidth) -
                 this.XAxis.Transform(this.data[0].X);
 
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
-                lineUp,
-                this.StrokeThickness,
-                dashArray,
-                LineJoin.Miter,
-                true);
+            if (this.StrokeThickness > 0)
+            {
+                rc.DrawLine(
+                    new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, legendBox.Bottom) },
+                    lineUp,
+                    this.StrokeThickness,
+                    dashArray,
+                    LineJoin.Miter,
+                    true);
 
-            rc.DrawRectangleAsPolygon(
-                new OxyRect(xmid - (candlewidth * 0.5), yclose, candlewidth, yopen - yclose),
-                fillUp,
-                lineUp,
-                this.StrokeThickness);
+                rc.DrawRectangleAsPolygon(
+                    new OxyRect(xmid - (candlewidth * 0.5), yclose, candlewidth, yopen - yclose),
+                    fillUp,
+                    lineUp,
+                    this.StrokeThickness);
+            }
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/ThreeColorLineSeries.cs
+++ b/Source/OxyPlot/Series/ThreeColorLineSeries.cs
@@ -216,41 +216,50 @@ namespace OxyPlot.Series
                 yHi = clippingRect.Bottom;
             }
 
-            clippingRect = new OxyRect(clippingRect.Left, yHi, clippingRect.Width, yLo - yHi);
+            if (this.StrokeThickness > 0 && this.ActualLineStyle != LineStyle.None)
+            {
+                clippingRect = new OxyRect(clippingRect.Left, yHi, clippingRect.Width, yLo - yHi);
 
-            rc.DrawClippedLine(
-                clippingRect,
-                pointsToRender,
-                this.MinimumSegmentLength * this.MinimumSegmentLength,
-                this.GetSelectableColor(this.ActualColor),
-                this.StrokeThickness,
-                this.ActualDashArray,
-                this.LineJoin,
-                false);
+                rc.DrawClippedLine(
+                    clippingRect,
+                    pointsToRender,
+                    this.MinimumSegmentLength * this.MinimumSegmentLength,
+                    this.GetSelectableColor(this.ActualColor),
+                    this.StrokeThickness,
+                    this.ActualDashArray,
+                    this.LineJoin,
+                    false);
+            }
 
-            clippingRect = new OxyRect(clippingRect.Left, yLo, clippingRect.Width, bottom - yLo);
+            if (this.StrokeThickness > 0 && this.ActualLineStyleLo != LineStyle.None)
+            {
+                clippingRect = new OxyRect(clippingRect.Left, yLo, clippingRect.Width, bottom - yLo);
 
-            rc.DrawClippedLine(
-                clippingRect,
-                pointsToRender,
-                this.MinimumSegmentLength * this.MinimumSegmentLength,
-                this.GetSelectableColor(this.ActualColorLo),
-                this.StrokeThickness,
-                this.ActualDashArrayLo,
-                this.LineJoin,
-                false);
+                rc.DrawClippedLine(
+                    clippingRect,
+                    pointsToRender,
+                    this.MinimumSegmentLength * this.MinimumSegmentLength,
+                    this.GetSelectableColor(this.ActualColorLo),
+                    this.StrokeThickness,
+                    this.ActualDashArrayLo,
+                    this.LineJoin,
+                    false);
+            }
 
-            clippingRect = new OxyRect(clippingRect.Left, top, clippingRect.Width, yHi - top);
+            if (this.StrokeThickness > 0 && this.ActualLineStyleHi != LineStyle.None)
+            {
+                clippingRect = new OxyRect(clippingRect.Left, top, clippingRect.Width, yHi - top);
 
-            rc.DrawClippedLine(
-                clippingRect,
-                pointsToRender,
-                this.MinimumSegmentLength * this.MinimumSegmentLength,
-                this.GetSelectableColor(this.ActualColorHi),
-                this.StrokeThickness,
-                this.ActualDashArrayHi,
-                this.LineJoin,
-                false);
+                rc.DrawClippedLine(
+                    clippingRect,
+                    pointsToRender,
+                    this.MinimumSegmentLength * this.MinimumSegmentLength,
+                    this.GetSelectableColor(this.ActualColorHi),
+                    this.StrokeThickness,
+                    this.ActualDashArrayHi,
+                    this.LineJoin,
+                    false);
+            }
         }
     }
 }

--- a/Source/OxyPlot/Series/TwoColorLineSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorLineSeries.cs
@@ -132,26 +132,33 @@ namespace OxyPlot.Series
             var dashArray = this.ActualDashArray;
             var dashArray2 = this.ActualDashArray2;
 
-            clippingRect = new OxyRect(clippingRect.Left, clippingRect.Top, clippingRect.Width, y - clippingRect.Top);
-            rc.DrawClippedLine(
-                clippingRect,
-                pointsToRender,
-                this.MinimumSegmentLength * this.MinimumSegmentLength,
-                this.GetSelectableColor(this.ActualColor),
-                this.StrokeThickness,
-                dashArray,
-                this.LineJoin,
-                false);
-            clippingRect = new OxyRect(clippingRect.Left, y, clippingRect.Width, bottom - y);
-            rc.DrawClippedLine(
-                clippingRect,
-                pointsToRender,
-                this.MinimumSegmentLength * this.MinimumSegmentLength,
-                this.GetSelectableColor(this.ActualColor2),
-                this.StrokeThickness,
-                dashArray2,
-                this.LineJoin,
-                false);
+            if (this.StrokeThickness > 0 && this.ActualLineStyle != LineStyle.None)
+            {
+                clippingRect = new OxyRect(clippingRect.Left, clippingRect.Top, clippingRect.Width, y - clippingRect.Top);
+                rc.DrawClippedLine(
+                    clippingRect,
+                    pointsToRender,
+                    this.MinimumSegmentLength * this.MinimumSegmentLength,
+                    this.GetSelectableColor(this.ActualColor),
+                    this.StrokeThickness,
+                    dashArray,
+                    this.LineJoin,
+                    false);
+            }
+
+            if (this.StrokeThickness > 0 && this.ActualLineStyle2 != LineStyle.None)
+            {
+                clippingRect = new OxyRect(clippingRect.Left, y, clippingRect.Width, bottom - y);
+                rc.DrawClippedLine(
+                    clippingRect,
+                    pointsToRender,
+                    this.MinimumSegmentLength * this.MinimumSegmentLength,
+                    this.GetSelectableColor(this.ActualColor2),
+                    this.StrokeThickness,
+                    dashArray2,
+                    this.LineJoin,
+                    false);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1312, and associated concerns, caused by the use of `null` as the DashArray for both `LineStyle.Solid` and `LineStyle.None`, and lack of explicit checks for `LineStyle.None`.

### Checklist

- [x] I have included examples or tests (PR #1313)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Include checks for `StrokeThickness > 0` and `lineStyle != LineStyle.None` in the following classes when rendering:
   - `LineSegmentSeries` (custom series)
   - `PathAnnotation` (which by extension covers `LineAnnotation`)
   - `AreaSeries`
   - `BoxPlotSeries`
   - `CandleStickSeries`
   - `CandleStickAndVolumeSeries`
   - `OldCandleStickSeries`
   - `VolumeSeries`
   - `HighLowSeries`
   - `TwoColorLineSeries`
   - `ThreeColorLineSeries`
- Exceptional instaces are:
   - `ArrowAnnotation`, where the check also disables the rendering of the arrow head
   - `OxyPlot.RenderingExtensions.DrawClippedPolygon`, where no `StrokeThickess` check is included

There changes have been effected in a manner that tries to be consistent with the example presented by [`LineSeries.Render`](https://github.com/oxyplot/oxyplot/blob/2c254dc8352f59b927e7f6600071fcfa5fe764e7/Source/OxyPlot/Series/LineSeries.cs#L725). Duly, the `StrokeThickness` check . The targets were found by searching for usage of the `LineStype.GetDashArray()` extension method.

### Concerns

It is not impossible that someone could be depending on the current behaviour somewhere, and the change will result in stuff 'just disappearing', which could be mightily confusing.

@oxyplot/admins
