### PR TITLE
Allowing to export .svg without the xml header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
 - Fixed references to RectangleItem in HistogramSeries
 - Fix AxisChangedEventArgs.DeltaMaximum in Axes.Reset (#1306)
 - Fixed Tracker for RectangleBarSeries (#1171)
+- Fixed issue with svg always containing the xml headers (#1212)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -53,6 +53,7 @@ Ilya Skriblovsky <IlyaSkriblovsky@gmail.com>
 Iurii Gazin <archeg@gmail.com>
 jaykul
 Jeremy Koritzinsky
+Jeremie Magnette
 jezza323
 Johan
 Johan20D

--- a/Source/OxyPlot/Svg/SvgExporter.cs
+++ b/Source/OxyPlot/Svg/SvgExporter.cs
@@ -68,7 +68,7 @@ namespace OxyPlot
                 textMeasurer = new PdfRenderContext(width, height, model.Background);
             }
 
-            using (var rc = new SvgRenderContext(stream, width, height, true, textMeasurer, model.Background, useVerticalTextAlignmentWorkaround))
+            using (var rc = new SvgRenderContext(stream, width, height, isDocument, textMeasurer, model.Background, useVerticalTextAlignmentWorkaround))
             {
                 model.Update(true);
                 model.Render(rc, width, height);


### PR DESCRIPTION
isDocument was not properly taken into account in the Export function. It was fixed to true, so always adding the xml headers.

Fixes #1212  .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- 
-
-

@oxyplot/admins
