### PR TITLE
Add Color property to HistogramItem (#1347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Workaround for text vertical alignment in SVG Export to accomodate viewers which don't support dominant-baseline (#459, #1198)
 - Issues Example demonstrating the rendering of Line and Arrow annotations with all LineStyles (#1312)
 - Add support for transposed (X and Y axis switched) plots with XYAxisSeries (#1334)
+- Add Color property to HistogramItem (#1347)
 
 ### Changed
 - Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -10,6 +10,7 @@
 namespace ExampleLibrary
 {
     using System;
+    using System.Linq;
 
     using ExampleLibrary.Utilities;
 
@@ -94,6 +95,12 @@ namespace ExampleLibrary
         public static PlotModel NormalDistribution()
         {
             return CreateNormalDistribution();
+        }
+
+        [Example("Individual Bin Colors")]
+        public static PlotModel IndividualBinColors()
+        {
+            return CreateIndividualBinColors();
         }
 
         public static PlotModel CreateExponentialDistribution(double mean = 1, int n = 10000)
@@ -186,6 +193,28 @@ namespace ExampleLibrary
             return model;
         }
 
+        public static PlotModel CreateIndividualBinColors(double mean = 1, int n = 10000)
+        {
+            var model = new PlotModel { Title = "Individual Bin Colors", Subtitle = "Minimum is Red, Maximum is Green" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Frequency" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "Observation" });
+
+            Random rnd = new Random(1);
+
+            HistogramSeries chs = new HistogramSeries() { FillColor = OxyColors.Gray, RenderInLegend = true, Title = "Measurements" };
+
+            var binningOptions = new BinningOptions(BinningOutlierMode.CountOutliers, BinningIntervalType.InclusiveLowerBound, BinningExtremeValueMode.ExcludeExtremeValues);
+            var binBreaks = HistogramHelpers.CreateUniformBins(0, 10, 20);
+            var bins = HistogramHelpers.Collect(SampleUniform(rnd, 0, 10, 1000), binBreaks, binningOptions).OrderBy(b => b.Count).ToArray();
+            bins.First().Color = OxyColors.Red;
+            bins.Last().Color = OxyColors.Green;
+            chs.Items.AddRange(bins);
+            chs.StrokeThickness = 1;
+            model.Series.Add(chs);
+
+            return model;
+        }
+
         private static IEnumerable<double> SampleExps(Random rnd, double mean, int count)
         {
             for (int i = 0; i < count; i++)
@@ -213,6 +242,14 @@ namespace ExampleLibrary
             var u1 = rnd.NextDouble();
             var u2 = rnd.NextDouble();
             return Math.Sqrt(-2 * Math.Log(u1)) * Math.Cos(2 * Math.PI * u2);
+        }
+
+        private static IEnumerable<double> SampleUniform(Random rnd, double min, double max, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return rnd.NextDouble() * (max - min) + min;
+            }
         }
     }
 }

--- a/Source/OxyPlot/Series/HistogramItem.cs
+++ b/Source/OxyPlot/Series/HistogramItem.cs
@@ -22,11 +22,25 @@ namespace OxyPlot.Series
         /// <param name="area">The area.</param>
         /// <param name="count">The count.</param>
         public HistogramItem(double rangeStart, double rangeEnd, double area, int count)
+            : this(rangeStart, rangeEnd, area, count, OxyColors.Automatic)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HistogramItem" /> class.
+        /// </summary>
+        /// <param name="rangeStart">The range start.</param>
+        /// <param name="rangeEnd">The range end.</param>
+        /// <param name="area">The area.</param>
+        /// <param name="count">The count.</param>
+        /// <param name="color">The color.</param>
+        public HistogramItem(double rangeStart, double rangeEnd, double area, int count, OxyColor color)
         {
             this.RangeStart = rangeStart;
             this.RangeEnd = rangeEnd;
             this.Area = area;
             this.Count = count;
+            this.Color = color;
         }
 
         /// <summary>
@@ -52,10 +66,18 @@ namespace OxyPlot.Series
         /// </summary>
         public double RangeCenter => this.RangeStart + ((this.RangeEnd - this.RangeStart) / 2);
 
+        /// <summary>
         /// Gets or sets the count.
         /// </summary>
         /// <value>The count.</value>
         public int Count { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color.
+        /// </summary>
+        /// <value>The color.</value>
+        /// <remarks>If set to Automatic, the FillColor of the RectangleBarSeries will be used.</remarks>
+        public OxyColor Color { get; set; }
 
         /// <summary>
         /// Gets the computed width of the item.
@@ -65,11 +87,11 @@ namespace OxyPlot.Series
         /// <summary>
         /// Gets the computed height of the item.
         /// </summary>
-        /// <value>The computed height of the item</value>
+        /// <value>The computed height of the item.</value>
         public double Height => this.Area / this.Width;
 
         /// <summary>
-        /// Gets the value of the item. Equivalent to the Height;
+        /// Gets the value of the item. Equivalent to the Height.
         /// </summary>
         /// <value>The value of the item.</value>
         public double Value => this.Height;
@@ -100,7 +122,14 @@ namespace OxyPlot.Series
         /// <returns>The to code.</returns>
         public string ToCode()
         {
-            return CodeGenerator.FormatConstructor(this.GetType(), "{0},{1},{2},{3}", this.RangeStart, this.RangeEnd, this.Area, this.Count);
+            if (!this.Color.IsAutomatic())
+            {
+                return CodeGenerator.FormatConstructor(this.GetType(), "{0},{1},{2},{3},{4}", this.RangeStart, this.RangeEnd, this.Area, this.Count, this.Color);
+            }
+            else
+            {
+                return CodeGenerator.FormatConstructor(this.GetType(), "{0},{1},{2},{3}", this.RangeStart, this.RangeEnd, this.Area, this.Count);
+            }
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -19,7 +19,7 @@ namespace OxyPlot.Series
     public class HistogramSeries : XYAxisSeries
     {
         /// <summary>
-        /// The default tracker format string
+        /// The default tracker format string.
         /// </summary>
         public new const string DefaultTrackerFormatString = "Start: {5}\nEnd: {6}\nValue: {7}\nArea: {8}\nCount: {9}";
 
@@ -41,7 +41,7 @@ namespace OxyPlot.Series
         /// <summary>
         /// The default color mapping.
         /// </summary>
-        private OxyColor defaultColorMapping(HistogramItem item) => ActualFillColor;
+        private OxyColor defaultColorMapping(HistogramItem item) => this.ActualFillColor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HistogramSeries" /> class.
@@ -55,7 +55,7 @@ namespace OxyPlot.Series
             this.LabelFormatString = null;
             this.LabelFontSize = 0;
             this.LabelPlacement = LabelPlacement.Outside;
-            this.ColorMapping = defaultColorMapping;
+            this.ColorMapping = this.defaultColorMapping;
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace OxyPlot.Series
         /// Gets or sets the delegate used to map from <see cref="ItemsSeries.ItemsSource" /> to <see cref="HistogramSeries" />. The default is <c>null</c>.
         /// </summary>
         /// <value>The mapping.</value>
-        /// <remarks>Example: series1.Mapping = item => new HistogramItem((double)item.BinStart, (double)item.BinStart + item.BinWidth, (double)item.Count / totalCount, item.Count);</remarks>
+        /// <remarks>Example: series1.Mapping = item => new HistogramItem((double)item.BinStart, (double)item.BinStart + item.BinWidth, (double)item.Count / totalCount, item.Count).</remarks>
         public Func<object, HistogramItem> Mapping { get; set; }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace OxyPlot.Series
                             item.RangeEnd,
                             item.Value,
                             item.Area,
-                            item.Count)
+                            item.Count),
                         };
                     }
                 }
@@ -222,7 +222,7 @@ namespace OxyPlot.Series
             // if no HistogramItems contain the point, return null
             return null;
         }
-        
+
         /// <summary>
         /// Renders the legend symbol on the specified rendering context.
         /// </summary>
@@ -354,7 +354,7 @@ namespace OxyPlot.Series
         {
             foreach (var item in items)
             {
-                var actualFillColor = ColorMapping(item);
+                var actualFillColor = this.GetItemFillColor(item);
 
                 // transform the data points to screen points
                 var p1 = this.Transform(item.RangeStart, 0);
@@ -368,6 +368,23 @@ namespace OxyPlot.Series
                 {
                     this.RenderLabel(rc, clippingRect, rectrect, item);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets the fill color of the given <see cref="HistogramItem"/>.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns>The fill color of the item.</returns>
+        protected OxyColor GetItemFillColor(HistogramItem item)
+        {
+            if (!item.Color.IsAutomatic())
+            {
+                return item.Color;
+            }
+            else
+            {
+                return this.ColorMapping(item);
             }
         }
 
@@ -396,7 +413,6 @@ namespace OxyPlot.Series
         /// <param name="rc">The render context.</param>
         /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="rect">The column rectangle.</param>
-        /// <param name="value">The value.</param>
         /// <param name="item">The item.</param>
         protected void RenderLabel(IRenderContext rc, OxyRect clippingRect, OxyRect rect, HistogramItem item)
         {


### PR DESCRIPTION
Fixes #1347 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add a `Color` property to `HistogramItem` and a new constructor (for code-gen purposes)
- This color is used as the fill-color for the item if it is not `Automatic`
- Some minor Style-Cop fixes in relevant files
- A new `HistogramSeries` example, showing custom colors and the Histogram legend symbology.

Work is loosely based on `RectangleBarItem`.

@oxyplot/admins
