### PR TITLE
Address edgecases in MagnitudeAxisFullPlotArea rendering (#1364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project will be documented in this file.
 - Fixed issue with svg always containing the xml headers (#1212)
 - In WPF, make sure the axes are initalized when the Model is set before the PlotView has been loaded (#1303)
 - Fixed MinimumSegmentLength not working for LineSeries (#1044)
+- Fixed rendering issues with MagnitudeAxisFullPlotArea (#1364)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
@@ -74,6 +74,12 @@ namespace OxyPlot.Axes
             double cornerangle_bottomleft = 360-degree * Math.Atan2(maxtickrect.Bottom, maxtickrect.Left);
             double cornerangle_bottomright = 360-degree * Math.Atan2(maxtickrect.Bottom, maxtickrect.Right);
 
+            // detect and filter dodgy values (these checks appear to be sufficient)
+            if (cornerangle_topleft < 0)
+                cornerangle_topleft += 360;
+            if (cornerangle_bottomleft > 360)
+                cornerangle_bottomleft -= 360;
+
             double cornerdistance_topright = Math.Sqrt(Math.Pow(distancerect.Top, 2) + Math.Pow(distancerect.Right, 2));
             double cornerdistance_topleft = Math.Sqrt(Math.Pow(distancerect.Top, 2) + Math.Pow(distancerect.Left, 2));
             double cornerdistance_bottomleft = Math.Sqrt(Math.Pow(distancerect.Bottom, 2) + Math.Pow(distancerect.Left, 2));
@@ -165,28 +171,40 @@ namespace OxyPlot.Axes
                     }
 
                     //Top right
-                    if (startangle_0_90 < cornerangle_topright)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (startangle_0_90 + angleAxis.Offset), (cornerangle_topright + angleAxis.Offset));
-                    if (cornerangle_topright < endangle_0_90)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (cornerangle_topright + angleAxis.Offset), (endangle_0_90 + angleAxis.Offset));
+                    if (r <= cornerdistance_topright)
+                    {
+                        if (startangle_0_90 < cornerangle_topright)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, (startangle_0_90 + angleAxis.Offset), (cornerangle_topright + angleAxis.Offset));
+                        if (cornerangle_topright < endangle_0_90)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, (cornerangle_topright + angleAxis.Offset), (endangle_0_90 + angleAxis.Offset));
+                    }
 
                     //Top left
-                    if (startangle_90_180 < cornerangle_topleft)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_90_180 + angleAxis.Offset, cornerangle_topleft + angleAxis.Offset);
-                    if (cornerangle_topleft < endangle_90_180)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_topleft + angleAxis.Offset, endangle_90_180 + angleAxis.Offset);
+                    if (r <= cornerdistance_topleft)
+                    {
+                        if (startangle_90_180 < cornerangle_topleft)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_90_180 + angleAxis.Offset, cornerangle_topleft + angleAxis.Offset);
+                        if (cornerangle_topleft < endangle_90_180)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_topleft + angleAxis.Offset, endangle_90_180 + angleAxis.Offset);
+                    }
 
                     //Bottom left
-                    if (startangle_180_270 < cornerangle_bottomleft)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_180_270 + angleAxis.Offset, cornerangle_bottomleft + angleAxis.Offset);
-                    if (cornerangle_bottomleft < endangle_180_270)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomleft + angleAxis.Offset, endangle_180_270 + angleAxis.Offset);
+                    if (r <= cornerdistance_bottomleft)
+                    {
+                        if (startangle_180_270 < cornerangle_bottomleft)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_180_270 + angleAxis.Offset, cornerangle_bottomleft + angleAxis.Offset);
+                        if (cornerangle_bottomleft < endangle_180_270)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomleft + angleAxis.Offset, endangle_180_270 + angleAxis.Offset);
+                    }
 
                     //Bottom right
-                    if (startangle_270_360 < cornerangle_bottomright)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_270_360 + angleAxis.Offset, cornerangle_bottomright + angleAxis.Offset);
-                    if (cornerangle_bottomright < endangle_270_360)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomright + angleAxis.Offset, endangle_270_360 + angleAxis.Offset);
+                    if (r <= cornerdistance_bottomright)
+                    {
+                        if (startangle_270_360 < cornerangle_bottomright)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_270_360 + angleAxis.Offset, cornerangle_bottomright + angleAxis.Offset);
+                        if (cornerangle_bottomright < endangle_270_360)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomright + angleAxis.Offset, endangle_270_360 + angleAxis.Offset);
+                    }
                 }
             }
 
@@ -247,28 +265,40 @@ namespace OxyPlot.Axes
                     }
 
                     //Top right
-                    if (startangle_0_90 < cornerangle_topright)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (startangle_0_90 + angleAxis.Offset), (cornerangle_topright + angleAxis.Offset));
-                    if (cornerangle_topright < endangle_0_90)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, (cornerangle_topright + angleAxis.Offset), (endangle_0_90 + angleAxis.Offset));
+                    if (r <= cornerdistance_topright)
+                    {
+                        if (startangle_0_90 < cornerangle_topright)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, (startangle_0_90 + angleAxis.Offset), (cornerangle_topright + angleAxis.Offset));
+                        if (cornerangle_topright < endangle_0_90)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, (cornerangle_topright + angleAxis.Offset), (endangle_0_90 + angleAxis.Offset));
+                    }
 
                     //Top left
-                    if (startangle_90_180 < cornerangle_topleft)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_90_180 + angleAxis.Offset, cornerangle_topleft + angleAxis.Offset);
-                    if (cornerangle_topleft < endangle_90_180)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_topleft + angleAxis.Offset, endangle_90_180 + angleAxis.Offset);
+                    if (r <= cornerdistance_topleft)
+                    {
+                        if (startangle_90_180 < cornerangle_topleft)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_90_180 + angleAxis.Offset, cornerangle_topleft + angleAxis.Offset);
+                        if (cornerangle_topleft < endangle_90_180)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_topleft + angleAxis.Offset, endangle_90_180 + angleAxis.Offset);
+                    }
 
                     //Bottom left
-                    if (startangle_180_270 < cornerangle_bottomleft)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_180_270 + angleAxis.Offset, cornerangle_bottomleft + angleAxis.Offset);
-                    if (cornerangle_bottomleft < endangle_180_270)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomleft + angleAxis.Offset, endangle_180_270 + angleAxis.Offset);
+                    if (r <= cornerdistance_bottomleft)
+                    {
+                        if (startangle_180_270 < cornerangle_bottomleft)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_180_270 + angleAxis.Offset, cornerangle_bottomleft + angleAxis.Offset);
+                        if (cornerangle_bottomleft < endangle_180_270)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomleft + angleAxis.Offset, endangle_180_270 + angleAxis.Offset);
+                    }
 
                     //Bottom right
-                    if (startangle_270_360 < cornerangle_bottomright)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_270_360 + angleAxis.Offset, cornerangle_bottomright + angleAxis.Offset);
-                    if (cornerangle_bottomright < endangle_270_360)
-                        this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomright + angleAxis.Offset, endangle_270_360 + angleAxis.Offset);
+                    if (r <= cornerdistance_bottomright)
+                    {
+                        if (startangle_270_360 < cornerangle_bottomright)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, startangle_270_360 + angleAxis.Offset, cornerangle_bottomright + angleAxis.Offset);
+                        if (cornerangle_bottomright < endangle_270_360)
+                            this.RenderTickArc(axis, angleAxis, tickValue, pen, cornerangle_bottomright + angleAxis.Offset, endangle_270_360 + angleAxis.Offset);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #1364 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Detect and correct spurious 'corner' angles in `MagnitudeAxisFullPlotAreaRenderer.Render` (MagnitudeAxisFullPlotAreaRenderer.cs):
    ![MagRad1](https://user-images.githubusercontent.com/5646475/66744164-9cc02a80-ee73-11e9-9fb7-e68eb35105a7.PNG)

- Do not render grid-lines which would be wholly outside the plot bounds:
    ![MagRad2](https://user-images.githubusercontent.com/5646475/66744166-9e89ee00-ee73-11e9-90b7-8029a8202c8b.PNG)
    This approach is necessary to resolve some lesser artefacts also, not just those observed by the moving the center into the very corner.

All issues can be observed on the Spiral Full Plot Area example. No changes are made to the lines that perform the actual rendering: only the `cornerangle_topleft` and `cornerangle_bottomleft` values are adjusted, and pairs of grid-lines in each quadrant filtered based on the corner distances.

@oxyplot/admins
