### PR TITLE
Remove unused LabelFontSize property from HistogramSeries (#1309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - TrackerControl reuses existing ContentControl when a new hit tracker result uses the same template as the currently shown tracker (#1281)
 - Add Count to HistogramSeries (#1347)
 - Overhaul HistogramHelpers (#1345)
+- Remove unused LabelFontSize property from HistogramSeries (#1309)
 
 ### Deprecated
 - OxyPlot.WP8 package. Use OxyPlot.Windows instead (#996)

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -53,7 +53,6 @@ namespace OxyPlot.Series
             this.StrokeThickness = 0;
             this.TrackerFormatString = DefaultTrackerFormatString;
             this.LabelFormatString = null;
-            this.LabelFontSize = 0;
             this.LabelPlacement = LabelPlacement.Outside;
             this.ColorMapping = this.defaultColorMapping;
         }
@@ -105,14 +104,7 @@ namespace OxyPlot.Series
         /// Gets or sets the format string for the cell labels. The default value is <c>0.00</c>.
         /// </summary>
         /// <value>The format string.</value>
-        /// <remarks>The label format string is only used when <see cref="LabelFontSize" /> is greater than 0.</remarks>
         public string LabelFormatString { get; set; }
-
-        /// <summary>
-        /// Gets or sets the font size of the labels. The default value is <c>0</c> (labels not visible).
-        /// </summary>
-        /// <value>The font size relative to the cell height.</value>
-        public double LabelFontSize { get; set; }
 
         /// <summary>
         /// Gets or sets the label margins.


### PR DESCRIPTION
Partially addresses #1309 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove the `LabelFontSize` property from `HistogramSeries`. This property was unused, and its intended purpose would be inappropriate for the `HistogramSeries`.

@oxyplot/admins
