### PR TITLE
Fix OxyPlot.Core.Drawing PngExporter Export to Stream background (#1382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 - In WPF, make sure the axes are initalized when the Model is set before the PlotView has been loaded (#1303)
 - Fixed MinimumSegmentLength not working for LineSeries (#1044)
 - Fixed rendering issues with MagnitudeAxisFullPlotArea (#1364)
+- OxyPlot.Core.Drawing PngExporter Export to Stream background (#1382)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/Examples/Core.Drawing/Example1/Example1.csproj
+++ b/Source/Examples/Core.Drawing/Example1/Example1.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Drawing.Common" Version="4.6.0-preview.19073.11" />
-    </ItemGroup>
-
-    <ItemGroup>
     <ProjectReference Include="..\..\..\OxyPlot.Core.Drawing\OxyPlot.Core.Drawing.csproj" />
   </ItemGroup>
 

--- a/Source/Examples/Core.Drawing/Example1/Program.cs
+++ b/Source/Examples/Core.Drawing/Example1/Program.cs
@@ -15,7 +15,11 @@
         {
             var outputUsingMemStream = "test-oxyplot-memstream.png";
             var outputToFile = "test-oxyplot-file.png";
+            var outputToFileBrush = "test-oxyplot-file-brush.png";
             var outputExportFileStream = "test-oxyplot-stream-export.png";
+            var outputExportBitmap = "test-oxyplot-exportobitmap.png";
+            var outputExportBitmapBrush = "test-oxyplot-exportobitmap-brush.png";
+            var outputExportStreamOOP = "test-oxyplot-ExportToStream.png";
             var outputExportFileOOP = "test-oxyplot-ExportToFile.png";
 
             var width = 1024;
@@ -23,28 +27,45 @@
 
             var model = BuildPlotModel();
 
+            // export to file using static methods
+            PngExporter.Export(model, outputToFile, width, height, OxyColors.LightGray);
 
-            PngExporter.Export(model, outputToFile, width, height, Brushes.White);
+            PngExporter.Export(model, outputToFileBrush, width, height, Brushes.LightGray);
 
+            // export to stream using static methods
             using (var stream = new MemoryStream())
             {
-                PngExporter.Export(model, stream, width, height, OxyColors.White, 96);
+                PngExporter.Export(model, stream, width, height, OxyColors.LightGray, 96);
                 System.IO.File.WriteAllBytes(outputUsingMemStream, stream.ToArray());
             }
 
-            using (var pngStream = PngExporter.ExportToStream(model, width, height, OxyColors.White))
+            using (var pngStream = PngExporter.ExportToStream(model, width, height, OxyColors.LightGray))
             {
                 var fileStream = new System.IO.FileStream(outputExportFileStream, FileMode.Create);
                 pngStream.CopyTo(fileStream);
                 fileStream.Flush();
             }
 
-            var stream2 = new MemoryStream();
-            var pngExporter = new PngExporter { Width = width, Height = height, Background = OxyColors.White };
-            pngExporter.Export(model, stream2);
+            // export to bitmap using static methods
+            using (var bm = PngExporter.ExportToBitmap(model, width, height, OxyColors.LightGray))
+            {
+                bm.Save(outputExportBitmap);
+            }
 
-            // Write to a file, OOP
-            var pngExporter2 = new PngExporter { Width = width, Height = height, Background = OxyColors.White };
+            using (var bm = PngExporter.ExportToBitmap(model, width, height, Brushes.LightGray))
+            {
+                bm.Save(outputExportBitmapBrush);
+            }
+
+            // export using the instance methods
+            using (var stream = new MemoryStream())
+            {
+                var pngExporter = new PngExporter { Width = width, Height = height, Background = OxyColors.LightGray };
+                pngExporter.Export(model, stream);
+                System.IO.File.WriteAllBytes(outputExportStreamOOP, stream.ToArray());
+            }
+
+            var pngExporter2 = new PngExporter { Width = width, Height = height, Background = OxyColors.LightGray };
             pngExporter2.ExportToFile(model, outputExportFileOOP);
         }
 

--- a/Source/OxyPlot.Core.Drawing/PngExporter.cs
+++ b/Source/OxyPlot.Core.Drawing/PngExporter.cs
@@ -18,40 +18,54 @@ namespace OxyPlot.Core.Drawing
     public class PngExporter : IExporter
     {
         /// <summary>
-        /// The export.
+        /// Gets or sets the width in pixels of the exported png.
         /// </summary>
-        /// <param name="model">
-        /// The model.
-        /// </param>
-        /// <param name="fileName">
-        /// The file name.
-        /// </param>
-        /// <param name="width">
-        /// The width.
-        /// </param>
-        /// <param name="height">
-        /// The height.
-        /// </param>
-        /// <param name="background">
-        /// The background.
-        /// </param>
-        public static void Export(IPlotModel model, string fileName, int width, int height, Brush background = null)
-        {
-            using (var bm = new Bitmap(width, height))
-            {
-                using (var g = Graphics.FromImage(bm))
-                {
-                    if (background != null)
-                    {
-                        g.FillRectangle(background, 0, 0, width, height);
-                    }
+        public int Width { get; set; }
 
-                    var rc = new GraphicsRenderContext(g) { RendersToScreen = false };
-                    rc.SetGraphicsTarget(g);
-                    model.Update(true);
-                    model.Render(rc, width, height);
-                    bm.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
-                }
+        /// <summary>
+        /// Gets or sets the height in pixels of the exported png.
+        /// </summary>
+        public int Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color of the exported png.
+        /// </summary>
+        public OxyColor Background { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resolution in dpi of the exported png.
+        /// </summary>
+        public double Resolution { get; set; }
+
+        /// <summary>
+        /// Exports the specified <see cref="PlotModel" /> to the specified file.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <param name="background">The background color.</param>
+        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
+        public static void Export(IPlotModel model, string fileName, int width, int height, OxyColor background, double resolution = 96)
+        {
+            Brush brush = background.IsInvisible() ? null : background.ToBrush();
+            Export(model, fileName, width, height, brush, resolution);
+        }
+
+        /// <summary>
+        /// Exports the specified <see cref="PlotModel" /> to the specified file.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <param name="background">The background color (defaults to null).</param>
+        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
+        public static void Export(IPlotModel model, string fileName, int width, int height, Brush background = null, double resolution = 96)
+        {
+            using (var bm = ExportToBitmap(model, width, height, background, resolution))
+            {
+                bm.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
             }
         }
 
@@ -73,13 +87,14 @@ namespace OxyPlot.Core.Drawing
         }
 
         /// <summary>
-        /// Exports the specified <see cref="PlotModel" /> to the specified <see cref="Stream" />.
+        /// Exports the specified <see cref="PlotModel" /> to a <see cref="MemoryStream" />.
         /// </summary>
         /// <param name="model">The model.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
         /// <param name="background">The background color.</param>
         /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
+        /// <returns>A <see cref="Stream"/>.</returns>
         public static Stream ExportToStream(IPlotModel model, int width, int height, OxyColor background, double resolution = 96)
         {
             var stream = new MemoryStream();
@@ -95,22 +110,34 @@ namespace OxyPlot.Core.Drawing
         /// Exports the specified <see cref="PlotModel" /> to a <see cref="Bitmap" />.
         /// </summary>
         /// <param name="model">The model to export.</param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="background"></param>
-        /// <param name="resolution"></param>
-        /// <returns>A bitmap.</returns>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <param name="background">The background color.</param>
+        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
+        /// <returns>A <see cref="Bitmap"/>.</returns>
         public static Bitmap ExportToBitmap(IPlotModel model, int width, int height, OxyColor background, double resolution = 96)
+        {
+            Brush brush = background.IsInvisible() ? null : background.ToBrush();
+            return ExportToBitmap(model, width, height, brush, resolution);
+        }
+
+        /// <summary>
+        /// Exports the specified <see cref="PlotModel" /> to a <see cref="Bitmap" />.
+        /// </summary>
+        /// <param name="model">The model to export.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <param name="background">The background color.</param>
+        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
+        /// <returns>A <see cref="Bitmap"/>.</returns>
+        public static Bitmap ExportToBitmap(IPlotModel model, int width, int height, Brush background, double resolution = 96)
         {
             var bm = new Bitmap(width, height);
             using (var g = Graphics.FromImage(bm))
             {
-                if (background.IsVisible())
+                if (background != null)
                 {
-                    using (var brush = background.ToBrush())
-                    {
-                        g.FillRectangle(brush, 0, 0, width, height);
-                    }
+                    g.FillRectangle(background, 0, 0, width, height);
                 }
 
                 using (var rc = new GraphicsRenderContext(g) { RendersToScreen = false })
@@ -126,26 +153,17 @@ namespace OxyPlot.Core.Drawing
         }
 
         /// <summary>
-        /// Gets or sets the width in pixels of the exported png.
+        /// Exports the specified <see cref="PlotModel"/> to the specified <see cref="Stream"/>.
         /// </summary>
-        public int Width { get; set; }
+        /// <param name="model">The model.</param>
+        /// <param name="stream">The output stream.</param>
+        public void Export(IPlotModel model, Stream stream) => Export(model, stream, this.Width, this.Height, this.Background, this.Resolution);
 
         /// <summary>
-        /// Gets or sets the height in pixels of the exported png.
+        /// Exports the specified <see cref="PlotModel"/> to the specified file.
         /// </summary>
-        public int Height { get; set; }
-
-        /// <summary>
-        /// Gets or sets the background color of the exported png.
-        /// </summary>
-        public OxyColor Background { get; set; }
-        
-        /// <summary>
-        /// Gets or sets the resolution in dpi of the exported png.
-        /// </summary>
-        public double Resolution { get; set; }
-
-        public void Export(IPlotModel model, Stream stream) => Export(model, stream, this.Width, this.Height, OxyColors.White, this.Resolution);
-        public void ExportToFile(IPlotModel model, string filename) => Export(model, filename, this.Width, this.Height, this.Background.ToBrush());
+        /// <param name="model">The model.</param>
+        /// <param name="filename">The file name.</param>
+        public void ExportToFile(IPlotModel model, string filename) => Export(model, filename, this.Width, this.Height, this.Background, this.Resolution);
     }
 }


### PR DESCRIPTION
Fixes #1382 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Pass the `Background` field to the static export method in the instance method `PngExporter.Export`
- Add an additional static overload for `PngExporter.Export`, which takes a file name and `OxyColor` background
- Address stylecop issues and reduce redundancy in `PngExporter.cs`
- Add additional examples to the Example1 program to test all overloads
- Change the background colours in the Example1 program to `LightGray` to verify they are being rendered.
- Remove package reference to `System.Drawing.Core` in Example1 program, which was causing it to fail to build on my machine (I believe it is redundant with the SDK now)

@oxyplot/admins
