### PR TITLE
Add example for #1385

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Issues Example demonstrating the rendering of Line and Arrow annotations with all LineStyles (#1312)
 - Add support for transposed (X and Y axis switched) plots with XYAxisSeries (#1334)
 - Add Color property to HistogramItem (#1347)
+- Example issue of Windows Forms clipping the last line of rendered text (#1124, #1385)
 
 ### Changed
 - Let Gtk# PlotView show up in Ui editor ToolBox of MonoDevelop and XamarinStudio (#1071)

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -2090,6 +2090,22 @@ namespace ExampleLibrary
             return plot;
         }
 
+        [Example("#1385: GraphicsRenderContext sometimes clips last line of text")]
+        public static PlotModel DrawMultilineText()
+        {
+            var plot = new PlotModel() { Title = "GraphicsRenderContext\nsometimes clips last\nline of text" };
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = 0, Maximum = 100 });
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 100 });
+
+            double y = 0.0;
+            for (int i = 2; i < 50; i++)
+            {
+                plot.Annotations.Add(new TextAnnotation() { Text = "GraphicsRenderContext\nsometimes clips last\nline of text", TextPosition = new DataPoint(50, y += i), FontSize = i });
+            }
+
+            return plot;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }


### PR DESCRIPTION
Adds an example for #1385 (and #1124)

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds an example, demonstrating #1385 (and #1124) clipping the last line of rendered multi-line text in some cases

@oxyplot/admins
