### PR TITLE
Fix Winforms clipping last line of rendered text (#1124, #1385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 - In WPF, make sure the axes are initalized when the Model is set before the PlotView has been loaded (#1303)
 - Fixed MinimumSegmentLength not working for LineSeries (#1044)
 - Fixed rendering issues with MagnitudeAxisFullPlotArea (#1364)
+- Fixed Winforms clipping last line of rendered text (#1124, #1385)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -244,7 +244,7 @@ namespace OxyPlot.WindowsForms
             {
                 this.stringFormat.Alignment = StringAlignment.Near;
                 this.stringFormat.LineAlignment = StringAlignment.Near;
-                var size = this.g.MeasureString(text, font, int.MaxValue, this.stringFormat);
+                var size = Ceiling(this.g.MeasureString(text, font, int.MaxValue, this.stringFormat));
                 if (maxSize != null)
                 {
                     if (size.Width > maxSize.Value.Width)
@@ -445,6 +445,17 @@ namespace OxyPlot.WindowsForms
         private static Font CreateFont(string fontFamily, double fontSize, FontStyle fontStyle)
         {
             return new Font(fontFamily, (float)fontSize * FontsizeFactor, fontStyle);
+        }
+
+        /// <summary>
+        /// Returns the ceiling of the given <see cref="SizeF"/> as a <see cref="SizeF"/>.
+        /// </summary>
+        /// <param name="size">The size.</param>
+        /// <returns>A <see cref="SizeF>"/></returns>
+        private static SizeF Ceiling(SizeF size)
+        {
+            var ceiling = Size.Ceiling(size);
+            return new SizeF(ceiling.Width, ceiling.Height);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1385 (and hopefully #1124).

### Checklist

- [x] I have included examples or tests (#1386, pictures in #1385)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Ceil text measurements (before max-size test) when rendering text in the Windows Forms `GraphicsRenderContext`
- Add a `Ceiling` method to the Windows Forms `GraphicsRenderContext` which internally calls `Size.Ceiling`, but produces a `SizeF` from the result

The motivation for this fix was found in the Windows Forms `Label` class: https://github.com/dotnet/winforms/blob/349a7c6e6eba848dba337c27c18583ba6f82041c/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs#L1298

@oxyplot/admins
