### PR TITLE
Make PNG exporters consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Overhaul HistogramHelpers (#1345)
 - Remove unused LabelFontSize property from HistogramSeries (#1309)
 - OxyPlot.Windows (UWP) moved to oxyplot-uwp repository (#1378)
+- Make the PngExporters consistent (#1390)
 
 ### Deprecated
 - OxyPlot.WP8 package. Use OxyPlot.Windows instead (#996)

--- a/Source/Examples/Core.Drawing/Example1/Program.cs
+++ b/Source/Examples/Core.Drawing/Example1/Program.cs
@@ -1,7 +1,6 @@
 ﻿namespace Example1
 {
     using System;
-    using System.Drawing;
     using System.IO;
     using System.Linq;
     using OxyPlot;
@@ -13,73 +12,46 @@
     {
         static void Main(string[] args)
         {
-            var outputUsingMemStream = "test-oxyplot-memstream.png";
-            var outputToFile = "test-oxyplot-file.png";
-            var outputToFileBrush = "test-oxyplot-file-brush.png";
-            var outputExportFileStream = "test-oxyplot-stream-export.png";
-            var outputExportBitmap = "test-oxyplot-exportobitmap.png";
-            var outputExportBitmapBrush = "test-oxyplot-exportobitmap-brush.png";
+            var outputToFile = "test-oxyplot-static-export-file.png";
             var outputExportStreamOOP = "test-oxyplot-ExportToStream.png";
             var outputExportFileOOP = "test-oxyplot-ExportToFile.png";
 
             var width = 1024;
             var height = 768;
+            var background = OxyColors.LightGray;
+            var resolution = 96d;
 
             var model = BuildPlotModel();
 
             // export to file using static methods
-            PngExporter.Export(model, outputToFile, width, height, OxyColors.LightGray);
-
-            PngExporter.Export(model, outputToFileBrush, width, height, Brushes.LightGray);
-
-            // export to stream using static methods
-            using (var stream = new MemoryStream())
-            {
-                PngExporter.Export(model, stream, width, height, OxyColors.LightGray, 96);
-                System.IO.File.WriteAllBytes(outputUsingMemStream, stream.ToArray());
-            }
-
-            using (var pngStream = PngExporter.ExportToStream(model, width, height, OxyColors.LightGray))
-            {
-                var fileStream = new System.IO.FileStream(outputExportFileStream, FileMode.Create);
-                pngStream.CopyTo(fileStream);
-                fileStream.Flush();
-            }
-
-            // export to bitmap using static methods
-            using (var bm = PngExporter.ExportToBitmap(model, width, height, OxyColors.LightGray))
-            {
-                bm.Save(outputExportBitmap);
-            }
-
-            using (var bm = PngExporter.ExportToBitmap(model, width, height, Brushes.LightGray))
-            {
-                bm.Save(outputExportBitmapBrush);
-            }
+            PngExporter.Export(model, outputToFile, width, height, background, resolution);
 
             // export using the instance methods
             using (var stream = new MemoryStream())
             {
-                var pngExporter = new PngExporter { Width = width, Height = height, Background = OxyColors.LightGray };
+                var pngExporter = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
                 pngExporter.Export(model, stream);
                 System.IO.File.WriteAllBytes(outputExportStreamOOP, stream.ToArray());
             }
 
-            var pngExporter2 = new PngExporter { Width = width, Height = height, Background = OxyColors.LightGray };
-            pngExporter2.ExportToFile(model, outputExportFileOOP);
+            var pngExporter2 = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
+            var bitmap = pngExporter2.ExportToBitmap(model);
+            bitmap.Save(outputExportFileOOP, System.Drawing.Imaging.ImageFormat.Png);
+            bitmap.Save(Path.ChangeExtension(outputExportFileOOP, ".gif"), System.Drawing.Imaging.ImageFormat.Gif);
         }
 
         private static IPlotModel BuildPlotModel()
         {
-            var rand = new Random();
+            var rand = new Random(21);
 
             var model = new PlotModel { Title = "Cake Type Popularity" };
 
             var cakePopularity = Enumerable.Range(1, 5).Select(i => rand.NextDouble()).ToArray();
             var sum = cakePopularity.Sum();
+            var barItems = cakePopularity.Select(cp => RandomBarItem(cp, sum)).ToArray();
             var barSeries = new BarSeries
             {
-                ItemsSource = cakePopularity.Select(cp => RandomBarItem(cp, sum)),
+                ItemsSource = barItems,
                 LabelPlacement = LabelPlacement.Base,
                 LabelFormatString = "{0:.00}%"
             };

--- a/Source/Examples/WPF/WpfExamples/Examples/ExportDemo/ShellViewModel.cs
+++ b/Source/Examples/WPF/WpfExamples/Examples/ExportDemo/ShellViewModel.cs
@@ -142,8 +142,8 @@ namespace ExportDemo
 
         public void CopyBitmap()
         {
-            var bitmap = PngExporter.ExportToBitmap(
-                this.Model, (int)this.Plot.ActualWidth, (int)this.Plot.ActualHeight, this.Model.Background);
+            var exporter = new PngExporter() { Background = this.Model.Background, Width = (int)this.Plot.ActualWidth, Height = (int)this.Plot.ActualHeight };
+            var bitmap = exporter.ExportToBitmap(this.Model);
             Clipboard.SetImage(bitmap);
         }
 

--- a/Source/OxyPlot.Core.Drawing/OxyPlot.Core.Drawing.csproj
+++ b/Source/OxyPlot.Core.Drawing/OxyPlot.Core.Drawing.csproj
@@ -10,6 +10,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/oxyplot/oxyplot.git</RepositoryUrl>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>

--- a/Source/OxyPlot.Core.Drawing/OxyPlotExtensions.cs
+++ b/Source/OxyPlot.Core.Drawing/OxyPlotExtensions.cs
@@ -29,6 +29,9 @@ namespace OxyPlot.Core.Drawing
 {
     using System.Drawing;
 
+    /// <summary>
+    /// Implements extension methods coverting to/from OxyPlot data structures.
+    /// </summary>
     public static class OxyPlotExtensions
     {
         /// <summary>

--- a/Source/OxyPlot.Core.Drawing/PngExporter.cs
+++ b/Source/OxyPlot.Core.Drawing/PngExporter.cs
@@ -48,107 +48,10 @@ namespace OxyPlot.Core.Drawing
         /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
         public static void Export(IPlotModel model, string fileName, int width, int height, OxyColor background, double resolution = 96)
         {
-            Brush brush = background.IsInvisible() ? null : background.ToBrush();
-            Export(model, fileName, width, height, brush, resolution);
-        }
-
-        /// <summary>
-        /// Exports the specified <see cref="PlotModel" /> to the specified file.
-        /// </summary>
-        /// <param name="model">The model.</param>
-        /// <param name="fileName">The file name.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        /// <param name="background">The background color (defaults to null).</param>
-        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
-        public static void Export(IPlotModel model, string fileName, int width, int height, Brush background = null, double resolution = 96)
-        {
-            using (var bm = ExportToBitmap(model, width, height, background, resolution))
+            var exporter = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
+            using (var stream = File.Create(fileName))
             {
-                bm.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
-            }
-        }
-
-        /// <summary>
-        /// Exports the specified <see cref="PlotModel" /> to the specified <see cref="Stream" />.
-        /// </summary>
-        /// <param name="model">The model.</param>
-        /// <param name="stream">The output stream.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        /// <param name="background">The background color.</param>
-        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
-        public static void Export(IPlotModel model, Stream stream, int width, int height, OxyColor background, double resolution = 96)
-        {
-            using (var bm = ExportToBitmap(model, width, height, background, resolution))
-            {
-                bm.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-            }
-        }
-
-        /// <summary>
-        /// Exports the specified <see cref="PlotModel" /> to a <see cref="MemoryStream" />.
-        /// </summary>
-        /// <param name="model">The model.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        /// <param name="background">The background color.</param>
-        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
-        /// <returns>A <see cref="Stream"/>.</returns>
-        public static Stream ExportToStream(IPlotModel model, int width, int height, OxyColor background, double resolution = 96)
-        {
-            var stream = new MemoryStream();
-            using (var bm = ExportToBitmap(model, width, height, background, resolution))
-            {
-                bm.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-                stream.Position = 0;
-                return stream;
-            }
-        }
-
-        /// <summary>
-        /// Exports the specified <see cref="PlotModel" /> to a <see cref="Bitmap" />.
-        /// </summary>
-        /// <param name="model">The model to export.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        /// <param name="background">The background color.</param>
-        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
-        /// <returns>A <see cref="Bitmap"/>.</returns>
-        public static Bitmap ExportToBitmap(IPlotModel model, int width, int height, OxyColor background, double resolution = 96)
-        {
-            Brush brush = background.IsInvisible() ? null : background.ToBrush();
-            return ExportToBitmap(model, width, height, brush, resolution);
-        }
-
-        /// <summary>
-        /// Exports the specified <see cref="PlotModel" /> to a <see cref="Bitmap" />.
-        /// </summary>
-        /// <param name="model">The model to export.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        /// <param name="background">The background color.</param>
-        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
-        /// <returns>A <see cref="Bitmap"/>.</returns>
-        public static Bitmap ExportToBitmap(IPlotModel model, int width, int height, Brush background, double resolution = 96)
-        {
-            var bm = new Bitmap(width, height);
-            using (var g = Graphics.FromImage(bm))
-            {
-                if (background != null)
-                {
-                    g.FillRectangle(background, 0, 0, width, height);
-                }
-
-                using (var rc = new GraphicsRenderContext(g) { RendersToScreen = false })
-                {
-                    model.Update(true);
-                    model.Render(rc, width, height);
-                }
-
-                // this throws an exception
-                // bm.SetResolution(resolution, resolution);
-                return bm;
+                exporter.Export(model, stream);
             }
         }
 
@@ -157,13 +60,41 @@ namespace OxyPlot.Core.Drawing
         /// </summary>
         /// <param name="model">The model.</param>
         /// <param name="stream">The output stream.</param>
-        public void Export(IPlotModel model, Stream stream) => Export(model, stream, this.Width, this.Height, this.Background, this.Resolution);
+        public void Export(IPlotModel model, Stream stream)
+        {
+            using (var bm = this.ExportToBitmap(model))
+            {
+                bm.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+            }
+        }
 
         /// <summary>
-        /// Exports the specified <see cref="PlotModel"/> to the specified file.
+        /// Exports the specified <see cref="PlotModel" /> to a <see cref="Bitmap" />.
         /// </summary>
-        /// <param name="model">The model.</param>
-        /// <param name="filename">The file name.</param>
-        public void ExportToFile(IPlotModel model, string filename) => Export(model, filename, this.Width, this.Height, this.Background, this.Resolution);
+        /// <param name="model">The model to export.</param>
+        /// <returns>A <see cref="Bitmap"/>.</returns>
+        public Bitmap ExportToBitmap(IPlotModel model)
+        {
+            var bm = new Bitmap(this.Width, this.Height);
+            using (var g = Graphics.FromImage(bm))
+            {
+                if (!this.Background.IsInvisible())
+                {
+                    g.FillRectangle(this.Background.ToBrush(), 0, 0, this.Width, this.Height);
+                }
+
+                using (var rc = new GraphicsRenderContext(g) { RendersToScreen = false })
+                {
+                    model.Update(true);
+                    model.Render(rc, this.Width, this.Height);
+                }
+
+                // this throws an exception
+                // bm.SetResolution(resolution, resolution);
+                // https://github.com/dotnet/corefx/blob/master/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs#L301
+
+                return bm;
+            }
+        }
     }
 }

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -451,7 +451,7 @@ namespace OxyPlot.WindowsForms
         /// Returns the ceiling of the given <see cref="SizeF"/> as a <see cref="SizeF"/>.
         /// </summary>
         /// <param name="size">The size.</param>
-        /// <returns>A <see cref="SizeF>"/></returns>
+        /// <returns>A <see cref="SizeF"/>.</returns>
         private static SizeF Ceiling(SizeF size)
         {
             var ceiling = Size.Ceiling(size);

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -10,6 +10,7 @@
         <PackageTags>plotting plot charting chart</PackageTags>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/oxyplot/oxyplot.git</RepositoryUrl>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>OxyPlot.WindowsForms.snk</AssemblyOriginatorKeyFile>

--- a/Source/OxyPlot.WindowsForms/PngExporter.cs
+++ b/Source/OxyPlot.WindowsForms/PngExporter.cs
@@ -42,7 +42,7 @@ namespace OxyPlot.WindowsForms
         /// <summary>
         /// Gets or sets the resolution (dpi) of the output image.
         /// </summary>
-        public int Resolution { get; set; }
+        public double Resolution { get; set; }
 
         /// <summary>
         /// Gets or sets the background color.
@@ -57,9 +57,10 @@ namespace OxyPlot.WindowsForms
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
         /// <param name="background">The background.</param>
-        public static void Export(IPlotModel model, string fileName, int width, int height, Brush background = null)
+        /// <param name="resolution">The resolution.</param>
+        public static void Export(IPlotModel model, string fileName, int width, int height, OxyColor background, double resolution = 96)
         {
-            var exporter = new PngExporter { Width = width, Height = height, Background = background.ToOxyColor() };
+            var exporter = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
             using (var stream = File.Create(fileName))
             {
                 exporter.Export(model, stream);
@@ -103,7 +104,7 @@ namespace OxyPlot.WindowsForms
                     model.Render(rc, this.Width, this.Height);
                 }
 
-                bm.SetResolution(this.Resolution, this.Resolution);
+                bm.SetResolution((float)this.Resolution, (float)this.Resolution);
                 return bm;
             }
         }

--- a/Source/OxyPlot.Wpf/PlotBase.Export.cs
+++ b/Source/OxyPlot.Wpf/PlotBase.Export.cs
@@ -79,7 +79,8 @@ namespace OxyPlot.Wpf
         public BitmapSource ToBitmap()
         {
             var background = this.ActualModel.Background.IsVisible() ? this.ActualModel.Background : this.Background.ToOxyColor();
-            return PngExporter.ExportToBitmap(this.ActualModel, (int)this.ActualWidth, (int)this.ActualHeight, background);
+            var exporter = new PngExporter() { Background = background, Width = (int)this.ActualWidth, Height = (int)this.ActualHeight };
+            return exporter.ExportToBitmap(this.ActualModel);
         }
     }
 }

--- a/Source/OxyPlot.Wpf/PlotBase.cs
+++ b/Source/OxyPlot.Wpf/PlotBase.cs
@@ -288,7 +288,7 @@ namespace OxyPlot.Wpf
             // it must be added last so it covers all other controls
             var mouseGrid = new Grid();
             mouseGrid.Background = Brushes.Transparent; // background must be set for hit test to work
-            this.grid.Children.Add(mouseGrid); 
+            this.grid.Children.Add(mouseGrid);
         }
 
         /// <summary>
@@ -474,8 +474,8 @@ namespace OxyPlot.Wpf
                 background = OxyColors.White;
             }
 
-            var bitmap = PngExporter.ExportToBitmap(
-                this.ActualModel, (int)this.ActualWidth, (int)this.ActualHeight, background);
+            var exporter = new PngExporter() { Background = background, Width = (int)this.ActualWidth, Height = (int)this.ActualHeight };
+            var bitmap = exporter.ExportToBitmap(this.ActualModel);
             Clipboard.SetImage(bitmap);
         }
 

--- a/Source/OxyPlot.Wpf/PngExporter.cs
+++ b/Source/OxyPlot.Wpf/PngExporter.cs
@@ -45,7 +45,7 @@ namespace OxyPlot.Wpf
         /// Gets or sets the resolution of the output image.
         /// </summary>
         /// <value>The resolution in dots per inch (dpi).</value>
-        public int Resolution { get; set; }
+        public double Resolution { get; set; }
 
         /// <summary>
         /// Gets or sets the background color.
@@ -61,47 +61,13 @@ namespace OxyPlot.Wpf
         /// <param name="height">The height of the output bitmap.</param>
         /// <param name="background">The background color. The default value is <c>null</c>.</param>
         /// <param name="resolution">The resolution (resolution). The default value is 96.</param>
-        public static void Export(IPlotModel model, string fileName, int width, int height, OxyColor background, int resolution = 96)
+        public static void Export(IPlotModel model, string fileName, int width, int height, OxyColor background, double resolution = 96)
         {
-            using (var s = File.Create(fileName))
+            var exporter = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
+            using (var stream = File.Create(fileName))
             {
-                Export(model, s, width, height, background, resolution);
+                exporter.Export(model, stream);
             }
-        }
-
-        /// <summary>
-        /// Exports the specified plot model to a stream.
-        /// </summary>
-        /// <param name="model">The model to export.</param>
-        /// <param name="stream">The stream.</param>
-        /// <param name="width">The width of the output bitmap.</param>
-        /// <param name="height">The height of the output bitmap.</param>
-        /// <param name="background">The background color. The default value is <c>null</c>.</param>
-        /// <param name="resolution">The resolution (resolution). The default value is 96.</param>
-        public static void Export(IPlotModel model, Stream stream, int width, int height, OxyColor background, int resolution = 96)
-        {
-            var exporter = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
-            exporter.Export(model, stream);
-        }
-
-        /// <summary>
-        /// Exports the specified plot model to a bitmap.
-        /// </summary>
-        /// <param name="model">The plot model.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        /// <param name="background">The background.</param>
-        /// <param name="resolution">The resolution (dpi).</param>
-        /// <returns>A bitmap.</returns>
-        public static BitmapSource ExportToBitmap(
-            IPlotModel model,
-            int width,
-            int height,
-            OxyColor background,
-            int resolution = 96)
-        {
-            var exporter = new PngExporter { Width = width, Height = height, Background = background, Resolution = resolution };
-            return exporter.ExportToBitmap(model);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1390.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change Core.Drawing and WPF PngExporters to be consistent with WindowsForms
- Remove methods with Brush parameter
- Change resolution parameter to double

@oxyplot/admins
@VisualMelon 