### PR TITLE
Dispose background brush in OxyPlot.Core.Drawing PngExporter (#1392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to this project will be documented in this file.
 - Fixed rendering issues with MagnitudeAxisFullPlotArea (#1364)
 - OxyPlot.Core.Drawing PngExporter Export to Stream background (#1382)
 - Fixed Winforms clipping last line of rendered text (#1124, #1385)
+- Dispose background brush in OxyPlot.Core.Drawing PngExporter (#1392)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/OxyPlot.Core.Drawing/PngExporter.cs
+++ b/Source/OxyPlot.Core.Drawing/PngExporter.cs
@@ -80,7 +80,10 @@ namespace OxyPlot.Core.Drawing
             {
                 if (!this.Background.IsInvisible())
                 {
-                    g.FillRectangle(this.Background.ToBrush(), 0, 0, this.Width, this.Height);
+                    using (var brush = this.Background.ToBrush())
+                    {
+                        g.FillRectangle(brush, 0, 0, this.Width, this.Height);
+                    }
                 }
 
                 using (var rc = new GraphicsRenderContext(g) { RendersToScreen = false })


### PR DESCRIPTION
Fixes #1392 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Dispose the brush used to render the background in the `PngExporter` for `OxyPlot.Core.Drawing`.

Winforms version already does this. Not applicable to any other PNG exporters.

@oxyplot/admins
