### PR TITLE
Fix Legend font size is not affected by DefaultFontSize (#1396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to this project will be documented in this file.
 - OxyPlot.Core.Drawing PngExporter background when exporting to stream (#1382)
 - Windows Forms clipping last line of rendered text (#1124, #1385)
 - Dispose background brush in OxyPlot.Core.Drawing PngExporter (#1392)
+- Legend font size is not affected by DefaultFontSize (#1396)
 
 ## [1.0.0] - 2016-09-11
 ### Added

--- a/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
@@ -156,6 +156,16 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Legend with DefaultFontSize")]
+        public static PlotModel LegendDefaultFontSize()
+        {
+            var model = CreateModel();
+            model.LegendFontSize = double.NaN;
+            model.LegendTitle = "Title in DefaultFontSize";
+            model.DefaultFontSize = 20;
+            return model;
+        }
+
         private static PlotModel CreateModel(int n = 20)
         {
             var model = new PlotModel { Title = "LineSeries", LegendBackground = OxyColor.FromAColor(200, OxyColors.White), LegendBorder = OxyColors.Black };

--- a/Source/OxyPlot/PlotModel/PlotModel.Legends.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Legends.cs
@@ -207,6 +207,7 @@ namespace OxyPlot
 
             double y = rect.Top;
             var maxsize = new OxySize(Math.Max(rect.Width - this.LegendSymbolLength - this.LegendSymbolMargin, 0), rect.Height);
+            var actualLegendFontSize = double.IsNaN(this.LegendFontSize) ? this.DefaultFontSize : this.LegendFontSize;
 
             rc.SetToolTip(s.ToolTip);
             var textSize = rc.DrawMathText(
@@ -214,7 +215,7 @@ namespace OxyPlot
                 s.Title,
                 this.LegendTextColor.GetActualColor(this.TextColor),
                 this.LegendFont ?? this.DefaultFont,
-                this.LegendFontSize,
+                actualLegendFontSize,
                 this.LegendFontWeight,
                 0,
                 actualItemAlignment,
@@ -289,6 +290,9 @@ namespace OxyPlot
 
             var size = new OxySize();
 
+            var actualLegendFontSize = double.IsNaN(this.LegendFontSize) ? this.DefaultFontSize : this.LegendFontSize;
+            var actualLegendTitleFontSize = double.IsNaN(this.LegendTitleFontSize) ? actualLegendFontSize : this.LegendTitleFontSize;
+
             // Render/measure the legend title
             if (!string.IsNullOrEmpty(this.LegendTitle))
             {
@@ -298,7 +302,7 @@ namespace OxyPlot
                     titleSize = rc.MeasureMathText(
                         this.LegendTitle,
                         this.LegendTitleFont ?? this.DefaultFont,
-                        this.LegendTitleFontSize,
+                        actualLegendTitleFontSize,
                         this.LegendTitleFontWeight);
                 }
                 else
@@ -308,7 +312,7 @@ namespace OxyPlot
                         this.LegendTitle,
                         this.LegendTitleColor.GetActualColor(this.TextColor),
                         this.LegendTitleFont ?? this.DefaultFont,
-                        this.LegendTitleFontSize,
+                        actualLegendTitleFontSize,
                         this.LegendTitleFontWeight,
                         0,
                         HorizontalAlignment.Left,
@@ -372,7 +376,7 @@ namespace OxyPlot
                     continue;
                 }
 
-                var textSize = rc.MeasureMathText(s.Title, this.LegendFont ?? this.DefaultFont, this.LegendFontSize, this.LegendFontWeight);
+                var textSize = rc.MeasureMathText(s.Title, this.LegendFont ?? this.DefaultFont, actualLegendFontSize, this.LegendFontWeight);
                 double itemWidth = this.LegendSymbolLength + this.LegendSymbolMargin + textSize.Width;
                 double itemHeight = textSize.Height;
 

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -251,10 +251,10 @@ namespace OxyPlot
 
             this.IsLegendVisible = true;
             this.LegendTitleFont = null;
-            this.LegendTitleFontSize = 12;
+            this.LegendTitleFontSize = double.NaN;
             this.LegendTitleFontWeight = FontWeights.Bold;
             this.LegendFont = null;
-            this.LegendFontSize = 12;
+            this.LegendFontSize = double.NaN;
             this.LegendFontWeight = FontWeights.Normal;
             this.LegendSymbolLength = 16;
             this.LegendSymbolMargin = 4;


### PR DESCRIPTION
Fixes #1396.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use the `DefaultFontSize` for Legend if `LegendFontSize` is not set

@oxyplot/admins
