### PR TITLE
Check for empty lists in RenderingExtensions (#1410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Copy to text report Ctrl+Alt+R (#1403)
 
+### Fixed
+- Exception when rendering polygon with no points (#1410)
+
 ## [2.0.0] - 2019-10-19
 ### Added 
 - WindowsForms and Wpf support .NET Core 3.0 (#1331)

--- a/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
+++ b/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
@@ -350,6 +350,12 @@ namespace OxyPlot
             LineJoin lineJoin = LineJoin.Miter,
             bool aliased = false)
         {
+            var n = points.Count;
+            if (n == 0)
+            {
+                return;
+            }
+
             if (lineStyle == LineStyle.None)
             {
                 return;
@@ -1111,9 +1117,14 @@ namespace OxyPlot
         /// <remarks>Points that are closer than the specified distance will not be included in the output buffer.</remarks>
         private static void ReducePoints(IList<ScreenPoint> points, double minDistSquared, List<ScreenPoint> outputBuffer)
         {
+            var n = points.Count;
+            if (n == 0)
+            {
+                return;
+            }
+
             outputBuffer.Add(points[0]);
             int lastPointIndex = 0;
-            var n = points.Count;
             for (int i = 1; i < n; i++)
             {
                 var sc1 = points[i];


### PR DESCRIPTION
Fixes #1410 .

### Checklist

- [ ] I have included examples or tests (ExampleLibrary, TwoColorAreaSeries/Temperature ver3)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add checks to `RenderingExtensions.DrawClippedPolygon` and `RenderingExtensions.ReducePoints` to exit early if no points are supplied.

Either addition would have address the `IndexOutOfRange` exception, but both seem reasonable additions given the similar `DrawClippedLine` method. The only behaviour change should be to produce no output and continue when previously their would have been an exception. Based on `DrawClippedLine`, attempting to render nothing should not be treated as exceptional.

@oxyplot/admins