### PR TITLE
Remove OxyThickness Width and Height properties (#1429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Copy to text report Ctrl+Alt+R (#1403)
 - ColumnSeries - functionality is replaced by transposed BarSeries (#1402)
 - Remove exporter Background properties (#1409)
+- Remove OxyThickness Width and Height properties (#1429)
 
 ### Fixed
 - Legend font size is not affected by DefaultFontSize (#1396)

--- a/Source/OxyPlot/Rendering/OxyThickness.cs
+++ b/Source/OxyPlot/Rendering/OxyThickness.cs
@@ -73,17 +73,6 @@ namespace OxyPlot
         }
 
         /// <summary>
-        /// Gets the height.
-        /// </summary>
-        public double Height
-        {
-            get
-            {
-                return this.Bottom - this.Top;
-            }
-        }
-
-        /// <summary>
         /// Gets the left thickness.
         /// </summary>
         /// <value>The left thickness.</value>
@@ -120,17 +109,6 @@ namespace OxyPlot
         }
 
         /// <summary>
-        /// Gets the width.
-        /// </summary>
-        public double Width
-        {
-            get
-            {
-                return this.Right - this.Left;
-            }
-        }
-
-        /// <summary>
         /// Returns C# code that generates this instance.
         /// </summary>
         /// <returns>The to code.</returns>
@@ -162,7 +140,7 @@ namespace OxyPlot
         /// <returns><c>true</c> if the value of the <paramref name="other" /> parameter is the same as the value of this instance; otherwise, <c>false</c>.</returns>
         public bool Equals(OxyThickness other)
         {
-            return this.Left.Equals(other.Left) && this.Top.Equals(other.Top) && this.Width.Equals(other.Width) && this.Height.Equals(other.Height);
+            return this.Left.Equals(other.Left) && this.Top.Equals(other.Top) && this.Right.Equals(other.Right) && this.Bottom.Equals(other.Bottom);
         }
     }
 }


### PR DESCRIPTION
Fixes #1429 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove the `Width` and `Height` properties of `OxyThickness`.
- Change `OxyThickness.Equals` to use to `Right` and `Bottom` instead of `Width` and `Height`.

@oxyplot/admins
