### PR TITLE
correct OxyPlot.WindowsForms description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Legend font size is not affected by DefaultFontSize (#1396)
 - Exception when rendering polygon with no points (#1410)
 - ErrorBarSeries, IntervalBarSeries and TornadoBarSeries work correctly in transposed mode (#1402)
+- OxyPlot.WindowsForms package description (#1457)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -97,6 +97,7 @@ Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
 Sarah Müller <sy-mueller@gmx-topmail.de>
 Senen Fernandez <senenf@gmail.com>
+Scott W Harden <swharden@gmail.com>
 Shankar Mathiah Nanjundan <shankar.ooty@hotmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>
 Soarc <gor.rustamyan@gmail.com>

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
-        <Description>OxyPlot is a plotting library for .NET. This is the portable core library that is referenced by the platform-specific OxyPlot packages.</Description>
+        <Description>OxyPlot is a plotting library for .NET. This package targets Windows Forms applications.</Description>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://oxyplot.github.io/</PackageProjectUrl>


### PR DESCRIPTION
The original description accidentally described OxyPlot.Core.
This new description matches the style of the OxyPlot.Wpf description.

Fixes #1457 