### PR TITLE
Fix #1455 Custom tracker strings can cause exception in histogram chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Exception when rendering polygon with no points (#1410)
 - ErrorBarSeries, IntervalBarSeries and TornadoBarSeries work correctly in transposed mode (#1402)
 - OxyPlot.WindowsForms package description (#1457)
+- Custom tracker strings can cause exception in histogram chart (#1455)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -85,6 +85,32 @@ namespace ExampleLibrary
             return CreateIndividualBinColors();
         }
 
+        [Example("Custom Item Mapping")]
+        public static PlotModel CustomItemMapping()
+        {
+            var model = new PlotModel { Title = "Custom Item Mapping" };
+
+            var s = new HistogramSeries { Mapping = obj => (HistogramItem)obj, TrackerFormatString = "{Description}"};
+            s.Items.Add(new CustomHistogramItem(1, 2, 4, 4, "Item 1"));
+            s.Items.Add(new CustomHistogramItem(2, 3, -4, 4, "Item 2"));
+            s.Items.Add(new CustomHistogramItem(3, 4, 2, 2, "Item 3"));
+            s.Items.Add(new CustomHistogramItem(4, 5, -2, 2, "Item 4"));
+            model.Series.Add(s);
+
+            return model;
+        }
+
+        public class CustomHistogramItem : HistogramItem
+        {
+            public CustomHistogramItem(double rangeStart, double rangeEnd, double area, int count, string description)
+                : base(rangeStart, rangeEnd, area, count)
+            {
+                this.Description = description;
+            }
+
+            public string Description { get; }
+        }
+
         public static PlotModel CreateExponentialDistribution(double mean = 1, int n = 10000)
         {
             var model = new PlotModel { Title = "Exponential Distribution", Subtitle = "Uniformly distributed bins (" + n + " samples)" };


### PR DESCRIPTION
Fixes #1455 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix the issue
- Remove some unnecessary code from HistogramSeries, most likely copy&paste remainders from initial implementation

@oxyplot/admins
