### PR TITLE
Support null, #FFF, auto and none in OxyColor.Parse

### DIFF
--- a/Source/OxyPlot.Tests/Foundation/OxyColorTests.cs
+++ b/Source/OxyPlot.Tests/Foundation/OxyColorTests.cs
@@ -22,6 +22,12 @@ namespace OxyPlot.Tests
             Assert.AreEqual(OxyColors.Red, OxyColor.Parse("#FFFF0000"));
             Assert.AreEqual(OxyColors.Red, OxyColor.Parse("255,0,0"));
             Assert.AreEqual(OxyColors.Red, OxyColor.Parse("255,255,0,0"));
+            Assert.AreEqual(OxyColors.Undefined, OxyColor.Parse(null));
+            Assert.AreEqual(OxyColors.Undefined, OxyColor.Parse("None"));
+            Assert.AreEqual(OxyColors.Automatic, OxyColor.Parse("Auto"));
+            Assert.AreEqual(OxyColors.Undefined, OxyColor.Parse("#00000000"));
+            Assert.AreEqual(OxyColors.Automatic, OxyColor.Parse("#00000001"));
+            Assert.AreEqual(OxyColors.White, OxyColor.Parse("#FFF"));
         }
 
         [Test]
@@ -113,6 +119,8 @@ namespace OxyPlot.Tests
         public new void ToString()
         {
             Assert.AreEqual("#ffff0000", OxyColors.Red.ToString());
+            Assert.AreEqual("#00000001", OxyColors.Automatic.ToString());
+            Assert.AreEqual("#00000000", OxyColors.Undefined.ToString());
         }
 
         [Test]

--- a/Source/OxyPlot/Rendering/OxyColor.cs
+++ b/Source/OxyPlot/Rendering/OxyColor.cs
@@ -108,10 +108,26 @@ namespace OxyPlot
         /// <exception cref="System.FormatException">Invalid format.</exception>
         public static OxyColor Parse(string value)
         {
+            if (value == null || string.Equals(value, "none", StringComparison.OrdinalIgnoreCase))
+            {
+                return OxyColors.Undefined;
+            }
+
+            if (string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase))
+            {
+                return OxyColors.Automatic;
+            }
+
             value = value.Trim();
             if (value.StartsWith("#"))
             {
                 value = value.Trim('#');
+                if (value.Length == 3)
+                {
+                    // replicate digits
+                    value = string.Format("{0}{0}{1}{1}{2}{2}", value[0], value[1], value[2]);
+                }
+
                 var u = uint.Parse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
                 if (value.Length < 8)
                 {
@@ -461,7 +477,7 @@ namespace OxyPlot
         {
             return this.IsAutomatic() ? defaultColor : this;
         }
- 
+
         /// <summary>
         /// Returns C# code that generates this instance.
         /// </summary>


### PR DESCRIPTION
Fixes #1472 .

### Checklist

- [x] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
