### PR TITLE
Fix bug in HistogramHelpers.Collect when using out-of-order bin breaks (#1476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - Support for transposed (X and Y axis switched) plots with XYAxisSeries (#1334)
 - Color property on HistogramItem (#1347)
 - Count property on HistogramSeries (#1347)
+- Bug in HistogramHelpers.Collect when using out-of-order bin breaks (#1476)
 
 ### Changed
 - OxyPlot.Core changed to target netstandard 1.0 and net45 (#946, #1147)

--- a/Source/OxyPlot.Tests/Utilities/HistogramHelperTests.cs
+++ b/Source/OxyPlot.Tests/Utilities/HistogramHelperTests.cs
@@ -190,8 +190,24 @@ namespace OxyPlot.Tests
 
             foreach (var binningMode in new[] { BinningOutlierMode.CountOutliers, BinningOutlierMode.IgnoreOutliers })
             {
-                var binningOptions = new BinningOptions(BinningOutlierMode.IgnoreOutliers, BinningIntervalType.InclusiveLowerBound, BinningExtremeValueMode.ExcludeExtremeValues);
+                var binningOptions = new BinningOptions(binningMode, BinningIntervalType.InclusiveLowerBound, BinningExtremeValueMode.ExcludeExtremeValues);
                 TestCollect(emptySample, breaks, expectedCounts, expectedAreas, binningOptions);
+            }
+        }
+
+        [Test]
+        public void Collect_OutOfOrderBinBreaks()
+        {
+            // binBreaks should be ordered by Collect
+            var sample = new double[] { 2, 3, 9, 8, 7 };
+            var outOfOrderBreaks = new double[] { 0.0, 10.0, 5.0, 15.0 };
+            var expectedCounts = new int[] { 2, 3, 0 };
+            var expectedAreas = new double[] { 0.4, 0.6, 0.0 };
+
+            foreach (var binningMode in new[] { BinningOutlierMode.CountOutliers, BinningOutlierMode.IgnoreOutliers })
+            {
+                var binningOptions = new BinningOptions(binningMode, BinningIntervalType.InclusiveLowerBound, BinningExtremeValueMode.ExcludeExtremeValues);
+                TestCollect(sample, outOfOrderBreaks, expectedCounts, expectedAreas, binningOptions);
             }
         }
 
@@ -207,7 +223,7 @@ namespace OxyPlot.Tests
 
             foreach (var binningMode in new[] { BinningOutlierMode.CountOutliers, BinningOutlierMode.IgnoreOutliers })
             {
-                var binningOptions = new BinningOptions(BinningOutlierMode.IgnoreOutliers, BinningIntervalType.InclusiveLowerBound, BinningExtremeValueMode.ExcludeExtremeValues);
+                var binningOptions = new BinningOptions(binningMode, BinningIntervalType.InclusiveLowerBound, BinningExtremeValueMode.ExcludeExtremeValues);
                 TestCollect(outlierSamples, breaks, expectedCounts, expectedAreas, binningOptions);
             }
         }

--- a/Source/OxyPlot/Utilities/HistogramHelpers.cs
+++ b/Source/OxyPlot/Utilities/HistogramHelpers.cs
@@ -15,7 +15,6 @@ namespace OxyPlot
 
     using OxyPlot.Series;
 
-#if !NET40
     /// <summary>
     /// Provides methods to collect data samples into bins for use with a <see cref="HistogramSeries" />.
     /// </summary>
@@ -27,8 +26,8 @@ namespace OxyPlot
         /// <param name="start">The inclusive lower-bound of the first bin.</param>
         /// <param name="end">The exclusive upper-bound of the last bin, which must be strictly greater than <paramred name="start" />.</param>
         /// <param name="binCount">The number of bins to create.</param>
-        /// <returns>An <see cref="IReadOnlyList{T}"/> containing the breaks between bins of uniform size.</returns>
-        public static IReadOnlyList<double> CreateUniformBins(double start, double end, int binCount)
+        /// <returns>An <see cref="List{T}"/> containing the breaks between bins of uniform size.</returns>
+        public static List<double> CreateUniformBins(double start, double end, int binCount)
         {
             if (binCount < 1)
             {
@@ -73,7 +72,7 @@ namespace OxyPlot
         /// <param name="binBreaks">The start and end values for the bins.</param>
         /// <param name="binningOptions">The binning options to use.</param>
         /// <returns>A list of <see cref="HistogramItem" /> corresponding to the generated bins with areas computed from the proportion of samples placed within.</returns>
-        public static IList<HistogramItem> Collect(IEnumerable<double> samples, IReadOnlyList<double> binBreaks, BinningOptions binningOptions)
+        public static IList<HistogramItem> Collect(IEnumerable<double> samples, IEnumerable<double> binBreaks, BinningOptions binningOptions)
         {
             if (samples is null)
             {
@@ -104,7 +103,7 @@ namespace OxyPlot
             }
 
             // count and assign samples to bins
-            int[] counts = new int[binBreaks.Count - 1];
+            int[] counts = new int[orderedBreaks.Count - 1];
             long total = 0;
 
             foreach (double sample in samples)
@@ -191,14 +190,13 @@ namespace OxyPlot
             // create actual items
             List<HistogramItem> items = new List<HistogramItem>(counts.Length);
 
-            for (int i = 0; i < binBreaks.Count - 1; i++)
+            for (int i = 0; i < orderedBreaks.Count - 1; i++)
             {
                 int count = counts[i];
-                items.Add(new HistogramItem(binBreaks[i], binBreaks[i + 1], (double)count / total, count));
+                items.Add(new HistogramItem(orderedBreaks[i], orderedBreaks[i + 1], (double)count / total, count));
             }
 
             return items;
         }
     }
-#endif
 }


### PR DESCRIPTION
Fixes #1476.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix `HistogramHelpers.Collect`, so that the output items are constructed from the internally ordered list of bin breaks
- Add a test for this condition
- Minor fixes to similar tests so that they cover a wider range of inputs as intended

In addition, this commit makes the following change to allow access to the `HistogramHelper` methods from .NET Framework 4.0
- Change the type of `binBreaks` to `IEnumerable<double>` (`IReadOnlyList<T>` is not available in .NET Framework 4.0)
- Change the return type of `Collect` to `List<HistogramItem`> (`IReadOnlyList<T>` is not available in .NET Framework 4.0)
- Remove compiler directories which remove the relevant APIs in .NET Framework 4.0 builds

@oxyplot/admins
