### PR TITLE
Qualify partial class modifiers at every declaration (#1465)

### DIFF
--- a/Source/OxyPlot.Wpf/PlotBase.Events.cs
+++ b/Source/OxyPlot.Wpf/PlotBase.Events.cs
@@ -15,7 +15,7 @@ namespace OxyPlot.Wpf
     /// <summary>
     /// Represents a control that displays a <see cref="PlotModel" />.
     /// </summary>
-    public partial class PlotBase
+    public abstract partial class PlotBase
     {
         /// <summary>
         /// Called before the <see cref="E:System.Windows.UIElement.KeyDown" /> event occurs.

--- a/Source/OxyPlot.Wpf/PlotBase.Export.cs
+++ b/Source/OxyPlot.Wpf/PlotBase.Export.cs
@@ -14,7 +14,7 @@ namespace OxyPlot.Wpf
     /// <summary>
     /// Represents a control that displays a <see cref="PlotModel" />.
     /// </summary>
-    public partial class PlotBase
+    public abstract partial class PlotBase
     {
         /// <summary>
         /// Saves the PlotView as a bitmap.

--- a/Source/OxyPlot.Wpf/PlotBase.Properties.cs
+++ b/Source/OxyPlot.Wpf/PlotBase.Properties.cs
@@ -16,7 +16,7 @@ namespace OxyPlot.Wpf
     /// <summary>
     /// Represents a control that displays a <see cref="PlotModel" />.
     /// </summary>
-    public partial class PlotBase
+    public abstract partial class PlotBase
     {
         /// <summary>
         /// Identifies the <see cref="DefaultTrackerTemplate"/> dependency property.

--- a/Source/OxyPlot/Graphics/Model.MouseEvents.cs
+++ b/Source/OxyPlot/Graphics/Model.MouseEvents.cs
@@ -14,7 +14,7 @@ namespace OxyPlot
     /// <summary>
     /// Provides an abstract base class for graphics models.
     /// </summary>
-    public partial class Model
+    public abstract partial class Model
     {
         /// <summary>
         /// The mouse hit tolerance.


### PR DESCRIPTION
Fixes #1465 .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Qualify partial class modifiers at every declaration site for the WPF `PlotBase` and Core `Model`
- Does not modify 'Designer.cs' files for any forms

@oxyplot/admins
