### PR TITLE
Upgrade to .NET Core 3.1 (#1488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Moved reporting functionality to oxyplot-reporting repository (#1403)
 - Change IPlotModel.Render to take an OxyRect (#1425)
 - Merge UIElement and SelectableElement into Element (#1426)
+- Upgrade to .NET Core 3.1 (#1488)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/Examples/ExampleGenerator/ExampleGenerator.csproj
+++ b/Source/Examples/ExampleGenerator/ExampleGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <!--<UseWindowsForms>true</UseWindowsForms>-->
         <OutputType>Exe</OutputType>
         <ApplicationIcon />

--- a/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.WPF.csproj
+++ b/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <UseWPF>true</UseWPF>
         <OutputType>WinExe</OutputType>
     </PropertyGroup>

--- a/Source/Examples/WPF/SimpleDemo/SimpleDemo.csproj
+++ b/Source/Examples/WPF/SimpleDemo/SimpleDemo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.0;net45;net40</TargetFrameworks>
+      <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
       <UseWPF>true</UseWPF>
       <OutputType>WinExe</OutputType>
   </PropertyGroup>

--- a/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
+++ b/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
       <UseWPF>true</UseWPF>
       <UseWindowsForms>true</UseWindowsForms>
       <OutputType>WinExe</OutputType>

--- a/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
+++ b/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>

--- a/Source/Examples/WindowsForms/WindowsFormsDemo/WindowsFormsDemo.csproj
+++ b/Source/Examples/WindowsForms/WindowsFormsDemo/WindowsFormsDemo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
       <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.0;net45;net40</TargetFrameworks>
+        <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <Description>OxyPlot is a plotting library for .NET. This package targets Windows Forms applications.</Description>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>

--- a/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
+++ b/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Fixes #1488.
Also fixes #1483.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Update all `netcoreapp3.0` targets to `netcoreapp3.1`
- Change target order so `net4xx` targets are listed before `netcoreapp3.x` targets

Did I miss anything?

@oxyplot/admins
