### PR TITLE
Fix NullReference in VolumeSeries if no data in Items list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Exception when rendering polygon with no points (#1410)
 - Custom tracker strings can cause exception in histogram chart (#1455)
 - OxyPlot.WindowsForms package description (#1457)
+- NullReference in VolumeSeries if no data in Items list (#1491)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -128,3 +128,4 @@ Markus Ebner
 Duncan Robertson <duncanjacobrobertson@gmail.com>
 LauXjpn <laucomm@gmail.com>
 R. Usamentiaga
+Dmytro Shaurin

--- a/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
@@ -365,7 +365,7 @@ namespace OxyPlot.Series
         /// <returns>A TrackerHitResult for the current hit.</returns>
         public override TrackerHitResult GetNearestPoint(ScreenPoint point, bool interpolate)
         {
-            if (this.XAxis == null || this.YAxis == null || interpolate || this.data.Count == 0)
+            if (this.XAxis == null || this.YAxis == null || interpolate || this.data == null || this.data.Count == 0)
             {
                 return null;
             }
@@ -422,6 +422,11 @@ namespace OxyPlot.Series
         {
             base.UpdateData();
             this.winIndex = 0;
+
+            if (this.data == null || this.data.Count == 0)
+            {
+                return;
+            }
 
             // determine minimum X gap between successive points
             var items = this.data;


### PR DESCRIPTION
Fixes #1491 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add a check for item == null in VolumeSeries.GetNearestPoint and VolumeSeries.UpdateData methods

@oxyplot/admins
