### PR TITLE
Remove WpfExamples dependency on OxyPlot.Pdf (#1499)

### DIFF
--- a/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
+++ b/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
@@ -6,7 +6,6 @@
       <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OxyPlot.Pdf\OxyPlot.Pdf.csproj" />
     <ProjectReference Include="..\..\..\OxyPlot.Wpf\OxyPlot.Wpf.csproj" />
     <ProjectReference Include="..\..\..\OxyPlot\OxyPlot.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #1499

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove useless and unused project reference in `WpfExamples` to `Oxyplot.Pdf` which was causing nuget to complain (#1499)

The dependency was unused (uses the Pdf support in `Oxyplot.Core` instead), and could not be used anyway, because the examples are compiled for .NET Core 3.1, but `OxyPlot.Pdf` only targets .NET Framework because PdfSharp only support .NET Framework (though there are efforts to port it to .NET Standard, e.g. https://github.com/ststeiger/PdfSharpCore and https://github.com/Didstopia/PDFSharp)

@oxyplot/admins
