### PR TITLE
Change github Workflow to use .NET Core 3.1.201

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.201
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/Source/Examples/WPF/WpfExamples/app.config
+++ b/Source/Examples/WPF/WpfExamples/app.config
@@ -1,3 +1,0 @@
-<?xml version="1.0"?>
-<configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>


### PR DESCRIPTION
### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change the github workflows .NET Core SDK version to 3.1.201 so that it doesn't fail
- Remove unused file `WpfSamples/app.config`

@oxyplot/admins
