### PR TITLE
Fix wrong index from FindWindowStartIndex

### DIFF
--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -786,6 +786,7 @@ namespace OxyPlot.Series
                     {
                         return end;
                     }
+                    lastguess = curGuess;
                 }
                 else
                 {


### PR DESCRIPTION
Fix an error where FindWindowStartIndex in OxyPlot.Series.XYAxisSeries would return the wrong value.

This error made it so that parts of the graph were sometimes not drawn, since the index returned from FindWindowStartIndex could be too large and therefore cause the drawing of the graph to start in the middle of the window instead of at the first visible part.

I'm not a developer for Oxyplot, but thought I'd make this pull request anyway, since it's a very non-controversial fix.
