### PR TITLE
Fix PerformanceTests to use EdgeMode

### DIFF
--- a/Source/Examples/PerformanceTest/EmptyRenderContext.cs
+++ b/Source/Examples/PerformanceTest/EmptyRenderContext.cs
@@ -18,253 +18,83 @@ namespace PerformanceTest
     /// </summary>
     public class EmptyRenderContext : IRenderContext
     {
-        /// <summary>
-        /// Gets a value indicating whether the context renders to screen.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if the context renders to screen; otherwise, <c>false</c>.
-        /// </value>
-        public bool RendersToScreen
-        {
-            get
-            {
-                return true;
-            }
-        }
+        /// <inheritdoc/>
+        public bool RendersToScreen { get; set; } = true;
 
-        /// <summary>
-        /// Draws an ellipse.
-        /// </summary>
-        /// <param name="rect">The rectangle.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the ellipse will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the ellipse will not be stroked.</param>
-        /// <param name="thickness">The thickness (in device independent units, 1/96 inch).</param>
-        public void DrawEllipse(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness = 1)
+        /// <inheritdoc/>
+        public void CleanUp()
         {
         }
 
-        /// <summary>
-        /// Draws a collection of ellipses, where all have the same stroke and fill.
-        /// This performs better than calling DrawEllipse multiple times.
-        /// </summary>
-        /// <param name="rectangles">The rectangles.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the ellipses will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the ellipses will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        public void DrawEllipses(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness = 1)
+        /// <inheritdoc/>
+        public void DrawEllipse(OxyRect extents, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
         }
 
-        /// <summary>
-        /// Draws a polyline.
-        /// </summary>
-        /// <param name="points">The points.</param>
-        /// <param name="stroke">The stroke color.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="dashArray">The dash array (in device independent units, 1/96 inch). Use <c>null</c> to get a solid line.</param>
-        /// <param name="lineJoin">The line join type.</param>
-        /// <param name="aliased">if set to <c>true</c> the shape will be aliased.</param>
-        public void DrawLine(
-            IList<ScreenPoint> points,
-            OxyColor stroke,
-            double thickness = 1,
-            double[] dashArray = null,
-            LineJoin lineJoin = LineJoin.Miter,
-            bool aliased = false)
+        /// <inheritdoc/>
+        public void DrawEllipses(IList<OxyRect> extents, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
         }
 
-        /// <summary>
-        /// Draws line segments defined by points (0,1) (2,3) (4,5) etc.
-        /// This should have better performance than calling DrawLine for each segment.
-        /// </summary>
-        /// <param name="points">The points.</param>
-        /// <param name="stroke">The stroke color.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="dashArray">The dash array (in device independent units, 1/96 inch).</param>
-        /// <param name="lineJoin">The line join type.</param>
-        /// <param name="aliased">if set to <c>true</c> the shape will be aliased.</param>
-        public void DrawLineSegments(
-            IList<ScreenPoint> points,
-            OxyColor stroke,
-            double thickness = 1,
-            double[] dashArray = null,
-            LineJoin lineJoin = LineJoin.Miter,
-            bool aliased = false)
+        /// <inheritdoc/>
+        public void DrawImage(OxyImage source, double srcX, double srcY, double srcWidth, double srcHeight, double destX, double destY, double destWidth, double destHeight, double opacity, bool interpolate)
         {
         }
 
-        /// <summary>
-        /// Draws a polygon.
-        /// </summary>
-        /// <param name="points">The points.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the polygon will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the polygon will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="dashArray">The dash array (in device independent units, 1/96 inch).</param>
-        /// <param name="lineJoin">The line join type.</param>
-        /// <param name="aliased">If set to <c>true</c> the polygon will be aliased.</param>
-        public void DrawPolygon(
-            IList<ScreenPoint> points,
-            OxyColor fill,
-            OxyColor stroke,
-            double thickness = 1,
-            double[] dashArray = null,
-            LineJoin lineJoin = LineJoin.Miter,
-            bool aliased = false)
+        /// <inheritdoc/>
+        public void DrawLine(IList<ScreenPoint> points, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray = null, LineJoin lineJoin = LineJoin.Miter)
         {
         }
 
-        /// <summary>
-        /// Draws a collection of polygons, where all polygons have the same stroke and fill.
-        /// This performs better than calling DrawPolygon multiple times.
-        /// </summary>
-        /// <param name="polygons">The polygons.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the polygons will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the polygons will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="dashArray">The dash array (in device independent units, 1/96 inch).</param>
-        /// <param name="lineJoin">The line join type.</param>
-        /// <param name="aliased">if set to <c>true</c> the shape will be aliased.</param>
-        public void DrawPolygons(
-            IList<IList<ScreenPoint>> polygons,
-            OxyColor fill,
-            OxyColor stroke,
-            double thickness = 1,
-            double[] dashArray = null,
-            LineJoin lineJoin = LineJoin.Miter,
-            bool aliased = false)
+        /// <inheritdoc/>
+        public void DrawLineSegments(IList<ScreenPoint> points, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray = null, LineJoin lineJoin = LineJoin.Miter)
         {
         }
 
-        /// <summary>
-        /// Draws a rectangle.
-        /// </summary>
-        /// <param name="rect">The rectangle.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the rectangle will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the rectangle will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        public void DrawRectangle(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness = 1)
+        /// <inheritdoc/>
+        public void DrawPolygon(IList<ScreenPoint> points, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray = null, LineJoin lineJoin = LineJoin.Miter)
         {
         }
 
-        /// <summary>
-        /// Draws a collection of rectangles, where all have the same stroke and fill.
-        /// This performs better than calling DrawRectangle multiple times.
-        /// </summary>
-        /// <param name="rectangles">The rectangles.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        public void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness = 1)
+        /// <inheritdoc/>
+        public void DrawPolygons(IList<IList<ScreenPoint>> polygons, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray = null, LineJoin lineJoin = LineJoin.Miter)
         {
         }
 
-        /// <summary>
-        /// Draws text.
-        /// </summary>
-        /// <param name="p">The position.</param>
-        /// <param name="text">The text.</param>
-        /// <param name="fill">The text color.</param>
-        /// <param name="fontFamily">The font family.</param>
-        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
-        /// <param name="fontWeight">The font weight.</param>
-        /// <param name="rotate">The rotation angle.</param>
-        /// <param name="halign">The horizontal alignment.</param>
-        /// <param name="valign">The vertical alignment.</param>
-        /// <param name="maxSize">The maximum size of the text (in device independent units, 1/96 inch).</param>
-        public void DrawText(
-            ScreenPoint p,
-            string text,
-            OxyColor fill,
-            string fontFamily = null,
-            double fontSize = 10,
-            double fontWeight = 500,
-            double rotate = 0,
-            HorizontalAlignment halign = HorizontalAlignment.Left,
-            VerticalAlignment valign = VerticalAlignment.Top,
-            OxySize? maxSize = null)
+        /// <inheritdoc/>
+        public void DrawRectangle(OxyRect rectangle, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
         }
 
-        /// <summary>
-        /// Measures the size of the specified text.
-        /// </summary>
-        /// <param name="text">The text.</param>
-        /// <param name="fontFamily">The font family.</param>
-        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
-        /// <param name="fontWeight">The font weight.</param>
-        /// <returns>
-        /// The size of the text (in device independent units, 1/96 inch).
-        /// </returns>
+        /// <inheritdoc/>
+        public void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void DrawText(ScreenPoint p, string text, OxyColor fill, string fontFamily = null, double fontSize = 10, double fontWeight = 400, double rotation = 0, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left, VerticalAlignment verticalAlignment = VerticalAlignment.Top, OxySize? maxSize = null)
+        {
+        }
+
+        /// <inheritdoc/>
         public OxySize MeasureText(string text, string fontFamily = null, double fontSize = 10, double fontWeight = 500)
         {
             return OxySize.Empty;
         }
 
-        /// <summary>
-        /// Sets the tool tip for the following items.
-        /// </summary>
-        /// <param name="text">The text in the tooltip.</param>
-        public void SetToolTip(string text)
+        /// <inheritdoc/>
+        public void ResetClip()
         {
         }
 
-        /// <summary>
-        /// Cleans up resources not in use.
-        /// </summary>
-        /// <remarks>
-        /// This method is called at the end of each rendering.
-        /// </remarks>
-        public void CleanUp()
-        {
-        }
-
-        /// <summary>
-        /// Draws a portion of the specified <see cref="OxyImage" />.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="srcX">The x-coordinate of the upper-left corner of the portion of the source image to draw.</param>
-        /// <param name="srcY">The y-coordinate of the upper-left corner of the portion of the source image to draw.</param>
-        /// <param name="srcWidth">Width of the portion of the source image to draw.</param>
-        /// <param name="srcHeight">Height of the portion of the source image to draw.</param>
-        /// <param name="destX">The x-coordinate of the upper-left corner of drawn image.</param>
-        /// <param name="destY">The y-coordinate of the upper-left corner of drawn image.</param>
-        /// <param name="destWidth">The width of the drawn image.</param>
-        /// <param name="destHeight">The height of the drawn image.</param>
-        /// <param name="opacity">The opacity.</param>
-        /// <param name="interpolate">interpolate if set to <c>true</c>.</param>
-        public void DrawImage(
-            OxyImage source,
-            double srcX,
-            double srcY,
-            double srcWidth,
-            double srcHeight,
-            double destX,
-            double destY,
-            double destWidth,
-            double destHeight,
-            double opacity,
-            bool interpolate)
-        {
-        }
-
-        /// <summary>
-        /// Sets the clip rectangle.
-        /// </summary>
-        /// <param name="rect">The clip rectangle.</param>
-        /// <returns>
-        /// True if the clip rectangle was set.
-        /// </returns>
-        public bool SetClip(OxyRect rect)
+        /// <inheritdoc/>
+        public bool SetClip(OxyRect clippingRectangle)
         {
             return true;
         }
 
-        /// <summary>
-        /// Resets the clip rectangle.
-        /// </summary>
-        public void ResetClip()
+        /// <inheritdoc/>
+        public void SetToolTip(string text)
         {
         }
     }

--- a/Source/Examples/PerformanceTest/Program.cs
+++ b/Source/Examples/PerformanceTest/Program.cs
@@ -136,9 +136,9 @@ namespace PerformanceTest
                     1,
                     OxyColors.Black,
                     1,
+                    EdgeRenderingMode.Automatic,
                     null,
                     LineJoin.Miter,
-                    false,
                     outputBuffer);
             }
 


### PR DESCRIPTION
Fixes the `PerformanceTest` project by updating it to use `EdgeMode`.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix one call on an `IRenderContext`
- Updated `EmptyRenderContext` to support `EdgeMode`

@oxyplot/admins
