### PR TITLE
Add renderer based on SkiaSharp (#1509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Support for high DPI for WPF (#149)
 - EdgeRenderingMode property to PlotElement, allowing customization of the way edges are treated by the renderer (#1428, #1358, #1077, #843, #145)
 - Color palettes Viridis, Plasma, Magma, Inferno and Cividis (#1505)
+- Renderer based on SkiaSharp, including exporters for PNG, JPEG, PDF and SVG (#1509)
 
 ### Changed
 - Legends model (#644)

--- a/Source/OxyPlot.CI.sln
+++ b/Source/OxyPlot.CI.sln
@@ -42,6 +42,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleBrowser.WindowsForms", "Examples\WindowsForms\ExampleBrowser\ExampleBrowser.WindowsForms.csproj", "{2A482337-AEB4-4E22-BB35-0E363BAE98BD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp", "OxyPlot.SkiaSharp\OxyPlot.SkiaSharp.csproj", "{BC027364-EC71-4174-AD51-449BEE34FAB5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp.Tests", "OxyPlot.SkiaSharp.Tests\OxyPlot.SkiaSharp.Tests.csproj", "{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -317,6 +321,54 @@ Global
 		{2A482337-AEB4-4E22-BB35-0E363BAE98BD}.Release|x64.Build.0 = Release|Any CPU
 		{2A482337-AEB4-4E22-BB35-0E363BAE98BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{2A482337-AEB4-4E22-BB35-0E363BAE98BD}.Release|x86.Build.0 = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|ARM.Build.0 = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|x64.Build.0 = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Debug|x86.Build.0 = Debug|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|ARM.ActiveCfg = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|ARM.Build.0 = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|iPhone.Build.0 = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|x64.ActiveCfg = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|x64.Build.0 = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|x86.ActiveCfg = Release|Any CPU
+		{BC027364-EC71-4174-AD51-449BEE34FAB5}.Release|x86.Build.0 = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|x64.Build.0 = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Debug|x86.Build.0 = Debug|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|ARM.Build.0 = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|iPhone.Build.0 = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|x64.ActiveCfg = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|x64.Build.0 = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|x86.ActiveCfg = Release|Any CPU
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,6 +381,7 @@ Global
 		{405690EE-3A1C-4F58-8161-F6634909EF4E} = {E124D189-92DF-4A3C-BFA9-6687F4878C12}
 		{29D713C4-1744-47B6-9D26-A7847DB94606} = {E124D189-92DF-4A3C-BFA9-6687F4878C12}
 		{2A482337-AEB4-4E22-BB35-0E363BAE98BD} = {E124D189-92DF-4A3C-BFA9-6687F4878C12}
+		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73} = {215581EE-098A-488B-91CE-980D94EED5A2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {282C7D1F-6AA7-4D54-8C6C-C83C2927F9FE}

--- a/Source/OxyPlot.SkiaSharp.Tests/ExportTest.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/ExportTest.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ExportTest.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    using ExampleLibrary;
+    using NUnit.Framework;
+    using System.IO;
+    using System.Linq;
+
+    public static class ExportTest
+    {
+        public static void Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(IExporter exporter, string directory, string extension)
+        {
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            foreach (var example in Examples.GetList().GroupBy(example => example.Category).Select(g => g.First()))
+            {
+                void ExportModelAndCheckFileExists(PlotModel model, string fileName)
+                {
+                    if (model == null)
+                    {
+                        return;
+                    }
+
+                    var path = Path.Combine(directory, FileNameUtilities.CreateValidFileName(fileName, extension));
+                    using (var s = File.Create(path))
+                    {
+                        exporter.Export(model, s);
+                    }
+
+                    Assert.IsTrue(File.Exists(path));
+                }
+
+                ExportModelAndCheckFileExists(example.PlotModel, $"{example.Category} - {example.Title}");
+                ExportModelAndCheckFileExists(example.TransposedPlotModel, $"{example.Category} - {example.Title} - Transposed");
+            }
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/FileNameUtilities.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/FileNameUtilities.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="FileNameUtilities.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    /// <summary>
+    /// Provides file name utilities.
+    /// </summary>
+    public static class FileNameUtilities
+    {
+        /// <summary>
+        /// Creates a valid file name.
+        /// </summary>
+        /// <param name="title">The title.</param>
+        /// <param name="extension">The extension.</param>
+        /// <returns>A file name.</returns>
+        public static string CreateValidFileName(string title, string extension)
+        {
+            var validFileName = title.Trim();
+            var invalidFileNameChars = "/?<>\\:*|\0\t\r\n".ToCharArray();
+            foreach (var invalChar in invalidFileNameChars)
+            {
+                validFileName = validFileName.Replace(invalChar.ToString(), string.Empty);
+            }
+
+            foreach (var invalChar in invalidFileNameChars)
+            {
+                validFileName = validFileName.Replace(invalChar.ToString(), string.Empty);
+            }
+
+            if (validFileName.Length > 160)
+            {
+                // safe value threshold is 260
+                validFileName = validFileName.Remove(156) + "...";
+            }
+
+            return validFileName + extension;
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/JpegExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/JpegExporterTests.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="JpegExporterTests.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    using System;
+    using System.IO;
+
+    using NUnit.Framework;
+
+    using OxyPlot.Series;
+    using OxyPlot.SkiaSharp;
+
+    [TestFixture]
+    public class JpegExporterTests
+    {
+        private const string JPEG_FOLDER = "JPEG";
+        private string outputDirectory;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, JPEG_FOLDER);
+            Directory.CreateDirectory(this.outputDirectory);
+        }
+
+        [Test]
+        public void Export_SomeExamplesInExampleLibrary_CheckThatAllFilesExist()
+        {
+            var exporter = new JpegExporter { Width = 400, Height = 300 };
+            var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
+            ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".jpg");
+        }
+
+        [Test]
+        public void ExportWithDifferentBackground()
+        {
+            var plotModel = CreateTestModel1();
+            plotModel.Background = OxyColors.Yellow;
+            var exporter = new PngExporter { Width = 400, Height = 300 };
+            var fileName = Path.Combine(this.outputDirectory, "BackgroundYellow.jpg");
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(plotModel, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        [Test]
+        [TestCase(10)]
+        [TestCase(50)]
+        [TestCase(90)]
+        [TestCase(100)]
+        public void ExportWithQuality(int quality)
+        {
+            var plotModel = CreateTestModel1();
+            var directory = Path.Combine(this.outputDirectory, "Quality");
+            Directory.CreateDirectory(directory);
+            var exporter = new JpegExporter { Width = 400, Height = 300, Quality = quality };
+
+            var fileName = Path.Combine(directory, $"Quality_{quality}.jpg");
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(plotModel, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        private static PlotModel CreateTestModel1()
+        {
+            var model = new PlotModel { Title = "Test 1" };
+            model.Series.Add(new FunctionSeries(Math.Sin, 0, Math.PI * 8, 200, "sin(x)"));
+            return model;
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+        <Description>OxyPlot SkiaSharp unit tests</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Copyright>OxyPlot contributors</Copyright>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <Platforms>AnyCPU;x86;x64</Platforms>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|AnyCPU'">
+        <PlatformTarget>x86</PlatformTarget>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|x86'">
+        <PlatformTarget>x86</PlatformTarget>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|x64'">
+        <PlatformTarget>x64</PlatformTarget>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Examples\ExampleLibrary\ExampleLibrary.csproj" />
+        <ProjectReference Include="..\OxyPlot.SkiaSharp\OxyPlot.SkiaSharp.csproj" />
+        <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    </ItemGroup>
+</Project>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxySvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxySvgExporterTests.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PngExporterTests.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    using NUnit.Framework;
+    using OxyPlot.SkiaSharp;
+    using System.IO;
+
+    [TestFixture]
+    public class OxySvgExporterTests
+    {
+        private const string SVG_FOLDER = "OxySVG";
+        private string outputDirectory;
+
+        [Test]
+        public void Export_SomeExamplesInExampleLibrary_CheckThatAllFilesExist()
+        {
+            using (var exporter = new SvgExporter { Width = 1000, Height = 750 })
+            {
+                var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
+                ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".svg");
+            }
+        }
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, SVG_FOLDER);
+            Directory.CreateDirectory(this.outputDirectory);
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/PdfExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/PdfExporterTests.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PdfExporterTests.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    using System.IO;
+    using global::SkiaSharp;
+    using NUnit.Framework;
+
+    using OxyPlot.Axes;
+    using OxyPlot.SkiaSharp;
+
+    [TestFixture]
+    public class PdfExporterTests
+    {
+        private const string PDF_FOLDER = "PDF";
+        private string outputDirectory;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, PDF_FOLDER);
+            Directory.CreateDirectory(this.outputDirectory);
+        }
+
+        [Test]
+        public void Export_SomeExamplesInExampleLibrary_CheckThatAllFilesExist()
+        {
+            var exporter = new PdfExporter { Width = 297 / 25.4f * 72, Height = 210 / 25.4f * 72 };
+            var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
+            ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".pdf");
+        }
+
+        [Test]
+        public void Pdf_Export_Unicode()
+        {
+            var model = new PlotModel { Title = "Unicode support ☺", TitleFont = "Arial" };
+            model.Axes.Add(new LinearAxis { Title = "λ", Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Title = "Ж", Position = AxisPosition.Left });
+            var exporter = new PdfExporter { Width = 400, Height = 400 };
+            var fileName = Path.Combine(this.outputDirectory, "unicode.pdf");
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(model, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        [Test]
+        public void Pdf_Export_CJK()
+        {
+            var fontManager = SKFontManager.Default;
+
+            var chineseChar = 0x9019; // 這
+            var chineseTypeface = fontManager.MatchCharacter(chineseChar);
+
+            var koreanChar = 0xC790; // 자
+            var koreanTypeface = fontManager.MatchCharacter(koreanChar);
+
+            var japaneseChar = 0x3053; // こ
+            var japaneseTypeface = fontManager.MatchCharacter(japaneseChar);
+
+            var model = new PlotModel { Title = "Chinese, Japanese and Korean characters" };
+            model.Axes.Add(new LinearAxis { Title = $"Korean (used Font: {koreanTypeface.FamilyName}): 자동 번역 된 텍스트입니다.", Position = AxisPosition.Bottom, TitleFont = koreanTypeface.FamilyName });
+            model.Axes.Add(new LinearAxis { Title = $"Japanese (used Font: {japaneseTypeface.FamilyName}): これは自動翻訳されたテキストです", Position = AxisPosition.Left, TitleFont = japaneseTypeface.FamilyName });
+            model.Axes.Add(new LinearAxis { Title = $"Chinese (used Font: {chineseTypeface.FamilyName}): 這是一些自動翻譯的文字", Position = AxisPosition.Right, TitleFont = chineseTypeface.FamilyName });
+            var exporter = new PdfExporter { Width = 400, Height = 400 };
+            var fileName = Path.Combine(this.outputDirectory, "cjk.pdf");
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(model, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/PngExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/PngExporterTests.cs
@@ -1,0 +1,103 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PngExporterTests.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    using System;
+    using System.IO;
+
+    using NUnit.Framework;
+
+    using OxyPlot.Series;
+    using OxyPlot.SkiaSharp;
+
+    [TestFixture]
+    public class PngExporterTests
+    {
+        private const string PNG_FOLDER = "PNG";
+        private string outputDirectory;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, PNG_FOLDER);
+            Directory.CreateDirectory(this.outputDirectory);
+        }
+
+        [Test]
+        public void Export_SomeExamplesInExampleLibrary_CheckThatAllFilesExist()
+        {
+            var exporter = new PngExporter { Width = 400, Height = 300 };
+            var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
+            ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".png");
+        }
+
+        [Test]
+        public void ExportToStream()
+        {
+            var plotModel = CreateTestModel1();
+            var exporter = new PngExporter { Width = 400, Height = 300 };
+            var stream = new MemoryStream();
+            exporter.Export(plotModel, stream);
+
+            Assert.IsTrue(stream.Length > 0);
+        }
+
+        [Test]
+        public void ExportToFile()
+        {
+            var plotModel = CreateTestModel1();
+            var fileName = Path.Combine(this.outputDirectory, "Plot1.png");
+            PngExporter.Export(plotModel, fileName, 400, 300);
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        [Test]
+        public void ExportWithDifferentBackground()
+        {
+            var plotModel = CreateTestModel1();
+            plotModel.Background = OxyColors.Yellow;
+            var fileName = Path.Combine(this.outputDirectory, "Background_Yellow.png");
+            var exporter = new PngExporter { Width = 400, Height = 300 };
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(plotModel, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        [Test]
+        [TestCase(1.2)]
+        [TestCase(2)]
+        [TestCase(3.1415)]
+        public void ExportWithResolution(double factor)
+        {
+            var resolution = (int)(96 * factor);
+            var plotModel = CreateTestModel1();
+            var directory = Path.Combine(this.outputDirectory, "Resolution");
+            Directory.CreateDirectory(directory);
+
+            var fileName = Path.Combine(directory, $"Resolution{resolution}.png");
+            var exporter = new PngExporter { Width = (int)(400 * factor), Height = (int)(300 * factor), Dpi = resolution };
+
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(plotModel, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        private static PlotModel CreateTestModel1()
+        {
+            var model = new PlotModel { Title = "Test 1" };
+            model.Series.Add(new FunctionSeries(Math.Sin, 0, Math.PI * 8, 200, "sin(x)"));
+            return model;
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/SkiaSvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/SkiaSvgExporterTests.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PngExporterTests.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp.Tests
+{
+    using NUnit.Framework;
+    using OxyPlot.SkiaSharp;
+    using System.IO;
+
+    [TestFixture]
+    public class SkiaSvgExporterTests
+    {
+        private const string SVG_FOLDER = "SkiaSVG";
+        private string outputDirectory;
+
+        [Test]
+        public void Export_SomeExamplesInExampleLibrary_CheckThatAllFilesExist()
+        {
+            var exporter = new SkiaSvgExporter { Width = 1000, Height = 750 };
+            var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
+            ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".svg");
+        }
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, SVG_FOLDER);
+            Directory.CreateDirectory(this.outputDirectory);
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.sln
+++ b/Source/OxyPlot.SkiaSharp.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29403.142
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Tests", "OxyPlot.Tests\OxyPlot.Tests.csproj", "{E6218B88-69F5-4E3F-9ABC-93AB82FD77AD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{B630CA82-A785-49CA-8FA0-3D3AF4D6626A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot", "OxyPlot\OxyPlot.csproj", "{7A0B35C0-DD17-4964-8E9A-44D6CECDC692}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleLibrary", "Examples\ExampleLibrary\ExampleLibrary.csproj", "{FACB89E5-53A5-4748-9F5B-E0714EBB37B2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Change log", "Change log", "{4334530D-EBDE-4F04-838A-DA5A8A598124}"
+	ProjectSection(SolutionItems) = preProject
+		..\AUTHORS = ..\AUTHORS
+		..\CHANGELOG.md = ..\CHANGELOG.md
+		..\CONTRIBUTORS = ..\CONTRIBUTORS
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{06B2EDA4-A30B-493A-A0A1-9DA28A2F4B0B}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\CONTRIBUTING.md = ..\.github\CONTRIBUTING.md
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp", "OxyPlot.SkiaSharp\OxyPlot.SkiaSharp.csproj", "{EE6B2700-9379-4882-9B43-F652995219A9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp.Tests", "OxyPlot.SkiaSharp.Tests\OxyPlot.SkiaSharp.Tests.csproj", "{107CDFF9-51FB-43CA-B701-61D515214906}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E6218B88-69F5-4E3F-9ABC-93AB82FD77AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6218B88-69F5-4E3F-9ABC-93AB82FD77AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6218B88-69F5-4E3F-9ABC-93AB82FD77AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6218B88-69F5-4E3F-9ABC-93AB82FD77AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A0B35C0-DD17-4964-8E9A-44D6CECDC692}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A0B35C0-DD17-4964-8E9A-44D6CECDC692}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A0B35C0-DD17-4964-8E9A-44D6CECDC692}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A0B35C0-DD17-4964-8E9A-44D6CECDC692}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FACB89E5-53A5-4748-9F5B-E0714EBB37B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FACB89E5-53A5-4748-9F5B-E0714EBB37B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FACB89E5-53A5-4748-9F5B-E0714EBB37B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FACB89E5-53A5-4748-9F5B-E0714EBB37B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE6B2700-9379-4882-9B43-F652995219A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE6B2700-9379-4882-9B43-F652995219A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE6B2700-9379-4882-9B43-F652995219A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE6B2700-9379-4882-9B43-F652995219A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{107CDFF9-51FB-43CA-B701-61D515214906}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{107CDFF9-51FB-43CA-B701-61D515214906}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{107CDFF9-51FB-43CA-B701-61D515214906}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{107CDFF9-51FB-43CA-B701-61D515214906}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FACB89E5-53A5-4748-9F5B-E0714EBB37B2} = {B630CA82-A785-49CA-8FA0-3D3AF4D6626A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C96D2723-A182-4A28-ABEE-51CEC95FC6E2}
+	EndGlobalSection
+EndGlobal

--- a/Source/OxyPlot.SkiaSharp/JpegExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/JpegExporter.cs
@@ -1,0 +1,95 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="JpegExporter.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using global::SkiaSharp;
+    using System.IO;
+
+    /// <summary>
+    /// Provides functionality to export plots to jpeg using the SkiaSharp renderer.
+    /// </summary>
+    public class JpegExporter : IExporter
+    {
+        /// <summary>
+        /// Gets or sets the DPI.
+        /// </summary>
+        public float Dpi { get; set; } = 96;
+
+        /// <summary>
+        /// Gets or sets the export height (in pixels).
+        /// </summary>
+        public int Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the export width (in pixels).
+        /// </summary>
+        public int Width { get; set; }
+
+        /// <summary>
+        /// Gets or sets the export quality (0-100).
+        /// </summary>
+        public int Quality { get; set; } = 90;
+
+        /// <summary>
+        /// Exports the specified model to a file.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="width">The width (points).</param>
+        /// <param name="height">The height (points).</param>
+        /// <param name="quality">The export quality (0-100).</param>
+        /// <param name="dpi">The DPI (dots per inch).</param>
+        public static void Export(IPlotModel model, string path, int width, int height, int quality, float dpi = 96)
+        {
+            using var stream = File.OpenWrite(path);
+            Export(model, stream, width, height, quality, dpi);
+        }
+
+        /// <summary>
+        /// Exports the specified model to a stream.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="stream">The output stream.</param>
+        /// <param name="width">The width (points).</param>
+        /// <param name="height">The height (points).</param>
+        /// <param name="quality">The export quality (0-100).</param>
+        /// <param name="dpi">The DPI (dots per inch).</param>
+        public static void Export(IPlotModel model, Stream stream, int width, int height, int quality, float dpi = 96)
+        {
+            var exporter = new JpegExporter { Width = width, Height = height, Quality = quality, Dpi = dpi };
+            exporter.Export(model, stream);
+        }
+
+        /// <inheritdoc/>
+        public void Export(IPlotModel model, Stream stream)
+        {
+            using var bitmap = new SKBitmap(this.Width, this.Height);
+
+            using (var canvas = new SKCanvas(bitmap))
+            using (var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas })
+            {
+                canvas.Clear(SKColors.White);
+                var dpiScale = this.Dpi / 96;
+                context.DpiScale = dpiScale;
+                model.Update(true);
+                var backgroundColor = model.Background;
+
+                // jpg doesn't support transparency
+                if (!backgroundColor.IsVisible())
+                {
+                    backgroundColor = OxyColors.White;
+                }
+
+                canvas.Clear(backgroundColor.ToSKColor());
+                model.Render(context, new OxyRect(0, 0, this.Width / dpiScale, this.Height / dpiScale));
+            }
+
+            using var skStream = new SKManagedWStream(stream);
+            SKPixmap.Encode(skStream, bitmap, SKEncodedImageFormat.Jpeg, this.Quality);
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Copyright>Copyright (c) 2020 OxyPlot contributors</Copyright>
+    <Authors>OxyPlot contributors</Authors>
+    <Description>OxyPlot is a plotting library for .NET. This package provides rendering based on SkiaSharp.</Description>
+    <RepositoryUrl>https://github.com/oxyplot/oxyplot.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>plotting plot charting chart skiasharp skia pdf</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://oxyplot.github.io/</PackageProjectUrl>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="1.68.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
+  </ItemGroup>
+</Project>

--- a/Source/OxyPlot.SkiaSharp/PdfExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PdfExporter.cs
@@ -1,0 +1,71 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PdfExporter.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using global::SkiaSharp;
+    using System.IO;
+
+    /// <summary>
+    /// Provides functionality to export plots to pdf using the SkiaSharp renderer.
+    /// </summary>
+    public class PdfExporter : IExporter
+    {
+        /// <summary>
+        /// Gets or sets the DPI.
+        /// </summary>
+        public float Dpi { get; set; } = 72;
+
+        /// <summary>
+        /// Gets or sets the export height (in points, as defined by <see cref="Dpi"/>).
+        /// </summary>
+        public float Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the export width (in points, as defined by <see cref="Dpi"/>).
+        /// </summary>
+        public float Width { get; set; }
+
+        /// <summary>
+        /// Exports the specified model to a file.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="width">The width (points).</param>
+        /// <param name="height">The height (points).</param>
+        public static void Export(IPlotModel model, string path, float width, float height)
+        {
+            using var stream = File.OpenWrite(path);
+            Export(model, stream, width, height);
+        }
+
+        /// <summary>
+        /// Exports the specified model to a stream.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="stream">The output stream.</param>
+        /// <param name="width">The width (points).</param>
+        /// <param name="height">The height (points).</param>
+        public static void Export(IPlotModel model, Stream stream, float width, float height)
+        {
+            var exporter = new PdfExporter { Width = width, Height = height };
+            exporter.Export(model, stream);
+        }
+
+        /// <inheritdoc/>
+        public void Export(IPlotModel model, Stream stream)
+        {
+            using var document = SKDocument.CreatePdf(stream, this.Dpi);
+            using var pdfCanvas = document.BeginPage(this.Width, this.Height);
+            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = pdfCanvas };
+            var dpiScale = this.Dpi / 96;
+            context.DpiScale = dpiScale;
+            model.Update(true);
+            pdfCanvas.Clear(model.Background.ToSKColor());
+            model.Render(context, new OxyRect(0, 0, this.Width / dpiScale, this.Height / dpiScale));
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/PngExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PngExporter.cs
@@ -1,0 +1,79 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PngExporter.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using global::SkiaSharp;
+    using System.IO;
+
+    /// <summary>
+    /// Provides functionality to export plots to png using the SkiaSharp renderer.
+    /// </summary>
+    public class PngExporter : IExporter
+    {
+        /// <summary>
+        /// Gets or sets the DPI.
+        /// </summary>
+        public float Dpi { get; set; } = 96;
+
+        /// <summary>
+        /// Gets or sets the export height (in pixels).
+        /// </summary>
+        public int Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the export width (in pixels).
+        /// </summary>
+        public int Width { get; set; }
+
+        /// <summary>
+        /// Exports the specified model to a file.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="width">The width (points).</param>
+        /// <param name="height">The height (points).</param>
+        /// <param name="dpi">The DPI (dots per inch).</param>
+        public static void Export(IPlotModel model, string path, int width, int height, float dpi = 96)
+        {
+            using var stream = File.OpenWrite(path);
+            Export(model, stream, width, height, dpi);
+        }
+
+        /// <summary>
+        /// Exports the specified model to a stream.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="stream">The output stream.</param>
+        /// <param name="width">The width (points).</param>
+        /// <param name="height">The height (points).</param>
+        /// <param name="dpi">The DPI (dots per inch).</param>
+        public static void Export(IPlotModel model, Stream stream, int width, int height, float dpi = 96)
+        {
+            var exporter = new PngExporter { Width = width, Height = height, Dpi = dpi };
+            exporter.Export(model, stream);
+        }
+
+        /// <inheritdoc/>
+        public void Export(IPlotModel model, Stream stream)
+        {
+            using var bitmap = new SKBitmap(this.Width, this.Height);
+
+            using (var canvas = new SKCanvas(bitmap))
+            using (var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas })
+            {
+                var dpiScale = this.Dpi / 96;
+                context.DpiScale = dpiScale;
+                model.Update(true);
+                canvas.Clear(model.Background.ToSKColor());
+                model.Render(context, new OxyRect(0, 0, this.Width / dpiScale, this.Height / dpiScale));
+            }
+
+            using var skStream = new SKManagedWStream(stream);
+            SKPixmap.Encode(skStream, bitmap, SKEncodedImageFormat.Png, 0);
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/SkiaExtensions.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaExtensions.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SkiaExtensions.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using global::SkiaSharp;
+
+    /// <summary>
+    /// Provides extension methods for conversion between SkiaSharp and oxyplot objects.
+    /// </summary>
+    public static class SkiaExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="OxyColor"/> to a <see cref="SKColor"/>;
+        /// </summary>
+        /// <param name="color">The <see cref="OxyColor"/>.</param>
+        /// <returns>The <see cref="SKColor"/>.</returns>
+        public static OxyColor ToOxyColor(this SKColor color)
+        {
+            return OxyColor.FromArgb(color.Alpha, color.Red, color.Green, color.Blue);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="SKColor"/> to a <see cref="OxyColor"/>;
+        /// </summary>
+        /// <param name="color">The <see cref="SKColor"/>.</param>
+        /// <returns>The <see cref="OxyColor"/>.</returns>
+        public static SKColor ToSKColor(this OxyColor color)
+        {
+            return new SKColor(color.R, color.G, color.B, color.A);
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -1,0 +1,861 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SkiaRenderContext.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using global::SkiaSharp;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Implements <see cref="IRenderContext" /> based on SkiaSharp.
+    /// </summary>
+    public class SkiaRenderContext : IRenderContext, IDisposable
+    {
+        private readonly Dictionary<FontDescriptor, SKTypeface> typefaceCache = new Dictionary<FontDescriptor, SKTypeface>();
+        private SKPaint paint = new SKPaint();
+        private SKPath path = new SKPath();
+
+        /// <summary>
+        /// Gets or sets the DPI scaling factor. A value of 1 corresponds to 96 DPI (dots per inch).
+        /// </summary>
+        public float DpiScale { get; set; } = 1;
+
+        /// <inheritdoc/>
+        public bool RendersToScreen { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the <see cref="SKCanvas"/> the <see cref="SkiaRenderContext"/> renders to. This must be set before any draw calls.
+        /// </summary>
+        public SKCanvas SkCanvas { get; set; }
+
+        /// <inheritdoc/>
+        public void CleanUp()
+        {
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
+        public void DrawEllipse(OxyRect extents, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0))
+            {
+                return;
+            }
+
+            var actualRect = this.Convert(extents);
+
+            if (fill.IsVisible())
+            {
+                var paint = this.GetFillPaint(fill, edgeRenderingMode);
+                this.SkCanvas.DrawOval(actualRect, paint);
+            }
+
+            if (stroke.IsVisible() && thickness > 0)
+            {
+                var paint = this.GetStrokePaint(stroke, thickness, edgeRenderingMode);
+                this.SkCanvas.DrawOval(actualRect, paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void DrawEllipses(IList<OxyRect> extents, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (!fill.IsVisible() && (!stroke.IsVisible() || thickness <= 0))
+            {
+                return;
+            }
+
+            var path = this.GetPath();
+            foreach (var extent in extents)
+            {
+                path.AddOval(this.Convert(extent));
+            }
+
+            if (fill.IsVisible())
+            {
+                var paint = this.GetFillPaint(fill, edgeRenderingMode);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+
+            if (stroke.IsVisible() && thickness > 0)
+            {
+                var paint = this.GetStrokePaint(stroke, thickness, edgeRenderingMode);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void DrawImage(
+            OxyImage source,
+            double srcX,
+            double srcY,
+            double srcWidth,
+            double srcHeight,
+            double destX,
+            double destY,
+            double destWidth,
+            double destHeight,
+            double opacity,
+            bool interpolate)
+        {
+            if (source == null)
+            {
+                return;
+            }
+
+            var bytes = source.GetData();
+            var image = SKBitmap.Decode(bytes);
+
+            var src = new SKRect((float)srcX, (float)srcY, (float)(srcX + srcWidth), (float)(srcY + srcHeight));
+            var dest = new SKRect(this.Convert(destX), this.Convert(destY), this.Convert(destX + destWidth), this.Convert(destY + destHeight));
+
+            var paint = this.GetImagePaint(opacity, interpolate);
+            this.SkCanvas.DrawBitmap(image, src, dest, paint);
+        }
+
+        /// <inheritdoc/>
+        public void DrawLine(
+            IList<ScreenPoint> points,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray = null,
+            LineJoin lineJoin = LineJoin.Miter)
+        {
+            if (points.Count < 2 || !stroke.IsVisible() || thickness <= 0)
+            {
+                return;
+            }
+
+            var path = this.GetPath();
+            var paint = this.GetLinePaint(stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
+            var actualPoints = this.GetActualPoints(points, thickness, edgeRenderingMode);
+            AddPoints(actualPoints, path);
+
+            this.SkCanvas.DrawPath(path, paint);
+        }
+
+        /// <inheritdoc/>
+        public void DrawLineSegments(
+            IList<ScreenPoint> points,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray = null,
+            LineJoin lineJoin = LineJoin.Miter)
+        {
+            if (points.Count < 2 || !stroke.IsVisible() || thickness <= 0)
+            {
+                return;
+            }
+
+            var paint = this.GetLinePaint(stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
+
+            var skPoints = new SKPoint[points.Count];
+            switch (edgeRenderingMode)
+            {
+                case EdgeRenderingMode.Automatic:
+                case EdgeRenderingMode.Adaptive:
+                case EdgeRenderingMode.PreferSharpness:
+                    var snapOffset = this.GetSnapOffset(thickness, edgeRenderingMode);
+                    for (var i = 0; i < points.Count - 1; i += 2)
+                    {
+                        var p1 = points[i];
+                        var p2 = points[i + 1];
+                        if (RenderContextBase.IsStraightLine(p1, p2))
+                        {
+                            skPoints[i] = this.ConvertSnap(p1, snapOffset);
+                            skPoints[i + 1] = this.ConvertSnap(p2, snapOffset);
+                        }
+                        else
+                        {
+                            skPoints[i] = this.Convert(p1);
+                            skPoints[i + 1] = this.Convert(p2);
+                        }
+                    }
+
+                    break;
+                default:
+                    for (var i = 0; i < points.Count; i += 2)
+                    {
+                        skPoints[i] = this.Convert(points[i]);
+                        skPoints[i + 1] = this.Convert(points[i + 1]);
+                    }
+
+                    break;
+            }
+
+            this.SkCanvas.DrawPoints(SKPointMode.Lines, skPoints, paint);
+        }
+
+        /// <inheritdoc/>
+        public void DrawPolygon(
+            IList<ScreenPoint> points,
+            OxyColor fill,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray = null,
+            LineJoin lineJoin = LineJoin.Miter)
+        {
+            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0) || points.Count < 2)
+            {
+                return;
+            }
+
+            var path = this.GetPath();
+            var actualPoints = this.GetActualPoints(points, thickness, edgeRenderingMode);
+            AddPoints(actualPoints, path);
+            path.Close();
+
+            if (fill.IsVisible())
+            {
+                var paint = this.GetFillPaint(fill, edgeRenderingMode);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+
+            if (stroke.IsVisible() && thickness > 0)
+            {
+                var paint = this.GetLinePaint(stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void DrawPolygons(
+            IList<IList<ScreenPoint>> polygons,
+            OxyColor fill,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray = null,
+            LineJoin lineJoin = LineJoin.Miter)
+        {
+            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0) || polygons.Count == 0)
+            {
+                return;
+            }
+
+            var path = this.GetPath();
+            foreach (var polygon in polygons)
+            {
+                if (polygon.Count < 2)
+                {
+                    continue;
+                }
+
+                var actualPoints = this.GetActualPoints(polygon, thickness, edgeRenderingMode);
+                AddPoints(actualPoints, path);
+                path.Close();
+            }
+
+            if (fill.IsVisible())
+            {
+                var paint = this.GetFillPaint(fill, edgeRenderingMode);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+
+            if (stroke.IsVisible() && thickness > 0)
+            {
+                var paint = this.GetLinePaint(stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void DrawRectangle(OxyRect rectangle, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0))
+            {
+                return;
+            }
+
+            var actualRectangle = this.GetActualRect(rectangle, thickness, edgeRenderingMode);
+
+            if (fill.IsVisible())
+            {
+                var paint = this.GetFillPaint(fill, edgeRenderingMode);
+                this.SkCanvas.DrawRect(actualRectangle, paint);
+            }
+
+            if (stroke.IsVisible() && thickness > 0)
+            {
+                var paint = this.GetStrokePaint(stroke, thickness, edgeRenderingMode);
+                this.SkCanvas.DrawRect(actualRectangle, paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0) || rectangles.Count == 0)
+            {
+                return;
+            }
+
+            var path = this.GetPath();
+            foreach (var rectangle in this.GetActualRects(rectangles, thickness, edgeRenderingMode))
+            {
+                path.AddRect(rectangle);
+            }
+
+            if (fill.IsVisible())
+            {
+                var paint = this.GetFillPaint(fill, edgeRenderingMode);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+
+            if (stroke.IsVisible() && thickness > 0)
+            {
+                var paint = this.GetStrokePaint(stroke, thickness, edgeRenderingMode);
+                this.SkCanvas.DrawPath(path, paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void DrawText(
+            ScreenPoint p,
+            string text,
+            OxyColor fill,
+            string fontFamily = null,
+            double fontSize = 10,
+            double fontWeight = 400,
+            double rotation = 0,
+            HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment verticalAlignment = VerticalAlignment.Top,
+            OxySize? maxSize = null)
+        {
+            if (text == null || !fill.IsVisible())
+            {
+                return;
+            }
+
+            var paint = this.GetTextPaint(fontFamily, fontSize, fontWeight);
+            paint.Color = fill.ToSKColor();
+
+            var width = paint.MeasureText(text);
+
+            var deltaX = horizontalAlignment switch
+            {
+                HorizontalAlignment.Left => 0,
+                HorizontalAlignment.Center => -width / 2,
+                HorizontalAlignment.Right => -width,
+                _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
+            };
+
+            var metrics = paint.FontMetrics;
+            var deltaY = verticalAlignment switch
+            {
+                VerticalAlignment.Top => -metrics.Ascent,
+                VerticalAlignment.Middle => -(metrics.Ascent + metrics.Descent) / 2,
+                VerticalAlignment.Bottom => -metrics.Descent,
+                _ => throw new ArgumentOutOfRangeException(nameof(verticalAlignment))
+            };
+
+            var x = this.Convert(p.X);
+            var y = this.Convert(p.Y);
+            using (new SKAutoCanvasRestore(this.SkCanvas))
+            {
+                this.SkCanvas.Translate(x, y);
+                this.SkCanvas.RotateDegrees((float)rotation);
+                this.SkCanvas.DrawText(text, new SKPoint(deltaX, deltaY), paint);
+            }
+        }
+
+        /// <inheritdoc/>
+        public OxySize MeasureText(string text, string fontFamily = null, double fontSize = 10, double fontWeight = 500)
+        {
+            if (text == null)
+            {
+                return new OxySize(0, 0);
+            }
+
+            var paint = this.GetTextPaint(fontFamily, fontSize, fontWeight);
+            var width = paint.MeasureText(text);
+            var height = paint.GetFontMetrics(out _);
+            return new OxySize(this.ConvertBack(width), this.ConvertBack(height));
+        }
+
+        /// <inheritdoc/>
+        public void ResetClip()
+        {
+            this.SkCanvas.Restore();
+        }
+
+        /// <inheritdoc/>
+        public bool SetClip(OxyRect clippingRectangle)
+        {
+            // if a clipping is already set, we have to restore it first
+            if (this.SkCanvas.SaveCount > 0)
+            {
+                this.SkCanvas.Restore();
+            }
+
+            this.SkCanvas.Save();
+            this.SkCanvas.ClipRect(this.Convert(clippingRectangle));
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public void SetToolTip(string text)
+        {
+        }
+
+        /// <summary>
+        /// Disposes managed resources.
+        /// </summary>
+        /// <param name="disposing">A value indicating whether this method is called from the Dispose method.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            this.paint?.Dispose();
+            this.paint = null;
+            this.path?.Dispose();
+            this.path = null;
+
+            foreach (var typeface in this.typefaceCache.Values)
+            {
+                typeface.Dispose();
+            }
+
+            this.typefaceCache.Clear();
+        }
+
+        /// <summary>
+        /// Adds the <see cref="SKPoint"/>s to the <see cref="SKPath"/> as a series of connected lines.
+        /// </summary>
+        /// <param name="points">The points.</param>
+        /// <param name="path">The path.</param>
+        private static void AddPoints(IEnumerable<SKPoint> points, SKPath path)
+        {
+            using var e = points.GetEnumerator();
+            if (!e.MoveNext())
+            {
+                return;
+            }
+
+            path.MoveTo(e.Current);
+            while (e.MoveNext())
+            {
+                path.LineTo(e.Current);
+            }
+        }
+
+        /// <summary>
+        /// Gets the pixel offset that a line with the specified thickness should snap to.
+        /// </summary>
+        /// <remarks>
+        /// This takes into account that lines with even stroke thickness should be snapped to the border between two pixels while lines with odd stroke thickness should be snapped to the middle of a pixel.
+        /// </remarks>
+        /// <param name="thickness">The line thickness.</param>
+        /// <returns>The snap offset.</returns>
+        private static float GetSnapOffset(float thickness)
+        {
+            var mod = thickness % 2;
+            var isOdd = mod >= 0.5 && mod < 1.5;
+            return isOdd ? 0.5f : 0;
+        }
+
+        /// <summary>
+        /// Snaps a value to a pixel with the specified offset.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="offset">The offset.</param>
+        /// <returns>The snapped value.</returns>
+        private static float Snap(float value, float offset)
+        {
+            return (float)Math.Round(value + offset, MidpointRounding.AwayFromZero) - offset;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="OxyRect"/> to a <see cref="SKRect"/>, taking into account DPI scaling.
+        /// </summary>
+        /// <param name="rect">The rectangle.</param>
+        /// <returns>The converted rectangle.</returns>
+        private SKRect Convert(OxyRect rect)
+        {
+            var left = this.Convert(rect.Left);
+            var right = this.Convert(rect.Right);
+            var top = this.Convert(rect.Top);
+            var bottom = this.Convert(rect.Bottom);
+            return new SKRect(left, top, right, bottom);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="double"/> to a <see cref="float"/>, taking into account DPI scaling.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The converted value.</returns>
+        private float Convert(double value)
+        {
+            return (float)value * this.DpiScale;
+        }
+
+        /// <summary>
+        /// Converts <see cref="double"/> dash array to a <see cref="float"/> array, taking into account DPI scaling.
+        /// </summary>
+        /// <param name="values">The array of values.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <returns>The array of converted values.</returns>
+        private float[] ConvertDashArray(double[] values, float strokeThickness)
+        {
+            var ret = new float[values.Length];
+            for (var i = 0; i < values.Length; i++)
+            {
+                ret[i] = this.Convert(values[i]) * strokeThickness;
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        /// Converts <see cref="ScreenPoint"/> to a <see cref="SKPoint"/>, taking into account DPI scaling.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>The converted point.</returns>
+        private SKPoint Convert(ScreenPoint point)
+        {
+            return new SKPoint(this.Convert(point.X), this.Convert(point.Y));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="float"/> to a <see cref="double"/>, applying reversed DPI scaling.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The converted value.</returns>
+        private double ConvertBack(float value)
+        {
+            return value / this.DpiScale;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="OxyRect"/> to a <see cref="SKRect"/>, taking into account DPI scaling and snapping the corners to pixels.
+        /// </summary>
+        /// <param name="rect">The rectangle.</param>
+        /// <param name="snapOffset">The snapping offset.</param>
+        /// <returns>The converted rectangle.</returns>
+        private SKRect ConvertSnap(OxyRect rect, float snapOffset)
+        {
+            var left = this.ConvertSnap(rect.Left, snapOffset);
+            var right = this.ConvertSnap(rect.Right, snapOffset);
+            var top = this.ConvertSnap(rect.Top, snapOffset);
+            var bottom = this.ConvertSnap(rect.Bottom, snapOffset);
+            return new SKRect(left, top, right, bottom);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="double"/> to a <see cref="float"/>, taking into account DPI scaling and snapping the value to a pixel.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="snapOffset">The snapping offset.</param>
+        /// <returns>The converted value.</returns>
+        private float ConvertSnap(double value, float snapOffset)
+        {
+            return Snap(this.Convert(value), snapOffset);
+        }
+
+        /// <summary>
+        /// Converts <see cref="ScreenPoint"/> to a <see cref="SKPoint"/>, taking into account DPI scaling and snapping the point to a pixel.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="snapOffset">The snapping offset.</param>
+        /// <returns>The converted point.</returns>
+        private SKPoint ConvertSnap(ScreenPoint point, float snapOffset)
+        {
+            return new SKPoint(this.ConvertSnap(point.X, snapOffset), this.ConvertSnap(point.Y, snapOffset));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SKPoint"/>s that should actually be rendered from the list of <see cref="ScreenPoint"/>s, taking into account DPI scaling and snapping if necessary.
+        /// </summary>
+        /// <param name="screenPoints">The points.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The actual points.</returns>
+        private IEnumerable<SKPoint> GetActualPoints(IList<ScreenPoint> screenPoints, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            switch (edgeRenderingMode)
+            {
+                case EdgeRenderingMode.Automatic when RenderContextBase.IsStraightLine(screenPoints):
+                case EdgeRenderingMode.Adaptive when RenderContextBase.IsStraightLine(screenPoints):
+                case EdgeRenderingMode.PreferSharpness:
+                    var snapOffset = this.GetSnapOffset(strokeThickness, edgeRenderingMode);
+                    return screenPoints.Select(p => this.ConvertSnap(p, snapOffset));
+                default:
+                    return screenPoints.Select(this.Convert);
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SKRect"/> that should actually be rendered from the <see cref="OxyRect"/>, taking into account DPI scaling and snapping if necessary.
+        /// </summary>
+        /// <param name="rect">The rectangle.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The actual rectangle.</returns>
+        private SKRect GetActualRect(OxyRect rect, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            switch (edgeRenderingMode)
+            {
+                case EdgeRenderingMode.PreferGeometricAccuracy:
+                case EdgeRenderingMode.PreferSpeed:
+                    return this.Convert(rect);
+                default:
+                    var actualThickness = this.GetActualThickness(strokeThickness, edgeRenderingMode);
+                    var snapOffset = GetSnapOffset(actualThickness);
+                    return this.ConvertSnap(rect, snapOffset);
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SKRect"/>s that should actually be rendered from the list of <see cref="OxyRect"/>s, taking into account DPI scaling and snapping if necessary.
+        /// </summary>
+        /// <param name="rects">The rectangles.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The actual rectangles.</returns>
+        private IEnumerable<SKRect> GetActualRects(IEnumerable<OxyRect> rects, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            switch (edgeRenderingMode)
+            {
+                case EdgeRenderingMode.PreferGeometricAccuracy:
+                case EdgeRenderingMode.PreferSpeed:
+                    return rects.Select(this.Convert);
+                default:
+                    var actualThickness = this.GetActualThickness(strokeThickness, edgeRenderingMode);
+                    var snapOffset = GetSnapOffset(actualThickness);
+                    return rects.Select(rect => this.ConvertSnap(rect, snapOffset));
+            }
+        }
+
+        /// <summary>
+        /// Gets the stroke thickness that should actually be used for rendering, taking into account DPI scaling and snapping if necessary.
+        /// </summary>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The actual stroke thickness.</returns>
+        private float GetActualThickness(double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            var scaledThickness = this.Convert(strokeThickness);
+            if (edgeRenderingMode == EdgeRenderingMode.PreferSharpness)
+            {
+                scaledThickness = Snap(scaledThickness, 0);
+            }
+
+            return scaledThickness;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SKPaint"/> containing information needed to render the fill of a shape.
+        /// </summary>
+        /// <remarks>
+        /// This modifies and returns the local <see cref="paint"/> instance.
+        /// </remarks>
+        /// <param name="fillColor">The fill color.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The paint.</returns>
+        private SKPaint GetFillPaint(OxyColor fillColor, EdgeRenderingMode edgeRenderingMode)
+        {
+            this.paint.Color = fillColor.ToSKColor();
+            this.paint.Style = SKPaintStyle.Fill;
+            this.paint.IsAntialias = this.ShouldUseAntiAliasing(edgeRenderingMode);
+            this.paint.PathEffect = null;
+            return this.paint;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SKPaint"/> containing information needed to render an image.
+        /// </summary>
+        /// <remarks>
+        /// This modifies and returns the local <see cref="paint"/> instance.
+        /// </remarks>
+        /// <param name="opacity">The opacity.</param>
+        /// <param name="interpolate">A value indicating whether interpolation should be used.</param>
+        /// <returns>The paint.</returns>
+        private SKPaint GetImagePaint(double opacity, bool interpolate)
+        {
+            this.paint.Color = new SKColor(0, 0, 0, (byte)(255 * opacity));
+            this.paint.FilterQuality = interpolate ? SKFilterQuality.High : SKFilterQuality.None;
+            this.paint.IsAntialias = true;
+            return this.paint;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SKPaint"/> containing information needed to render a line.
+        /// </summary>
+        /// <remarks>
+        /// This modifies and returns the local <see cref="paint"/> instance.
+        /// </remarks>
+        /// <param name="strokeColor">The stroke color.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <param name="dashArray">The dash array.</param>
+        /// <param name="lineJoin">The line join.</param>
+        /// <returns>The paint.</returns>
+        private SKPaint GetLinePaint(OxyColor strokeColor, double strokeThickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray, LineJoin lineJoin)
+        {
+            var paint = this.GetStrokePaint(strokeColor, strokeThickness, edgeRenderingMode);
+
+            if (dashArray != null)
+            {
+                var actualDashArray = this.ConvertDashArray(dashArray, paint.StrokeWidth);
+                paint.PathEffect = SKPathEffect.CreateDash(actualDashArray, 0);
+            }
+
+            paint.StrokeJoin = lineJoin switch
+            {
+                LineJoin.Miter => SKStrokeJoin.Miter,
+                LineJoin.Round => SKStrokeJoin.Round,
+                LineJoin.Bevel => SKStrokeJoin.Bevel,
+                _ => throw new ArgumentOutOfRangeException(nameof(lineJoin))
+            };
+
+            return paint;
+        }
+
+        /// <summary>
+        /// Gets an empty <see cref="SKPath"/>.
+        /// </summary>
+        /// <remarks>
+        /// This clears and returns the local <see cref="path"/> instance.
+        /// </remarks>
+        /// <returns>The path.</returns>
+        private SKPath GetPath()
+        {
+            this.path.Reset();
+            return this.path;
+        }
+
+        /// <summary>
+        /// Gets the snapping offset for the specified stroke thickness.
+        /// </summary>
+        /// <remarks>
+        /// This takes into account that lines with even stroke thickness should be snapped to the border between two pixels while lines with odd stroke thickness should be snapped to the middle of a pixel.
+        /// </remarks>
+        /// <param name="thickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The snap offset.</returns>
+        private float GetSnapOffset(double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            var actualThickness = this.GetActualThickness(thickness, edgeRenderingMode);
+            return GetSnapOffset(actualThickness);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SKPaint"/> containing information needed to render a stroke.
+        /// </summary>
+        /// <remarks>
+        /// This modifies and returns the local <see cref="paint"/> instance.
+        /// </remarks>
+        /// <param name="strokeColor">The stroke color.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The paint.</returns>
+        private SKPaint GetStrokePaint(OxyColor strokeColor, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            this.paint.Color = strokeColor.ToSKColor();
+            this.paint.Style = SKPaintStyle.Stroke;
+            this.paint.IsAntialias = this.ShouldUseAntiAliasing(edgeRenderingMode);
+            this.paint.StrokeWidth = this.GetActualThickness(strokeThickness, edgeRenderingMode);
+            this.paint.PathEffect = null;
+            this.paint.StrokeJoin = SKStrokeJoin.Miter;
+            return this.paint;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SKPaint"/> containing information needed to render text.
+        /// </summary>
+        /// <remarks>
+        /// This modifies and returns the local <see cref="paint"/> instance.
+        /// </remarks>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">The font size.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <returns>The paint.</returns>
+        private SKPaint GetTextPaint(string fontFamily, double fontSize, double fontWeight)
+        {
+            var fontDescriptor = new FontDescriptor(fontFamily, fontWeight);
+            if (!this.typefaceCache.TryGetValue(fontDescriptor, out var typeface))
+            {
+                typeface = SKTypeface.FromFamilyName(fontFamily, new SKFontStyle((int)fontWeight, (int)SKFontStyleWidth.Normal, SKFontStyleSlant.Upright));
+                this.typefaceCache.Add(fontDescriptor, typeface);
+            }
+
+            this.paint.Typeface = typeface;
+            this.paint.TextSize = this.Convert(fontSize);
+            this.paint.IsAntialias = true;
+            this.paint.Style = SKPaintStyle.Fill;
+            this.paint.HintingLevel = this.RendersToScreen ? SKPaintHinting.Full : SKPaintHinting.NoHinting;
+            this.paint.SubpixelText = this.RendersToScreen;
+            this.paint.TextAlign = SKTextAlign.Left;
+            return this.paint;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether anti-aliasing should be used taking in account the specified edge rendering mode.
+        /// </summary>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns><c>true</c> if anti-aliasing should be used; <c>false</c> otherwise.</returns>
+        private bool ShouldUseAntiAliasing(EdgeRenderingMode edgeRenderingMode)
+        {
+            return edgeRenderingMode != EdgeRenderingMode.PreferSpeed;
+        }
+
+        /// <summary>
+        /// Represents a font description.
+        /// </summary>
+        private struct FontDescriptor
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="FontDescriptor"/> struct.
+            /// </summary>
+            /// <param name="fontFamily">The font family.</param>
+            /// <param name="fontWeight">The font weight.</param>
+            public FontDescriptor(string fontFamily, double fontWeight)
+            {
+                this.FontFamily = fontFamily;
+                this.FontWeight = fontWeight;
+            }
+
+            /// <summary>
+            /// The font family.
+            /// </summary>
+            public string FontFamily { get; }
+
+            /// <summary>
+            /// The font weight.
+            /// </summary>
+            public double FontWeight { get; }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj)
+            {
+                return obj is FontDescriptor other && this.FontFamily == other.FontFamily && this.FontWeight == other.FontWeight;
+            }
+
+            /// <inheritdoc/>
+            public override int GetHashCode()
+            {
+                var hashCode = -1030903623;
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.FontFamily);
+                hashCode = hashCode * -1521134295 + this.FontWeight.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/SkiaSvgExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaSvgExporter.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SkiaSvgExporter.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using global::SkiaSharp;
+    using System.IO;
+
+    /// <summary>
+    /// Provides functionality to export plots to scalable vector graphics using the SkiaSharp SVG canvas.
+    /// </summary>
+    public class SkiaSvgExporter : IExporter
+    {
+        /// <summary>
+        /// Gets or sets the height (in user units) of the output area.
+        /// </summary>
+        public float Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width (in user units) of the output area.
+        /// </summary>
+        public float Width { get; set; }
+
+        /// <inheritdoc/>
+        public void Export(IPlotModel model, Stream stream)
+        {
+            using var skStream = new SKManagedWStream(stream);
+            using var writer = new SKXmlStreamWriter(skStream);
+            using var canvas = SKSvgCanvas.Create(new SKRect(0, 0, this.Width, this.Height), writer);
+            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas };
+            model.Update(true);
+            model.Render(context, new OxyRect(0, 0, this.Width, this.Height));
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/SvgExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/SvgExporter.cs
@@ -1,0 +1,32 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SvgExporter.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    using System;
+
+    /// <summary>
+    /// Provides functionality to export plots to scalable vector graphics using SkiaSharp-based text measuring.
+    /// </summary>
+    public sealed class SvgExporter : OxyPlot.SvgExporter, IDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SvgExporter" /> class, using a <see cref="SkiaRenderContext"/> as text measurer.
+        /// </summary>
+        public SvgExporter()
+        {
+            this.TextMeasurer = new SkiaRenderContext();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            var skiaMeasurer = this.TextMeasurer as SkiaRenderContext;
+            skiaMeasurer?.Dispose();
+            this.TextMeasurer = null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1509.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add `SkiaRenderContext`, implementing `IRenderContext` using SkiaSharp
- Add PNG, PDF, SVG and JPEG exporters based on `SkiaRenderContext`

See also my notes in #1509.

@oxyplot/admins
