### PR TITLE
Add text shaping support to SkiaRenderContext (#1520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - EdgeRenderingMode property to PlotElement, allowing customization of the way edges are treated by the renderer (#1428, #1358, #1077, #843, #145)
 - Color palettes Viridis, Plasma, Magma, Inferno and Cividis (#1505)
 - Renderer based on SkiaSharp, including exporters for PNG, JPEG, PDF and SVG (#1509)
+- Text shaping support to SkiaRenderContext (#1520)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -356,7 +356,7 @@ namespace ExampleLibrary
         /// <returns>
         /// A plot model.
         /// </returns>
-        private static PlotModel DrawTextWithMetrics(string text, string font, double fontSize, double expectedWidth, double expectedHeight, double baseline, double xheight, double ascent, double descent, double before, double after, string platform)
+        public static PlotModel DrawTextWithMetrics(string text, string font, double fontSize, double expectedWidth, double expectedHeight, double baseline, double xheight, double ascent, double descent, double before, double after, string platform)
         {
             // http://msdn.microsoft.com/en-us/library/ms742190(v=vs.110).aspx
             // http://msdn.microsoft.com/en-us/library/xwf9s90b(v=vs.110).aspx

--- a/Source/OxyPlot.SkiaSharp.Tests/PngExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/PngExporterTests.cs
@@ -8,7 +8,7 @@ namespace OxyPlot.SkiaSharp.Tests
 {
     using System;
     using System.IO;
-
+    using ExampleLibrary;
     using NUnit.Framework;
 
     using OxyPlot.Series;
@@ -88,6 +88,41 @@ namespace OxyPlot.SkiaSharp.Tests
             using (var stream = File.OpenWrite(fileName))
             {
                 exporter.Export(plotModel, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ExportUseTextShapingAlignment(bool useTextShaping)
+        {
+            var model = RenderingCapabilities.DrawTextAlignment();
+            model.Background = OxyColors.White;
+            var fileName = Path.Combine(this.outputDirectory, $"Alignment, UseTextShaping={useTextShaping}.png");
+            var exporter = new PngExporter { Width = 450, Height = 200, UseTextShaping = useTextShaping };
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(model, stream);
+            }
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ExportUseTextShapingMeasurements(bool useTextShaping)
+        {
+            var model = RenderingCapabilities.DrawTextWithMetrics("TeffVAll", "Arial", 60, double.NaN, double.NaN, 105, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, "");
+
+            model.Background = OxyColors.White;
+            var fileName = Path.Combine(this.outputDirectory, $"Measurements, UseTextShaping={useTextShaping}.png");
+            var exporter = new PngExporter { Width = 450, Height = 150, UseTextShaping = useTextShaping };
+            using (var stream = File.OpenWrite(fileName))
+            {
+                exporter.Export(model, stream);
             }
 
             Assert.IsTrue(File.Exists(fileName));

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="1.68.1.1" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="1.68.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />

--- a/Source/OxyPlot.SkiaSharp/PdfExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PdfExporter.cs
@@ -30,6 +30,11 @@ namespace OxyPlot.SkiaSharp
         public float Width { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether text shaping should be used when rendering text.
+        /// </summary>
+        public bool UseTextShaping { get; set; } = true;
+
+        /// <summary>
         /// Exports the specified model to a file.
         /// </summary>
         /// <param name="model">The model.</param>
@@ -60,7 +65,7 @@ namespace OxyPlot.SkiaSharp
         {
             using var document = SKDocument.CreatePdf(stream, this.Dpi);
             using var pdfCanvas = document.BeginPage(this.Width, this.Height);
-            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = pdfCanvas };
+            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = pdfCanvas, UseTextShaping = this.UseTextShaping };
             var dpiScale = this.Dpi / 96;
             context.DpiScale = dpiScale;
             model.Update(true);

--- a/Source/OxyPlot.SkiaSharp/PngExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PngExporter.cs
@@ -30,6 +30,11 @@ namespace OxyPlot.SkiaSharp
         public int Width { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether text shaping should be used when rendering text.
+        /// </summary>
+        public bool UseTextShaping { get; set; } = true;
+
+        /// <summary>
         /// Exports the specified model to a file.
         /// </summary>
         /// <param name="model">The model.</param>
@@ -63,7 +68,7 @@ namespace OxyPlot.SkiaSharp
             using var bitmap = new SKBitmap(this.Width, this.Height);
 
             using (var canvas = new SKCanvas(bitmap))
-            using (var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas })
+            using (var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas, UseTextShaping = this.UseTextShaping })
             {
                 var dpiScale = this.Dpi / 96;
                 context.DpiScale = dpiScale;

--- a/Source/OxyPlot.SkiaSharp/SkiaSvgExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaSvgExporter.cs
@@ -30,7 +30,8 @@ namespace OxyPlot.SkiaSharp
             using var skStream = new SKManagedWStream(stream);
             using var writer = new SKXmlStreamWriter(skStream);
             using var canvas = SKSvgCanvas.Create(new SKRect(0, 0, this.Width, this.Height), writer);
-            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas };
+            // SVG export does not work with UseTextShaping=true. However SVG does text shaping by itself anyway, so we can just disable it
+            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas, UseTextShaping = false };
             model.Update(true);
             model.Render(context, new OxyRect(0, 0, this.Width, this.Height));
         }


### PR DESCRIPTION
Fixes #1520.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add text shaping support to `SkiaRenderContext`
- This also improves horizontal text alignment when no text shaping is used, particular for `SkiaSvgExporter` (previously this could be slightly inaccurate because of SVG's text shaping)

@oxyplot/admins
