### PR TITLE
Fix possible out-of-bounds exception in HeatMapSeries HitTest (#1524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Custom tracker strings can cause exception in histogram chart (#1455)
 - OxyPlot.WindowsForms package description (#1457)
 - NullReference in VolumeSeries if no data in Items list (#1491)
+- Possible out-of-bounds exception in HeatMapSeries HitTest (#1524)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -384,6 +384,12 @@ namespace OxyPlot.Series
                 point = this.Transform(p);
             }
 
+            // perform a second range check in index space to accomodate rounding
+            if (i < -0.5 || i > this.Data.GetLength(0) - 0.5 || j < -0.5 || j > this.Data.GetLength(1) - 0.5)
+            {
+                return null;
+            }
+
             var value = GetValue(this.Data, i, j);
             var colorAxis = this.ColorAxis as Axis;
             var colorAxisTitle = (colorAxis != null ? colorAxis.Title : null) ?? DefaultColorAxisTitle;


### PR DESCRIPTION
Fixes #1524 .

This deals with a boundary condition, where mid-point rounding for non-interpolated heatmaps results in extreme values snapping to indexes outside the bounds of the heat-map once in index space.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add an additional bounds check to `HeatMapSeries.GetNearsetPoint` to avoid passing extreme indexes to `GetValue` which can cause a crash when using the tracker

This should only change behaviour where previously the hit test would crash the application: instead it will now fail cleanly.

### Notes

 - `GetValue` assumes in-bounds input; crashes if they exceed to equal the dimension + 1
 - `IsPointInRange` has inclusive upper and lower bounds
 - `HitTest` does a range check with `IsPointInRange`, but may exceed the exclusive upper bound after rounding if `interpolation == false`.
 - It is not unthinkable that values which are in-bounds before performing the various computations in `HitTest` are out-of-bounds by the end due to floating point errors: this change should accommodate those as well

@oxyplot/admins
