### PR TITLE
WPF CanvasRenderContext draws ellipses too small by half stroke thickness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - OxyPlot.WindowsForms package description (#1457)
 - NullReference in VolumeSeries if no data in Items list (#1491)
 - Possible out-of-bounds exception in HeatMapSeries HitTest (#1524)
+- WPF CanvasRenderContext draws ellipses too small by half stroke thickness (#1537)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -136,17 +136,7 @@ namespace OxyPlot.Wpf
         ///<inheritdoc/>
         public void DrawEllipse(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
-            var e = this.CreateAndAdd<Ellipse>(rect.Left, rect.Top);
-            this.SetStroke(e, stroke, thickness, edgeRenderingMode);
-            if (fill.IsVisible())
-            {
-                e.Fill = this.GetCachedBrush(fill);
-            }
-
-            e.Width = rect.Width;
-            e.Height = rect.Height;
-            Canvas.SetLeft(e, rect.Left);
-            Canvas.SetTop(e, rect.Top);
+            this.DrawEllipses(new[] { rect }, fill, stroke, thickness, edgeRenderingMode);
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
Fixes #1537.

### Checklist

- [ ] I have included examples or tests ('Ellipses - EdgeRenderingMode' example covers this)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Make `CanvasRenderContext.DrawEllipse(...)` call `CanvasRenderContext.DrawEllipses(...)`, which functions correctly.

@oxyplot/admins
