### PR TITLE
Add RenderTarget property to SkiaRenderContext (#1539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Extract most of the functionality from OxyPlot.Wpf into OxyPlot.Wpf.Shared to allow code sharing with other WPF PlotViews (#1515)
 - WPF ExampleBrowser can switch between Canvas and SkiaSharp renderers (#1515)
 - OxyPlot.ImageSharp now targets .NET Standard 1.3 (#1530)
+- SkiaRenderContext does not apply pixel snapping when rendering to vector graphic (#1539)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/OxyPlot.SkiaSharp/JpegExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/JpegExporter.cs
@@ -70,7 +70,7 @@ namespace OxyPlot.SkiaSharp
             using var bitmap = new SKBitmap(this.Width, this.Height);
 
             using (var canvas = new SKCanvas(bitmap))
-            using (var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas })
+            using (var context = new SkiaRenderContext { RenderTarget = RenderTarget.PixelGraphic, SkCanvas = canvas })
             {
                 canvas.Clear(SKColors.White);
                 var dpiScale = this.Dpi / 96;

--- a/Source/OxyPlot.SkiaSharp/PdfExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PdfExporter.cs
@@ -65,7 +65,7 @@ namespace OxyPlot.SkiaSharp
         {
             using var document = SKDocument.CreatePdf(stream, this.Dpi);
             using var pdfCanvas = document.BeginPage(this.Width, this.Height);
-            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = pdfCanvas, UseTextShaping = this.UseTextShaping };
+            using var context = new SkiaRenderContext { RenderTarget = RenderTarget.VectorGraphic, SkCanvas = pdfCanvas, UseTextShaping = this.UseTextShaping };
             var dpiScale = this.Dpi / 96;
             context.DpiScale = dpiScale;
             model.Update(true);

--- a/Source/OxyPlot.SkiaSharp/PngExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PngExporter.cs
@@ -68,7 +68,7 @@ namespace OxyPlot.SkiaSharp
             using var bitmap = new SKBitmap(this.Width, this.Height);
 
             using (var canvas = new SKCanvas(bitmap))
-            using (var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas, UseTextShaping = this.UseTextShaping })
+            using (var context = new SkiaRenderContext { RenderTarget = RenderTarget.PixelGraphic, SkCanvas = canvas, UseTextShaping = this.UseTextShaping })
             {
                 var dpiScale = this.Dpi / 96;
                 context.DpiScale = dpiScale;

--- a/Source/OxyPlot.SkiaSharp/RenderTarget.cs
+++ b/Source/OxyPlot.SkiaSharp/RenderTarget.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RenderTarget.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.SkiaSharp
+{
+    /// <summary>
+    /// Defines a render target for <see cref="SkiaRenderContext"/>.
+    /// </summary>
+    public enum RenderTarget
+    {
+        /// <summary>
+        /// Indicates that the <see cref="SkiaRenderContext"/> renders to a screen.
+        /// </summary>
+        /// <remarks>
+        /// The render context may try to snap shapes to device pixels and will use sub-pixel text rendering.
+        /// </remarks>
+        Screen,
+
+        /// <summary>
+        /// Indicates that the <see cref="SkiaRenderContext"/> renders to a pixel graphic.
+        /// </summary>
+        /// <remarks>
+        /// The render context may try to snap shapes to pixels, but will not use sub-pixel text rendering.
+        /// </remarks>
+        PixelGraphic,
+
+        /// <summary>
+        /// Indicates that the <see cref="SkiaRenderContext"/> renders to a vector graphic.
+        /// </summary>
+        /// <remarks>
+        /// The render context will not use any rendering enhancements that are specific to pixel graphics.
+        /// </remarks>
+        VectorGraphic
+    }
+}

--- a/Source/OxyPlot.SkiaSharp/SvgExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/SvgExporter.cs
@@ -31,7 +31,7 @@ namespace OxyPlot.SkiaSharp
             using var writer = new SKXmlStreamWriter(skStream);
             using var canvas = SKSvgCanvas.Create(new SKRect(0, 0, this.Width, this.Height), writer);
             // SVG export does not work with UseTextShaping=true. However SVG does text shaping by itself anyway, so we can just disable it
-            using var context = new SkiaRenderContext { RendersToScreen = false, SkCanvas = canvas, UseTextShaping = false };
+            using var context = new SkiaRenderContext { RenderTarget = RenderTarget.VectorGraphic, SkCanvas = canvas, UseTextShaping = false };
             model.Update(true);
             model.Render(context, new OxyRect(0, 0, this.Width, this.Height));
         }


### PR DESCRIPTION
Fixes #1539.

### Checklist

- [ ] I have included examples or tests (can be verified by existing examples)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add `RenderTarget` property to `SkiaRenderContext`
- Update SkiaSharp-based exporters to define an appropriate `RenderTarget`

@oxyplot/admins
