### PR TITLE
Add consistent support for unix line endings (#1545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - JpegExporter for OxyPlot.ImageSharp
 - Multi-line aligned text rendering example
 - WindowsForms ExampleBrowser can display transposed versions of examples (#1535)
+- Example for Issue #1545 showing the use of different line endings
+- Support for unix line endings in OxyPlot.ImageSharp, OxyPlot.Svg, and OxyPlot.Pdf (#1545)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -2265,6 +2265,20 @@ namespace ExampleLibrary
             return plot;
         }
 
+        [Example("#1545: Some render contexts do not support unix line endings.")]
+        public static PlotModel UnixLineEndings()
+        {
+            var plot = new PlotModel() { Title = "Some render contexts\r\ndo not support\nunix line endings." };
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = 0, Maximum = 100 });
+            plot.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 100 });
+
+            plot.Annotations.Add(new TextAnnotation() { Text = "CRLF\r\nLine\r\nEndings", TextPosition = new DataPoint(16, 50), FontSize = 12 });
+            plot.Annotations.Add(new TextAnnotation() { Text = "LF\nLine\nEndings", TextPosition = new DataPoint(50, 50), FontSize = 12 });
+            plot.Annotations.Add(new TextAnnotation() { Text = "Mixed\r\nLine\nEndings", TextPosition = new DataPoint(84, 50), FontSize = 12 });
+
+            return plot;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }

--- a/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
+++ b/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
@@ -13,7 +13,6 @@ namespace OxyPlot.ImageSharp
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-
     using SixLabors.Fonts;
     using SixLabors.Fonts.Exceptions;
     using SixLabors.ImageSharp;
@@ -217,7 +216,7 @@ namespace OxyPlot.ImageSharp
             // Add a little more onto the path so that it doesn't wrap early
             var pathWidthFudge = 1.1f;
 
-            var lines = text.Split(new[] { '\n' }, StringSplitOptions.None);
+            var lines = StringHelper.SplitLines(text);
             for (int li = 0; li < lines.Length; li++)
             {
                 var line = lines[li];
@@ -568,24 +567,13 @@ namespace OxyPlot.ImageSharp
         }
 
         /// <summary>
-        /// Counts the number of lines in the text, by adding one to the number of line-feeds.
+        /// Counts the number of lines in the text.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <returns>The number of lines in the text.</returns>
         private static int CountLines(string text)
         {
-            var count = 1;
-
-            // TODO: should we omit leading/trailing empty lines? (Compare with WinForms)
-            for (int i = 0; i < text.Length; i++)
-            {
-                if (text[i] == '\n')
-                {
-                    count++;
-                }
-            }
-
-            return count;
+            return StringHelper.SplitLines(text).Length;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Pdf/PortableDocumentFont.cs
+++ b/Source/OxyPlot/Pdf/PortableDocumentFont.cs
@@ -9,8 +9,6 @@
 
 namespace OxyPlot
 {
-    using System.Text.RegularExpressions;
-
     /// <summary>
     /// Represents a font that can be used in a <see cref="PortableDocument" />.
     /// </summary>
@@ -106,7 +104,7 @@ namespace OxyPlot
         {
             int wmax = 0;
 
-            var lines = Regex.Split(text, "\r\n");
+            var lines = StringHelper.SplitLines(text);
 
             int lineCount = lines.Length;
 

--- a/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
+++ b/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
@@ -562,7 +562,7 @@ namespace OxyPlot
         /// <param name="dy">The line spacing.</param>
         public static void DrawMultilineText(this IRenderContext rc, ScreenPoint point, string text, OxyColor color, string fontFamily = null, double fontSize = 10, double fontWeight = FontWeights.Normal, double dy = 12)
         {
-            var lines = text.Split(new[] { "\r\n" }, StringSplitOptions.None);
+            var lines = StringHelper.SplitLines(text);
             for (int i = 0; i < lines.Length; i++)
             {
                 rc.DrawText(

--- a/Source/OxyPlot/Svg/SvgRenderContext.cs
+++ b/Source/OxyPlot/Svg/SvgRenderContext.cs
@@ -12,7 +12,6 @@ namespace OxyPlot
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Provides a render context for scalable vector graphics output.
@@ -159,8 +158,8 @@ namespace OxyPlot
                 return;
             }
 
-            var lines = Regex.Split(text, "\r\n");
-            
+            var lines = StringHelper.SplitLines(text);
+
             var textSize = this.MeasureText(text, fontFamily, fontSize, fontWeight);
             var lineHeight = textSize.Height / lines.Length;
             var lineOffset = new ScreenVector(-Math.Sin(rotate / 180.0 * Math.PI) * lineHeight, +Math.Cos(rotate / 180.0 * Math.PI) * lineHeight);

--- a/Source/OxyPlot/Utilities/StringHelper.cs
+++ b/Source/OxyPlot/Utilities/StringHelper.cs
@@ -117,5 +117,15 @@ namespace OxyPlot
                 }
             }
         }
+
+        /// <summary>
+        /// Splits the given text into separate lines.
+        /// </summary>
+        /// <param name="text">The text to split.</param>
+        /// <returns>An array of the individual lines.</returns>
+        public static string[] SplitLines(string text)
+        {
+            return Regex.Split(text, "\r?\n");
+        }
     }
 }


### PR DESCRIPTION
Fixes #1545 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds an example with mixed LF and CRLF line endings
- Adds a `SplitLines` method to `StringHelper` so that string splitting is done all in one place
- Call the aforementioned `SplitLines` methods in `OxyPlot.ImageSharp`, `OxyPlot.Svg`, `OxyPlot.Pdf`, and the `DrawMultilineText` helper so that they all will provide consistent support for line endings
- Remove some embarrassing micro-optimisation in `OxyPlot.ImageSharp.ImageRenderContext`

The method is not used in e.g. WinForms because the renderer handles the line-endings as intended already.

Originally the plan was to put the method in `RenderContextBase` since this is only a concern for rendering; however, `OxyPlot.Pdf` support would have been tricky in this case, and I don't see any reason why this method shouldn't be generally available. My main concern is that it is a general enough method that it may conflict with user's code, and as such shouldn't be an extension method.

@oxyplot/admins
