### PR TITLE
Add support for multi-line text to SkiaRenderContext (#1538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - WindowsForms ExampleBrowser can display transposed versions of examples (#1535)
 - Example for Issue #1545 showing the use of different line endings
 - Support for unix line endings in OxyPlot.ImageSharp, OxyPlot.Svg, and OxyPlot.Pdf (#1545)
+- Multi-Line Text support to SkiaRenderContext (#1538)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -263,6 +263,32 @@ namespace ExampleLibrary
         }
 
         /// <summary>
+        /// Shows multi-line alignment capabilities for the DrawText method.
+        /// </summary>
+        /// <returns>A plot model.</returns>
+        [Example("DrawText - Multi-line Alignment/Rotation")]
+        public static PlotModel DrawMultilineTextAlignmentRotation()
+        {
+            var model = new PlotModel();
+            model.Annotations.Add(new DelegateAnnotation(rc =>
+            {
+                for (var ha = HorizontalAlignment.Left; ha <= HorizontalAlignment.Right; ha++)
+                {
+                    for (var va = VerticalAlignment.Top; va <= VerticalAlignment.Bottom; va++)
+                    {
+                        var origin = new ScreenPoint(((int)ha + 2) * 170, ((int)va + 2) * 170);
+                        rc.FillCircle(origin, 3, OxyColors.Blue, EdgeRenderingMode.Adaptive);
+                        for (var rotation = 0; rotation < 360; rotation += 90)
+                        {
+                            rc.DrawText(origin, $"R{rotation:000}\n{ha}\n{va}", OxyColors.Black, fontSize: 20d, rotation: rotation, horizontalAlignment: ha, verticalAlignment: va);
+                        }
+                    }
+                }
+            }));
+            return model;
+        }
+
+        /// <summary>
         /// Shows color capabilities for the DrawText method.
         /// </summary>
         /// <returns>A plot model.</returns>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -7,6 +7,7 @@
         <Copyright>OxyPlot contributors</Copyright>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Platforms>AnyCPU;x86;x64</Platforms>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|AnyCPU'">
         <PlatformTarget>x86</PlatformTarget>

--- a/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
@@ -6,6 +6,7 @@
 
 namespace OxyPlot.SkiaSharp.Tests
 {
+    using ExampleLibrary;
     using NUnit.Framework;
     using OxyPlot.SkiaSharp;
     using System.IO;
@@ -22,6 +23,15 @@ namespace OxyPlot.SkiaSharp.Tests
             var exporter = new SvgExporter { Width = 1000, Height = 750 };
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
             ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".svg");
+        }
+
+        [Test]
+        public void TestMultilineAlignment()
+        {
+            var exporter = new SvgExporter { Width = 1000, Height = 750 };
+            var model = RenderingCapabilities.DrawMultilineTextAlignmentRotation();
+            using var stream = File.Create(Path.Combine(this.outputDirectory, "Multiline-Alignment.svg"));
+            exporter.Export(model, stream);
         }
 
         [OneTimeSetUp]

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -354,12 +354,14 @@ namespace OxyPlot.SkiaSharp
             var x = this.Convert(p.X);
             var y = this.Convert(p.Y);
 
-            var metrics = paint.FontMetrics;
+            var lines = StringHelper.SplitLines(text);
+            var lineHeight = paint.GetFontMetrics(out var metrics);
+
             var deltaY = verticalAlignment switch
             {
                 VerticalAlignment.Top => -metrics.Ascent,
-                VerticalAlignment.Middle => -(metrics.Ascent + metrics.Descent) / 2,
-                VerticalAlignment.Bottom => -metrics.Descent,
+                VerticalAlignment.Middle => -(metrics.Ascent + metrics.Descent + lineHeight * (lines.Length - 1)) / 2,
+                VerticalAlignment.Bottom => -metrics.Descent - lineHeight * (lines.Length - 1),
                 _ => throw new ArgumentOutOfRangeException(nameof(verticalAlignment))
             };
 
@@ -367,31 +369,36 @@ namespace OxyPlot.SkiaSharp
             this.SkCanvas.Translate(x, y);
             this.SkCanvas.RotateDegrees((float)rotation);
 
-            if (this.UseTextShaping)
+            foreach (var line in lines)
             {
-                var width = this.MeasureText(text, shaper, paint);
-                var deltaX = horizontalAlignment switch
+                if (this.UseTextShaping)
                 {
-                    HorizontalAlignment.Left => 0,
-                    HorizontalAlignment.Center => -width / 2,
-                    HorizontalAlignment.Right => -width,
-                    _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
-                };
+                    var width = this.MeasureText(line, shaper, paint);
+                    var deltaX = horizontalAlignment switch
+                    {
+                        HorizontalAlignment.Left => 0,
+                        HorizontalAlignment.Center => -width / 2,
+                        HorizontalAlignment.Right => -width,
+                        _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
+                    };
 
-                this.paint.TextAlign = SKTextAlign.Left;
-                this.SkCanvas.DrawShapedText(shaper, text, deltaX, deltaY, paint);
-            }
-            else
-            {
-                paint.TextAlign = horizontalAlignment switch
+                    this.paint.TextAlign = SKTextAlign.Left;
+                    this.SkCanvas.DrawShapedText(shaper, line, deltaX, deltaY, paint);
+                }
+                else
                 {
-                    HorizontalAlignment.Left => SKTextAlign.Left,
-                    HorizontalAlignment.Center => SKTextAlign.Center,
-                    HorizontalAlignment.Right => SKTextAlign.Right,
-                    _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
-                };
+                    paint.TextAlign = horizontalAlignment switch
+                    {
+                        HorizontalAlignment.Left => SKTextAlign.Left,
+                        HorizontalAlignment.Center => SKTextAlign.Center,
+                        HorizontalAlignment.Right => SKTextAlign.Right,
+                        _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
+                    };
 
-                this.SkCanvas.DrawText(text, 0, deltaY, paint);
+                    this.SkCanvas.DrawText(line, 0, deltaY, paint);
+                }
+
+                deltaY += lineHeight;
             }
         }
 
@@ -403,9 +410,11 @@ namespace OxyPlot.SkiaSharp
                 return new OxySize(0, 0);
             }
 
+            var lines = StringHelper.SplitLines(text);
             var paint = this.GetTextPaint(fontFamily, fontSize, fontWeight, out var shaper);
-            var width = this.MeasureText(text, shaper, paint);
-            var height = paint.GetFontMetrics(out _);
+            var height = paint.GetFontMetrics(out _) * lines.Length;
+            var width = lines.Max(line => this.MeasureText(line, shaper, paint)); 
+
             return new OxySize(this.ConvertBack(width), this.ConvertBack(height));
         }
 


### PR DESCRIPTION
Fixes #1538.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add support for multi-line text to `SkiaRenderContext` using the `StringHelper.SplitLines(...)` method
- Add an additional example showing multi-line text in combination with rotation and alignment
- Add an additional SkiaSharp-based SVG export test based in the new example to also cover the code path without text shaping 

@oxyplot/admins
