### PR TITLE
Reduce dependence on default axes in ExampleLibrary (#1547)

### DIFF
--- a/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
@@ -602,6 +602,7 @@ namespace ExampleLibrary
                     Position = AxisPosition.Left,
                     MinimumRange = 400
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -616,6 +617,7 @@ namespace ExampleLibrary
                     Position = AxisPosition.Left,
                     MaximumRange = 40
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -1078,6 +1080,7 @@ namespace ExampleLibrary
         [Example("No axes defined")]
         public static PlotModel NoAxesDefined()
         {
+            // TODO: as part of #992, replace this with the new appropriate behaviour for missing axes (e.g. throw) or otherwise remove
             var plotModel = new PlotModel { Title = "No axes defined", Subtitle = "Bottom and left axes are auto-generated." };
             plotModel.Series.Add(new FunctionSeries(Math.Cos, 0, 10, 400));
             return plotModel;

--- a/Source/Examples/ExampleLibrary/Axes/CartesianAxesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/CartesianAxesExamples.cs
@@ -7,7 +7,7 @@
 namespace ExampleLibrary
 {
     using System;
-
+    using ExampleLibrary.Utilities;
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
@@ -18,17 +18,19 @@ namespace ExampleLibrary
         [Example("Trigonometric functions")]
         public static PlotModel FunctionSeries()
         {
-            var pm = new PlotModel { Title = "Trigonometric functions", PlotType = PlotType.Cartesian };
-            pm.Series.Add(new FunctionSeries(Math.Sin, -10, 10, 0.1, "sin(x)"));
-            pm.Series.Add(new FunctionSeries(Math.Cos, -10, 10, 0.1, "cos(x)"));
-            pm.Series.Add(new FunctionSeries(t => 5 * Math.Cos(t), t => 5 * Math.Sin(t), 0, 2 * Math.PI, 1000, "cos(t),sin(t)"));
-            return pm;
+            var plot = PlotModelUtilities.CreateModelWithDefaultAxes("Trigonometric functions");
+            plot.PlotType = PlotType.Cartesian;
+            plot.Series.Add(new FunctionSeries(Math.Sin, -10, 10, 0.1, "sin(x)"));
+            plot.Series.Add(new FunctionSeries(Math.Cos, -10, 10, 0.1, "cos(x)"));
+            plot.Series.Add(new FunctionSeries(t => 5 * Math.Cos(t), t => 5 * Math.Sin(t), 0, 2 * Math.PI, 1000, "cos(t),sin(t)"));
+            return plot;
         }
 
         [Example("Clover")]
         public static PlotModel Clover()
         {
-            var plot = new PlotModel { Title = "Parametric function", PlotType = PlotType.Cartesian };
+            var plot = PlotModelUtilities.CreateModelWithDefaultAxes("Parametric function");
+            plot.PlotType = PlotType.Cartesian;
             plot.Series.Add(new FunctionSeries(t => 2 * Math.Cos(2 * t) * Math.Cos(t), t => 2 * Math.Cos(2 * t) * Math.Sin(t),
                 0, Math.PI * 2, 1000, "2cos(2t)cos(t) , 2cos(2t)sin(t)"));
             return plot;

--- a/Source/Examples/ExampleLibrary/Axes/DateTimeAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/DateTimeAxisExamples.cs
@@ -231,7 +231,8 @@ namespace ExampleLibrary
         public static PlotModel LabelFormatter()
         {
             var model = new PlotModel { Title = "Using LabelFormatter to format labels by day of week" };
-            model.Axes.Add(new DateTimeAxis { LabelFormatter = x => DateTimeAxis.ToDateTime(x).DayOfWeek.ToString().Substring(0, 3) });
+            model.Axes.Add(new DateTimeAxis { Position = AxisPosition.Bottom, LabelFormatter = x => DateTimeAxis.ToDateTime(x).DayOfWeek.ToString().Substring(0, 3) });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
             var series = new LineSeries();
             model.Series.Add(series);
             for (int i = 0; i < 7; i++)

--- a/Source/Examples/ExampleLibrary/Axes/LogarithmicAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/LogarithmicAxisExamples.cs
@@ -136,6 +136,7 @@ namespace ExampleLibrary
         {
             var model = new PlotModel { Title = "AbsoluteMaximum = 1000" };
             model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left, Minimum = 0.1, Maximum = 1000, AbsoluteMaximum = 1000 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             model.Series.Add(new FunctionSeries(Math.Exp, 0, Math.Log(900), 100));
             return model;
         }
@@ -148,6 +149,7 @@ namespace ExampleLibrary
             int n = 0;
             logAxis.AxisChanged += (s, e) => { model.Subtitle = "Changed " + (n++) + " times. ActualMaximum=" + logAxis.ActualMaximum; };
             model.Axes.Add(logAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             model.Series.Add(new FunctionSeries(Math.Exp, 0, Math.Log(900), 100));
             return model;
         }

--- a/Source/Examples/ExampleLibrary/CustomSeries/CustomSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/CustomSeriesExamples.cs
@@ -12,6 +12,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("Custom series"), Tags("Series")]
     public static class CustomSeriesExamples
@@ -21,7 +22,7 @@ namespace ExampleLibrary
         {
             int n = 20;
 
-            var model = new PlotModel { Title = "ErrorSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ErrorSeries");
             var l = new Legend
             {
                 LegendPosition = LegendPosition.BottomRight
@@ -49,7 +50,7 @@ namespace ExampleLibrary
         [Example("LineSegmentSeries")]
         public static PlotModel LineSegmentSeries()
         {
-            var model = new PlotModel { Title = "LineSegmentSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSegmentSeries");
 
             var lss1 = new LineSegmentSeries { Title = "The first series" };
 
@@ -85,7 +86,7 @@ namespace ExampleLibrary
         [Example("FlagSeries")]
         public static PlotModel FlagSeries()
         {
-            var model = new PlotModel { Title = "FlagSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("FlagSeries");
 
             var s1 = new FlagSeries { Title = "Incidents", Color = OxyColors.Red };
             s1.Values.Add(2);

--- a/Source/Examples/ExampleLibrary/Discussions/DiscussionExamples.cs
+++ b/Source/Examples/ExampleLibrary/Discussions/DiscussionExamples.cs
@@ -14,6 +14,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("Z0 Discussions")]
     public class DiscussionExamples
@@ -21,7 +22,7 @@ namespace ExampleLibrary
         [Example("#445576: Invisible contour series")]
         public static PlotModel InvisibleContourSeries()
         {
-            var model = new PlotModel { Title = "Invisible contour series" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Invisible contour series");
             var cs = new ContourSeries
             {
                 IsVisible = false,
@@ -36,10 +37,10 @@ namespace ExampleLibrary
         [Example("#461507: StairStepSeries NullReferenceException")]
         public static PlotModel StairStepSeries_NullReferenceException()
         {
-            var plotModel1 = new PlotModel { Title = "StairStepSeries NullReferenceException" };
-            plotModel1.Series.Add(new StairStepSeries());
-            return plotModel1;
-        }
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("StairStepSeries NullReferenceException");
+            model.Series.Add(new StairStepSeries());
+            return model;
+        }   
 
         [Example("#501409: Heatmap interpolation color")]
         public static PlotModel HeatMapSeriesInterpolationColor()
@@ -49,7 +50,7 @@ namespace ExampleLibrary
             data[0, 1] = 0;
             data[0, 2] = -10;
 
-            var model = new PlotModel { Title = "HeatMapSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("HeatMapSeries");
             model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = new OxyPalette(OxyColors.Red, OxyColors.Green, OxyColors.Blue) });
 
             var hms = new HeatMapSeries
@@ -114,7 +115,8 @@ namespace ExampleLibrary
                 Title = "Reduced color saturation",
             };
 
-            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Left });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             // modify the saturation of the default colors
             model.DefaultColors = model.DefaultColors.Select(c => c.ChangeSaturation(0.5)).ToList();
@@ -139,7 +141,8 @@ namespace ExampleLibrary
                 Title = "Medium intensity colors",
             };
 
-            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Left });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             // See http://www.perceptualedge.com/articles/visual_business_intelligence/rules_for_using_color.pdf
             model.DefaultColors = new[]
@@ -174,7 +177,8 @@ namespace ExampleLibrary
                 Title = "Brewer colors (Accent scheme)",
             };
 
-            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Left });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             // See http://colorbrewer2.org/?type=qualitative&scheme=Accent&n=4
             model.DefaultColors = new[]
@@ -205,7 +209,8 @@ namespace ExampleLibrary
                 Title = "Brewer colors (Paired scheme)",
             };
 
-            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new CategoryAxis { Position = AxisPosition.Left });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             // See http://colorbrewer2.org/?type=qualitative&scheme=Paired&n=6
             model.DefaultColors = new[]

--- a/Source/Examples/ExampleLibrary/Examples/ItemsSourceExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/ItemsSourceExamples.cs
@@ -11,7 +11,7 @@ namespace ExampleLibrary
 {
     using System;
     using System.Collections.Generic;
-
+    using ExampleLibrary.Utilities;
     using OxyPlot;
     using OxyPlot.Series;
 
@@ -29,7 +29,7 @@ namespace ExampleLibrary
                 points.Add(new DataPoint(x, y(x)));
             }
 
-            var model = new PlotModel { Title = "Using IDataPoint" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Using IDataPoint");
             model.Series.Add(new LineSeries { ItemsSource = points });
             return model;
         }
@@ -44,7 +44,7 @@ namespace ExampleLibrary
                 points.Add(new PointType1(x, y(x)));
             }
 
-            var model = new PlotModel { Title = "Items implementing IDataPointProvider" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Items implementing IDataPointProvider");
             model.Series.Add(new LineSeries { ItemsSource = points });
             return model;
         }
@@ -59,7 +59,7 @@ namespace ExampleLibrary
                 points.Add(new PointType2(x, y(x)));
             }
 
-            var model = new PlotModel { Title = "Using Mapping property" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Using Mapping property");
             model.Series.Add(
                 new LineSeries
                 {
@@ -79,7 +79,7 @@ namespace ExampleLibrary
                 points.Add(new PointType2(x, y(x)));
             }
 
-            var model = new PlotModel { Title = "Using reflection (slow)" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Using reflection (slow)");
             model.Series.Add(new LineSeries { ItemsSource = points, DataFieldX = "Abscissa", DataFieldY = "Ordinate" });
             return model;
         }
@@ -94,7 +94,7 @@ namespace ExampleLibrary
                 points.Add(new ItemType3(x, y(x)));
             }
 
-            var model = new PlotModel { Title = "Using reflection with path (slow)" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Using reflection with path (slow)");
             model.Series.Add(new LineSeries { ItemsSource = points, DataFieldX = "Point.X", DataFieldY = "Point.Y" });
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
@@ -12,6 +12,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("Legends")]
     public static class LegendExamples
@@ -389,7 +390,7 @@ namespace ExampleLibrary
 
         private static PlotModel CreateModel(int n = 20)
         {
-            var model = new PlotModel { Title = "LineSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries");
 
             for (int i = 1; i <= n; i++)
             {

--- a/Source/Examples/ExampleLibrary/Examples/MouseEventExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/MouseEventExamples.cs
@@ -14,6 +14,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("Mouse Events")]
     public class MouseEventExamples
@@ -73,7 +74,7 @@ namespace ExampleLibrary
         [Example("MouseDown event and HitTestResult")]
         public static PlotModel MouseDownEventHitTestResult()
         {
-            var model = new PlotModel { Title = "MouseDown HitTestResult", Subtitle = "Reports the index of the nearest point." };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("MouseDown HitTestResult", "Reports the index of the nearest point.");
 
             var s1 = new LineSeries();
             s1.Points.Add(new DataPoint(0, 10));
@@ -105,7 +106,7 @@ namespace ExampleLibrary
         [Example("LineSeries and PlotModel MouseDown event")]
         public static PlotModel MouseDownEvent()
         {
-            var model = new PlotModel { Title = "MouseDown", Subtitle = "Left click to edit or add points." };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("MouseDown", "Left click to edit or add points.");
             var l = new Legend
             {
                 LegendSymbolLength = 40
@@ -449,7 +450,7 @@ namespace ExampleLibrary
         [Example("Add Series")]
         public static PlotModel AddSeriesByMouseDownEvent()
         {
-            var model = new PlotModel { Title = "MouseDown", Subtitle = "Left click to add series." };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("MouseDown", "Left click to add series.");
             var l = new Legend
             {
                 LegendSymbolLength = 40
@@ -474,7 +475,7 @@ namespace ExampleLibrary
         [Example("Select range")]
         public static PlotModel SelectRange()
         {
-            var model = new PlotModel { Title = "Select range", Subtitle = "Left click and drag to select a range." };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Select range", "Left click and drag to select a range.");
             model.Series.Add(new FunctionSeries(Math.Cos, 0, 40, 0.1));
 
             var range = new RectangleAnnotation { Fill = OxyColor.FromAColor(120, OxyColors.SkyBlue), MinimumX = 0, MaximumX = 0 };

--- a/Source/Examples/ExampleLibrary/Examples/PerformanceExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PerformanceExamples.cs
@@ -9,7 +9,7 @@ namespace ExampleLibrary
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using ExampleLibrary.Utilities;
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
@@ -20,7 +20,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 1M points")]
         public static PlotModel LineSeries1M()
         {
-            var model = new PlotModel { Title = "LineSeries, 1M points" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 1M points");
             var s1 = new LineSeries();
             AddPoints(s1.Points, 1000000);
             model.Series.Add(s1);
@@ -30,7 +30,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 1M points, EdgeRenderingMode==PreferSpeed")]
         public static PlotModel LineSeries1MSpeed()
         {
-            var model = new PlotModel { Title = "LineSeries, 1M points" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 1M points");
             var s1 = new LineSeries() { EdgeRenderingMode = EdgeRenderingMode.PreferSpeed };
             AddPoints(s1.Points, 1000000);
             model.Series.Add(s1);
@@ -40,7 +40,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points")]
         public static PlotModel LineSeries()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points");
             var s1 = new LineSeries();
             AddPoints(s1.Points, 100000);
             model.Series.Add(s1);
@@ -50,7 +50,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points (dashed line)")]
         public static PlotModel LineSeriesDashedLines()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points", Subtitle = "LineStyle = Dash" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points", "LineStyle = Dash");
             var s1 = new LineSeries { LineStyle = LineStyle.Dash };
             AddPoints(s1.Points, 100000);
             model.Series.Add(s1);
@@ -60,7 +60,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points, markers")]
         public static PlotModel LineSeries1WithMarkers()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points", Subtitle = "MarkerType = Square" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points", "MarkerType = Square");
             var s1 = new LineSeries { MarkerType = MarkerType.Square };
             AddPoints(s1.Points, 100000);
             model.Series.Add(s1);
@@ -70,7 +70,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points, markers, lower resolution")]
         public static PlotModel LineSeries1WithMarkersLowRes()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points, markers, lower resolution", Subtitle = "MarkerType = Square, MarkerResolution = 3" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points, markers, lower resolution", "MarkerType = Square, MarkerResolution = 3");
             var s1 = new LineSeries { MarkerType = MarkerType.Square, MarkerResolution = 3 };
             AddPoints(s1.Points, 100000);
             model.Series.Add(s1);
@@ -80,7 +80,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points, round line joins")]
         public static PlotModel LineSeriesRoundLineJoins()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points", Subtitle = "LineJoin = Round" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points", "LineJoin = Round");
             var s1 = new LineSeries { LineJoin = LineJoin.Round };
             AddPoints(s1.Points, 100000);
             model.Series.Add(s1);
@@ -90,7 +90,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points by ItemsSource set to a List<DataPoint>")]
         public static PlotModel LineSeriesItemsSourceList()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points by ItemsSource set to a List<DataPoint>" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points by ItemsSource set to a List<DataPoint>");
             var s1 = new LineSeries();
             var points = new List<DataPoint>();
             AddPoints(points, 100000);
@@ -103,7 +103,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points by ItemsSource and Mapping")]
         public static PlotModel LineSeriesItemsSourceMapping()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points by ItemsSource and Mapping", Subtitle = "Using the Mapping function" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points by ItemsSource and Mapping", "Using the Mapping function");
             var s1 = new LineSeries();
             var points = new List<DataPoint>();
             AddPoints(points, 100000);
@@ -118,7 +118,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points by ItemsSource and reflection")]
         public static PlotModel LineSeriesItemsSourceReflection()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points, ItemsSource with reflection", Subtitle = "DataFieldX and DataFieldY" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points, ItemsSource with reflection", "DataFieldX and DataFieldY");
             var s1 = new LineSeries();
             var points = new List<DataPoint>();
             AddPoints(points, 100000);
@@ -134,7 +134,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 100k points (thick)")]
         public static PlotModel LineSeriesThick()
         {
-            var model = new PlotModel { Title = "LineSeries, 100k points (thick)", Subtitle = "StrokeThickness = 10" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 100k points (thick)", "StrokeThickness = 10");
             var s1 = new LineSeries { StrokeThickness = 10 };
             AddPoints(s1.Points, 100000);
             model.Series.Add(s1);
@@ -145,7 +145,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 3k points, miter line joins")]
         public static PlotModel LineSeries2MiterLineJoins()
         {
-            var model = new PlotModel { Title = "LineSeries, 3k points, miter line joins", Subtitle = "LineJoin = Miter" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 3k points, miter line joins", "LineJoin = Miter");
             var s1 = new LineSeries { LineJoin = LineJoin.Miter, StrokeThickness = 8.0 };
             for (int i = 0; i < 3000; i++)
             {
@@ -160,7 +160,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 3k points, round line joins")]
         public static PlotModel LineSeries2RoundLineJoins()
         {
-            var model = new PlotModel { Title = "LineSeries, 3k points, round line joins", Subtitle = "LineJoin = Round" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 3k points, round line joins", "LineJoin = Round");
             var s1 = new LineSeries { LineJoin = LineJoin.Round, StrokeThickness = 8.0 };
             for (int i = 0; i < 3000; i++)
             {
@@ -174,7 +174,7 @@ namespace ExampleLibrary
         [Example("LineSeries, 3k points, bevel line joins")]
         public static PlotModel LineSeries2BevelLineJoins()
         {
-            var model = new PlotModel { Title = "LineSeries, 3k points, bevel line joins", Subtitle = "LineJoin = Bevel" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries, 3k points, round line joins", "LineJoin = Bevel");
             var s1 = new LineSeries { LineJoin = LineJoin.Bevel, StrokeThickness = 8.0 };
             for (int i = 0; i < 3000; i++)
             {
@@ -188,7 +188,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries (squares)")]
         public static PlotModel ScatterSeriesSquares()
         {
-            var model = new PlotModel { Title = "ScatterSeries (squares)" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (squares)");
             var s1 = new ScatterSeries();
             AddPoints(s1.Points, 2000);
             model.Series.Add(s1);
@@ -198,7 +198,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries (squares with outline)")]
         public static PlotModel ScatterSeriesSquaresOutline()
         {
-            var model = new PlotModel { Title = "ScatterSeries (squares with outline)", Subtitle = "MarkerStroke = Black" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (squares with outline)", "MarkerStroke = Black");
             var s1 = new ScatterSeries { MarkerStroke = OxyColors.Black };
             AddPoints(s1.Points, 2000);
             model.Series.Add(s1);
@@ -208,7 +208,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries (squares without fill color)")]
         public static PlotModel ScatterSeriesSquaresOutlineOnly()
         {
-            var model = new PlotModel { Title = "ScatterSeries (squares without fill color)", Subtitle = ";arkerFill = Transparent, MarkerStroke = Black" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (squares with fill color)", "MarkerFill = Transparent, MarkerStroke = Black");
             var s1 = new ScatterSeries { MarkerFill = OxyColors.Transparent, MarkerStroke = OxyColors.Black };
             AddPoints(s1.Points, 2000);
             model.Series.Add(s1);
@@ -218,7 +218,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries by ItemsSource and reflection")]
         public static PlotModel ScatterSeriesItemsSourceReflection()
         {
-            var model = new PlotModel { Title = "ScatterSeries (by ItemsSource)", Subtitle = "DataFieldX = 'X', DataFieldY = 'Y'" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (by ItemsSource)", "DataFieldX = 'X', DataFieldY = 'Y'");
             model.Series.Add(new ScatterSeries { ItemsSource = GetPoints(2000), DataFieldX = "X", DataFieldY = "Y" });
             return model;
         }
@@ -226,7 +226,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries (circles)")]
         public static PlotModel ScatterSeriesCircles()
         {
-            var model = new PlotModel { Title = "ScatterSeries (circles)", Subtitle = "MarkerType = Circle" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (circles)", "MarkerType = Circle");
             var s1 = new ScatterSeries { MarkerType = MarkerType.Circle };
             AddPoints(s1.Points, 2000);
             model.Series.Add(s1);
@@ -236,7 +236,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries (circles with outline)")]
         public static PlotModel ScatterSeriesCirclesOutline()
         {
-            var model = new PlotModel { Title = "ScatterSeries (circles with outline)", Subtitle = "MarkerType = Circle, MarkerStroke = Black" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (circles with outline)", "MarkerType = Circle, MarkerStroke = Black");
             var s1 = new ScatterSeries { MarkerType = MarkerType.Circle, MarkerStroke = OxyColors.Black };
             AddPoints(s1.Points, 2000);
             model.Series.Add(s1);
@@ -246,7 +246,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries (cross)")]
         public static PlotModel ScatterSeriesCrosses()
         {
-            var model = new PlotModel { Title = "ScatterSeries (cross)", Subtitle = "MarkerType = Cross" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries (cross)", "MarkerType = Cross");
             var s1 = new ScatterSeries
             {
                 MarkerType = MarkerType.Cross,
@@ -314,7 +314,7 @@ namespace ExampleLibrary
 
         private static PlotModel IntOverflow(int n)
         {
-            var model = new PlotModel { Title = "int overflow", Subtitle = "n = " + n };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("int overflow", "n = " + n);
             var ls = new LineSeries();
             int k = 0;
             for (int i = 0; i < n; i++)

--- a/Source/Examples/ExampleLibrary/Examples/PlotControllerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PlotControllerExamples.cs
@@ -50,6 +50,9 @@ namespace ExampleLibrary
         public static Example MouseHandlingExample()
         {
             var model = new PlotModel { Title = "Mouse handling example" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+
             var series = new ScatterSeries();
             model.Series.Add(series);
 
@@ -73,7 +76,6 @@ namespace ExampleLibrary
         public static Example ClickingOnAnAnnotation()
         {
             var plotModel = new PlotModel { Title = "Clicking on an annotation", Subtitle = "Click on the rectangles" };
-
             plotModel.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             plotModel.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
 

--- a/Source/Examples/ExampleLibrary/Examples/PlotModelExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PlotModelExamples.cs
@@ -185,7 +185,8 @@ namespace ExampleLibrary
         public static PlotModel InvalidAxisKey()
         {
             var model = new PlotModel();
-            model.Axes.Add(new LinearAxis());
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
             model.Series.Add(new LineSeries { XAxisKey = "invalidKey" });
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -11,6 +11,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("Tracker")]
     public static class TrackerExamples
@@ -18,7 +19,7 @@ namespace ExampleLibrary
         [Example("No interpolation")]
         public static PlotModel NoInterpolation()
         {
-            var model = new PlotModel { Title = "No tracker interpolation", Subtitle = "Used for discrete values or scatter plots." };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("No tracker interpolation", "Used for discrete values or scatter plots.");
             var l = new Legend
             {
                 LegendSymbolLength = 30
@@ -50,7 +51,7 @@ namespace ExampleLibrary
         [Example("TrackerChangedEvent")]
         public static PlotModel TrackerChangedEvent()
         {
-            var model = new PlotModel { Title = "Handling the TrackerChanged event", Subtitle = "Press the left mouse button to test the tracker." };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Handling the TrackerChanged event", "ress the left mouse button to test the tracker.");
             model.Series.Add(new FunctionSeries(Math.Sin, 0, 10, 100));
             model.TrackerChanged += (s, e) =>
             {

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -17,6 +17,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("Z1 Issues")]
     public class Issues
@@ -24,7 +25,7 @@ namespace ExampleLibrary
         [Example("#1095: Issue 1095 Part 1")]
         public static PlotModel IssueHalfPolarReversedAxesPart1()
         {
-            var plotModel = new PlotModel { Title = "", };
+            var plotModel = new PlotModel() { Title = "" };
             plotModel.PlotType = OxyPlot.PlotType.Polar;
             plotModel.Axes.Add(
                 new AngleAxis()
@@ -53,7 +54,7 @@ namespace ExampleLibrary
         [Example("#1095: Issue 1095 Part 2")]
         public static PlotModel IssueHalfPolarReversedAxesPart2()
         {
-            var plotModel = new PlotModel { Title = "", };
+            var plotModel = new PlotModel() { Title = "" };
             plotModel.PlotType = OxyPlot.PlotType.Polar;
             plotModel.Axes.Add(
                 new AngleAxis()
@@ -82,10 +83,7 @@ namespace ExampleLibrary
         [Example("#91 AxisTitleDistance")]
         public static PlotModel AxisTitleDistance()
         {
-            var plotModel = new PlotModel
-            {
-                Title = "AxisTitleDistance"
-            };
+            var plotModel = new PlotModel() { Title = "AxisTitleDistance" };
 
             var l = new Legend
             {
@@ -127,7 +125,7 @@ namespace ExampleLibrary
         [Example("#1044 MinimumSegmentLength not working with AreaSeries")]
         public static PlotModel MinimumSegmentLengthInAreaSeries()
         {
-            var model = new PlotModel() { Title = "MinimumSegmentLength in AreaSeries", Subtitle = "Three different areas should be visible" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("MinimumSegmentLength in AreaSeries", "Three different areas should be visible");
             for (var msl = 0; msl <= 200; msl += 100)
             {
                 var series = new AreaSeries
@@ -151,7 +149,7 @@ namespace ExampleLibrary
         [Example("#1044 MinimumSegmentLength not working with LinesSeries")]
         public static PlotModel MinimumSegmentLengthInLineSeries()
         {
-            var model = new PlotModel() { Title = "MinimumSegmentLength in LineSeries", Subtitle = "Three different curves should be visible" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("MinimumSegmentLength in LineSeries", "Three different curves should be visible");
             for (var msl = 0; msl <= 200; msl += 100)
             {
                 var series = new LineSeries
@@ -174,7 +172,7 @@ namespace ExampleLibrary
         [Example("#1303 Problem with infinity size polyline")]
         public static PlotModel InfinitySizePolyline()
         {
-            var model = new PlotModel();
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes(null);
             var series = new OxyPlot.Series.LineSeries();
             series.Points.Add(new DataPoint(0, 0));
             series.Points.Add(new DataPoint(1, -1e40));
@@ -299,11 +297,10 @@ namespace ExampleLibrary
             return model;
         }
 
-
         [Example("Support colour coding on scatter plots (Closed)")]
         public static PlotModel ColorCodingOnScatterPlots()
         {
-            var model = new PlotModel { Title = "Colour coding on scatter plots" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Colour coding on scatter plots");
             var colorAxis = new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), Minimum = 0, Maximum = 5, HighColor = OxyColors.Gray, LowColor = OxyColors.Black };
             model.Axes.Add(colorAxis);
 
@@ -424,6 +421,8 @@ namespace ExampleLibrary
             var model = new PlotModel { Title = "LineSeries with smoothing", Subtitle = "Tracker uses wrong points" };
             var logarithmicAxis1 = new LogarithmicAxis { Position = AxisPosition.Bottom };
             model.Axes.Add(logarithmicAxis1);
+            var linearAxis1 = new LinearAxis { Position = AxisPosition.Left };
+            model.Axes.Add(linearAxis1);
 
             // Add a line series
             var s1 = new LineSeries
@@ -556,7 +555,7 @@ namespace ExampleLibrary
         [Example("Argument out of range in OxyPlot mouse over (Closed)")]
         public static PlotModel ArgumentOutOfRangeInMouseOver()
         {
-            var model = new PlotModel { Title = "Argument out of range in OxyPlot mouse over" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Argument out of range in OxyPlot mouse over");
             var ls = new LineSeries();
             ls.Points.Add(new DataPoint(10, 10));
             ls.Points.Add(new DataPoint(10, 10));
@@ -568,7 +567,7 @@ namespace ExampleLibrary
         [Example("Slow redraws with noisy data (Closed)")]
         public static PlotModel NoisyData()
         {
-            var model = new PlotModel { Title = "Noisy data" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Noisy data");
 
             var points = new List<DataPoint>();
             var rng = new Random(7);
@@ -584,7 +583,7 @@ namespace ExampleLibrary
         [Example("Dashed line test (Closed)")]
         public static PlotModel DashedLineTest()
         {
-            var model = new PlotModel { Title = "Dashed line test" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Dashed line test");
 
             for (int y = 1; y <= 24; y++)
             {
@@ -617,7 +616,7 @@ namespace ExampleLibrary
         [Example("AreaSeries draws on top of other elements (Closed)")]
         public static PlotModel DefaultAnnotationLayer()
         {
-            var plotModel1 = new PlotModel { Title = "Annotations should be drawn on top by default", Subtitle = "The line annotation should be on top!" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("Annotations should be drawn on top by default", "The line annotation should be on top!");
             var areaSeries1 = new AreaSeries();
             areaSeries1.Points.Add(new DataPoint(0, 50));
             areaSeries1.Points.Add(new DataPoint(10, 40));
@@ -644,7 +643,7 @@ namespace ExampleLibrary
         [Example("#79: LegendItemAlignment = Center (closed)")]
         public static PlotModel LegendItemAlignmentCenter()
         {
-            var plotModel1 = new PlotModel { Title = "LegendItemAlignment = Center" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("LegendItemAlignment = Center");
             var l = new Legend
             {
                 LegendItemAlignment = HorizontalAlignment.Center,
@@ -662,7 +661,7 @@ namespace ExampleLibrary
         [Example("AreaSeries should respect CanTrackerInterpolatePoints (Closed)")]
         public static PlotModel AreaSeries_CanTrackerInterpolatePointsFalse()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with CanTrackerInterpolatePoints=false" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with CanTrackerInterpolatePoints=false");
             var areaSeries1 = new AreaSeries { CanTrackerInterpolatePoints = false };
             areaSeries1.Points.Add(new DataPoint(0, 50));
             areaSeries1.Points.Add(new DataPoint(10, 40));
@@ -677,7 +676,7 @@ namespace ExampleLibrary
         [Example("AreaSeries should respect CanTrackerInterpolatePoints=true (Closed)")]
         public static PlotModel AreaSeries_CanTrackerInterpolatePointsTrue()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with CanTrackerInterpolatePoints=true" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with CanTrackerInterpolatePoints=true");
             var areaSeries1 = new AreaSeries { CanTrackerInterpolatePoints = true };
             areaSeries1.Points.Add(new DataPoint(0, 50));
             areaSeries1.Points.Add(new DataPoint(10, 40));
@@ -692,7 +691,7 @@ namespace ExampleLibrary
         [Example("GetNearestPoint return DataPoint even when custom IDataPoint used (closed)")]
         public static PlotModel GetNearestPointReturnsDataPoint()
         {
-            var plotModel1 = new PlotModel { Title = "GetNearestPoint" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("GetNearestPoint");
             //// TODO: add code to reproduce
             return plotModel1;
         }
@@ -700,7 +699,7 @@ namespace ExampleLibrary
         [Example("#102: Selecting points changes the legend colours")]
         public static PlotModel SelectingPointsChangesTheLegendColors()
         {
-            var plotModel1 = new PlotModel { Title = "Selecting points changes the legend colours" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("Selecting points changes the legend colours");
             //// TODO: add code to reproduce
             return plotModel1;
         }
@@ -708,7 +707,7 @@ namespace ExampleLibrary
         [Example("Empty LineSeries with smoothing (Closed)")]
         public static PlotModel EmptyLineSeriesWithSmoothing_ThrowsException()
         {
-            var plotModel1 = new PlotModel { Title = "Empty LineSeries with smoothing" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("Empty LineSeries with smoothing");
             plotModel1.Series.Add(new LineSeries
             {
                 InterpolationAlgorithm = InterpolationAlgorithms.CanonicalSpline
@@ -766,13 +765,14 @@ namespace ExampleLibrary
         {
             var model = new PlotModel { Title = "Floating-point inaccuracy" };
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -0.0515724495834661, Maximum = 0.016609368598352, MajorStep = 0.02, MinorStep = 0.002 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             return model;
         }
 
         [Example("LineSeries.Dashes property (Closed)")]
         public static PlotModel DashesTest()
         {
-            var model = new PlotModel { Title = "Dashed line test" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Dashed line test");
 
             for (int y = 1; y <= 10; y++)
             {
@@ -795,7 +795,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries and LinearColorAxis on the same plot (Closed)")]
         public static PlotModel ScatterSeriesAndLinearColorAxis()
         {
-            var plotModel = new PlotModel { Title = "ScatterSeries and LinearColorAxis on the same plot" };
+            var plotModel = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries and LinearColorAxis on the same plot");
             int npoints = 100;
             var random = new Random();
 
@@ -822,7 +822,7 @@ namespace ExampleLibrary
         [Example("#133: MinorStep should not be MajorStep/5 when MajorStep is 2")]
         public static PlotModel MinorTicks()
         {
-            var plotModel1 = new PlotModel { Title = "Issue 10117" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("Issue 10117");
             plotModel1.Axes.Add(new LinearAxis { Minimum = 0, Maximum = 16 });
             return plotModel1;
         }
@@ -960,10 +960,7 @@ namespace ExampleLibrary
         [Example("ScatterSeries with invalid point and marker type circle (closed)")]
         public static PlotModel ScatterSeriesWithInvalidPointAndMarkerTypeCircle()
         {
-            var plotModel1 = new PlotModel
-            {
-                Title = "ScatterSeries with invalid point and marker type circle",
-            };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterSeries with invalid point and marker type circle");
             plotModel1.Series.Add(new ScatterSeries
             {
                 MarkerType = MarkerType.Circle,
@@ -975,10 +972,7 @@ namespace ExampleLibrary
         [Example("RectangleBarSeries rendered on top layer (rejected)")]
         public static PlotModel RectangleBarSeriesRenderedOnTopLayer()
         {
-            var plotModel1 = new PlotModel
-            {
-                Title = "RectangleBarSeries rendered on top layer",
-            };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("RectangleBarSeries rendered on top layer");
             var lineSeries1 = new LineSeries();
             lineSeries1.Points.Add(new DataPoint(0, 1));
             lineSeries1.Points.Add(new DataPoint(1, 0));
@@ -996,10 +990,7 @@ namespace ExampleLibrary
         [Example("Legend is not visible (closed)")]
         public static PlotModel LegendIsNotVisible()
         {
-            var plotModel = new PlotModel
-            {
-                Title = "Legend is not visible",
-            };
+            var plotModel = PlotModelUtilities.CreateModelWithDefaultAxes("Legend is not visible");
             plotModel.Series.Add(new LineSeries { Title = "LineSeries 1" });
             plotModel.Series.Add(new LineSeries { Title = "LineSeries 2" });
             plotModel.Series.Add(new LineSeries { Title = "LineSeries 3" });
@@ -1103,11 +1094,10 @@ namespace ExampleLibrary
         [Example("#226: LineSeries exception when smoothing")]
         public static PlotModel LineSeriesExceptionWhenSmoothing()
         {
-            var plotModel1 = new PlotModel
-            {
-                Title = "LineSeries null reference exception when smoothing is enabled and all datapoints have the same y value",
-                Subtitle = "Click on the plot to reproduce the issue."
-            };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes(
+                title: "LineSeries null reference exception when smoothing is enabled and all datapoints have the same y value",
+                subtitle: "Click on the plot to reproduce the issue."
+            );
             var ls = new LineSeries
             {
                 InterpolationAlgorithm = InterpolationAlgorithms.CanonicalSpline,
@@ -1122,10 +1112,7 @@ namespace ExampleLibrary
         [Example("#79: Center aligned legends (closed)")]
         public static PlotModel CenterAlignedLegends()
         {
-            var plotModel1 = new PlotModel
-            {
-                Title = "Center aligned legends"
-            };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("Center aligned legends");
 
             var l = new Legend
             {
@@ -1143,10 +1130,7 @@ namespace ExampleLibrary
         [Example("#356: Draw legend line with custom pattern")]
         public static PlotModel LegendWithCustomPattern()
         {
-            var plotModel1 = new PlotModel
-            {
-                Title = "Draw legend line with custom pattern",
-            };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("Draw legend line with custom pattern");
             var solid = new LineSeries
             {
                 Title = "Solid",
@@ -1179,7 +1163,7 @@ namespace ExampleLibrary
         [Example("#409: ImageAnnotation width width/height crashes")]
         public static PlotModel ImageAnnotationWithWidthHeightCrashes()
         {
-            var myModel = new PlotModel { Title = "Example 1" };
+            var myModel = PlotModelUtilities.CreateModelWithDefaultAxes("Example 1");
             myModel.Series.Add(new FunctionSeries(Math.Cos, 0, 10, 0.1, "cos(x)"));
 
             var rng = new Random();
@@ -1444,7 +1428,7 @@ namespace ExampleLibrary
         [Example("#42: ContourSeries not working for not square data array")]
         public static PlotModel IndexOutOfRangeContour()
         {
-            var model = new PlotModel { Title = "Issue #42" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Issue #42");
             model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(5) });
 
             var x = ArrayBuilder.CreateVector(0, 1, 20);
@@ -1465,7 +1449,7 @@ namespace ExampleLibrary
         [Example("#624: Rendering math text with syntax error gets stuck in an endless loop")]
         public static PlotModel MathTextWithSyntaxError()
         {
-            var model = new PlotModel { Title = "Math text syntax errors" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Math text syntax errors");
             model.Series.Add(new LineSeries { Title = "x_{1" });
             model.Series.Add(new LineSeries { Title = "x^{2" });
             model.Series.Add(new LineSeries { Title = "x^{2_{1" });
@@ -1549,6 +1533,7 @@ namespace ExampleLibrary
                     Minimum = 50,
                     MinimumRange = 500
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -1566,6 +1551,7 @@ namespace ExampleLibrary
                     MinimumRange = 5,
                     MaximumRange = 200
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -1581,6 +1567,7 @@ namespace ExampleLibrary
                     AbsoluteMinimum = 50,
                     MinimumRange = 500
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -1611,6 +1598,7 @@ namespace ExampleLibrary
                     AbsoluteMinimum = 20,
                     MaximumRange = 50
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -1626,6 +1614,7 @@ namespace ExampleLibrary
                     AbsoluteMaximum = -20,
                     MaximumRange = 25
                 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -1641,6 +1630,7 @@ namespace ExampleLibrary
                 HighColor = OxyColors.Gray,
                 LowColor = OxyColors.Black
             });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             var data = new double[,] { { 1, 2 }, { 1, 1 }, { 2, 1 }, { 2, 2 } };
 
@@ -1665,7 +1655,8 @@ namespace ExampleLibrary
                 Title = "IntervalLength = 0",
                 Subtitle = "An exception should be thrown. Should not go into infinite loop."
             };
-            model.Axes.Add(new LinearAxis { IntervalLength = 0 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, IntervalLength = 0 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
             return model;
         }
 
@@ -1730,6 +1721,7 @@ namespace ExampleLibrary
         {
             var plotModel1 = new PlotModel { Title = "Auto plot margin not taking width of axis tick labels into account" };
             plotModel1.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1e8, Maximum = 1e8 });
+            plotModel1.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
             return plotModel1;
         }
 
@@ -1749,6 +1741,7 @@ namespace ExampleLibrary
             };
 
             model.Axes.Add(yaxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             var series = new LineSeries();
             series.Points.Add(new DataPoint(0, 10.1));
@@ -1786,17 +1779,16 @@ namespace ExampleLibrary
         [Example("#880: Too much padding")]
         public static PlotModel TooMuchPadding()
         {
-            return new PlotModel { Title = "Too much padding", Padding = new OxyThickness(0, 0, 0, 10000) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Too much padding");
+            model.Padding = new OxyThickness(0, 0, 0, 10000);
+            return model;
         }
 
         [Example("#880: Too much padding with legend outside")]
         public static PlotModel TooMuchPaddingWithLegend()
         {
-            var model = new PlotModel
-            {
-                Title = "Too much padding with legend outside",
-                Padding = new OxyThickness(500)
-            };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("much padding with legend outside");
+            model.Padding = new OxyThickness(0, 0, 0, 500);
 
             var l = new Legend
             {
@@ -1812,7 +1804,8 @@ namespace ExampleLibrary
         [Example("#880: Too much title padding")]
         public static PlotModel TooMuchTitlePadding()
         {
-            var model = new PlotModel { Title = "Too much title padding", TitlePadding = 10000 };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Too much padding");
+            model.TitlePadding = 10000;
             return model;
         }
 
@@ -1833,6 +1826,7 @@ namespace ExampleLibrary
             };
 
             model.Axes.Add(yaxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             var series = new LineSeries();
             series.Points.Add(new DataPoint(0, 10.1));
@@ -1863,6 +1857,7 @@ namespace ExampleLibrary
             };
 
             model.Axes.Add(yaxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             var series = new LineSeries();
             series.Points.Add(new DataPoint(0, 10.1));
@@ -1916,7 +1911,8 @@ namespace ExampleLibrary
         public static PlotModel LogarithmicAxisReversed()
         {
             var model = new PlotModel();
-            model.Axes.Add(new LogarithmicAxis { StartPosition = 1, EndPosition = 0 });
+            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, StartPosition = 1, EndPosition = 0 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
 
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -117,6 +117,7 @@ namespace ExampleLibrary
             //    Points = RungeKutta4(f, t0, y0, 4, 1)
             //});
 
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Misc/XkcdExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/XkcdExamples.cs
@@ -15,6 +15,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     /// <summary>
     /// Plot examples in XKCD style.
@@ -29,12 +30,7 @@ namespace ExampleLibrary
         [Example("Test #1")]
         public static PlotModel Test1()
         {
-            var model = new PlotModel
-            {
-                Title = "XKCD style plot",
-                Subtitle = "Install the 'Humor Sans' font for the best experience",
-                RenderingDecorator = rc => new XkcdRenderingDecorator(rc)
-            };
+            var model = CreateXkcdPlotModel("XKCD style plot", "Install the 'Humor Sans' font for the best experience");
             model.Series.Add(new FunctionSeries(Math.Sin, 0, 10, 50, "sin(x)"));
             return model;
         }
@@ -47,11 +43,7 @@ namespace ExampleLibrary
         [Example("Test #2")]
         public static PlotModel Test2()
         {
-            var model = new PlotModel
-            {
-                Title = "Test #2",
-                RenderingDecorator = rc => new XkcdRenderingDecorator(rc)
-            };
+            var model = CreateXkcdPlotModel("Test #2");
 
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = 0, Maximum = 8, Title = "INTENSITY" });
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "TIME" });
@@ -102,11 +94,7 @@ namespace ExampleLibrary
         [Example("Test #3")]
         public static PlotModel Test3()
         {
-            var model = new PlotModel
-            {
-                Title = "Test #3",
-                RenderingDecorator = rc => new XkcdRenderingDecorator(rc)
-            };
+            var model = CreateXkcdPlotModel("Text #3");
 
             var l = new Legend
             {
@@ -139,6 +127,13 @@ namespace ExampleLibrary
             model.Series.Add(s2);
             model.Axes.Add(categoryAxis);
             model.Axes.Add(valueAxis);
+            return model;
+        }
+
+        private static PlotModel CreateXkcdPlotModel(string title, string subtitle = null)
+        {
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes(title, subtitle);
+            model.RenderingDecorator = rc => new XkcdRenderingDecorator(rc);
             return model;
         }
     }

--- a/Source/Examples/ExampleLibrary/Series/AreaSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/AreaSeriesExamples.cs
@@ -19,7 +19,7 @@ namespace ExampleLibrary
         [DocumentationExample("Series/AreaSeries")]
         public static PlotModel DefaultStyle()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with default style" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with default style");
             plotModel1.Series.Add(CreateExampleAreaSeries());
             return plotModel1;
         }
@@ -27,7 +27,7 @@ namespace ExampleLibrary
         [Example("Different stroke colors")]
         public static PlotModel DifferentColors()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with different stroke colors" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with different stroke colors");
             var areaSeries1 = CreateExampleAreaSeries();
             areaSeries1.Color = OxyColors.Red;
             areaSeries1.Color2 = OxyColors.Blue;
@@ -38,7 +38,7 @@ namespace ExampleLibrary
         [Example("Crossing lines")]
         public static PlotModel CrossingLines()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with crossing lines" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with crossing lines");
             var areaSeries1 = new AreaSeries();
             areaSeries1.Points.Add(new DataPoint(0, 50));
             areaSeries1.Points.Add(new DataPoint(10, 140));
@@ -69,7 +69,7 @@ namespace ExampleLibrary
         [Example("Constant baseline (empty Points2)")]
         public static PlotModel ConstantBaseline()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with constant baseline", Subtitle = "Empty Points2, ConstantY2 = 0 (default)" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with constant baseline", "Empty Points2, ConstantY2 = 0(default)");
             var areaSeries1 = new AreaSeries();
             areaSeries1.Points.Add(new DataPoint(0, 50));
             areaSeries1.Points.Add(new DataPoint(10, 140));
@@ -81,7 +81,7 @@ namespace ExampleLibrary
         [Example("Constant baseline (empty Points2, ConstantY2=NaN)")]
         public static PlotModel ConstantBaselineNaN()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with constant baseline", Subtitle = "Empty Points2, ConstantY2 = NaN" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with constant baseline", "Empty Points2, ConstantY2 = NaN");
             var areaSeries1 = new AreaSeries();
             areaSeries1.Points.Add(new DataPoint(0, 50));
             areaSeries1.Points.Add(new DataPoint(10, 140));
@@ -94,7 +94,7 @@ namespace ExampleLibrary
         [Example("Constant baseline (ItemsSource and DataField2 not set)")]
         public static PlotModel ConstantBaselineItemsSource()
         {
-            var plotModel1 = new PlotModel { Title = "AreaSeries with constant baseline", Subtitle = "ItemsSource and DataField2 not set, ConstantY2 = -20" };
+            var plotModel1 = PlotModelUtilities.CreateModelWithDefaultAxes("AreaSeries with constant baseline", "ItemsSource and DataField2 not set, ConstantY2 = -20");
             var areaSeries1 = new AreaSeries();
             var points = new[] { new DataPoint(0, 50), new DataPoint(10, 140), new DataPoint(20, 60) };
             areaSeries1.ItemsSource = points;

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -268,6 +268,7 @@ namespace ExampleLibrary
         [Example("No axes defined")]
         public static PlotModel NoAxes()
         {
+            // TODO: as part of #992, replace this with the new appropriate behaviour for missing axes (e.g. throw) or otherwise remove
             var model = CreateSimpleModel(false, "No axes defined");
             model.Axes.Clear(); // default axes will be generated
             return model;
@@ -276,6 +277,7 @@ namespace ExampleLibrary
         [Example("Stacked and no axes defined")]
         public static PlotModel StackedNoAxes()
         {
+            // TODO: as part of #992, replace this with the new appropriate behaviour for missing axes (e.g. throw) or otherwise remove
             var model = CreateSimpleModel(true, "Stacked and no axes defined");
             model.Axes.Clear(); // default axes will be generated
             return model;
@@ -594,6 +596,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B", "C" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             model.Series.Add(series);
             return model;
@@ -625,6 +628,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             return model;
         }
 
@@ -649,6 +653,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -674,6 +679,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -699,6 +705,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -723,6 +730,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -743,6 +751,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -763,6 +772,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -787,6 +797,7 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             return model;
         }
@@ -811,6 +822,8 @@ namespace ExampleLibrary
             };
             categoryAxis.Labels.AddRange(new[] { "A", "B" });
             model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+
             return model;
         }
 

--- a/Source/Examples/ExampleLibrary/Series/BoxPlotSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BoxPlotSeriesExamples.cs
@@ -188,6 +188,7 @@ namespace ExampleLibrary
                 MinorStep = 1,
                 StringFormat = "yyyy-MM-dd"
             });
+            m.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
             var boxPlotSeries = new BoxPlotSeries
             {
                 TrackerFormatString = "X: {1:yyyy-MM-dd}\nUpper Whisker: {2:0.00}\nThird Quartil: {3:0.00}\nMedian: {4:0.00}\nFirst Quartil: {5:0.00}\nLower Whisker: {6:0.00}\nMean: {7:0.00}"

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -7,7 +7,7 @@
 namespace ExampleLibrary
 {
     using System;
-
+    using ExampleLibrary.Utilities;
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
@@ -23,7 +23,7 @@ namespace ExampleLibrary
         [Example("Peaks")]
         public static PlotModel Peaks()
         {
-            var model = new PlotModel { Title = "Peaks" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Peaks");
             var cs = new ContourSeries
             {
                 ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
@@ -39,7 +39,7 @@ namespace ExampleLibrary
         [DocumentationExample("Series/ContourSeries")]
         public static PlotModel PeaksWithColors()
         {
-            var model = new PlotModel { Title = "Peaks" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Peaks");
             var cs = new ContourSeries
             {
                 ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
@@ -57,6 +57,7 @@ namespace ExampleLibrary
         {
             var model = new PlotModel { Title = "Peaks" };
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -3.16262, Maximum = 3.162 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
 
             var cs = new ContourSeries
             {

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/HighLowSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/HighLowSeriesExamples.cs
@@ -43,6 +43,7 @@ namespace ExampleLibrary
             }
 
             model.Series.Add(s1);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, MaximumPadding = 0.3, MinimumPadding = 0.3 });
 
             return model;
@@ -70,6 +71,8 @@ namespace ExampleLibrary
                 StringFormat = "yyyy-MM-dd"
             };
             m.Axes.Add(a);
+            m.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+
             var s = new HighLowSeries
             {
                 TrackerFormatString =

--- a/Source/Examples/ExampleLibrary/Series/FunctionSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FunctionSeriesExamples.cs
@@ -13,6 +13,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("FunctionSeries"), Tags("Series")]
     public class FunctionSeriesExamples
@@ -162,8 +163,9 @@ namespace ExampleLibrary
         public static PlotModel LimaconOfPascal()
         {
             // http://en.wikipedia.org/wiki/Lima%C3%A7on
+            var m = PlotModelUtilities.CreateModelWithDefaultAxes("Limaçon of Pascal");
+            m.PlotType = PlotType.Cartesian;
 
-            var m = new PlotModel { Title = "Limaçon of Pascal", PlotType = PlotType.Cartesian };
             for (int a = 4; a <= 4; a++)
                 for (int b = 0; b <= 10; b++)
                 {
@@ -198,8 +200,9 @@ namespace ExampleLibrary
         {
             // http://en.wikipedia.org/wiki/Trisectrix_of_Maclaurin
             // http://mathworld.wolfram.com/MaclaurinTrisectrix.html
+            var m = PlotModelUtilities.CreateModelWithDefaultAxes("Trisectrix of Maclaurin");
+            m.PlotType = PlotType.Cartesian;
 
-            var m = new PlotModel { Title = "Trisectrix of Maclaurin", PlotType = PlotType.Cartesian };
             double a = 1;
             m.Series.Add(new FunctionSeries(t => a * (t * t - 3) / (t * t + 1), t => a * t * (t * t - 3) / (t * t + 1), -5, 5, 1000));
             return m;
@@ -210,7 +213,9 @@ namespace ExampleLibrary
         {
             // http://en.wikipedia.org/wiki/Fermat's_spiral
             // http://www.wolframalpha.com/input/?i=Fermat%27s+spiral
-            var m = new PlotModel { Title = "Fermat's spiral", PlotType = PlotType.Cartesian };
+            var m = PlotModelUtilities.CreateModelWithDefaultAxes("Fermat's spiral");
+            m.PlotType = PlotType.Cartesian;
+
             double a = 1;
             m.Series.Add(new FunctionSeries(t => a * Math.Sqrt(t) * Math.Cos(t), t => a * Math.Sqrt(t) * Math.Sin(t), 0, 20, 1000));
             m.Series.Add(new FunctionSeries(t => -a * Math.Sqrt(t) * Math.Cos(t), t => -a * Math.Sqrt(t) * Math.Sin(t), 0, 20, 1000));
@@ -221,7 +226,9 @@ namespace ExampleLibrary
         public static PlotModel FishCurve()
         {
             // http://www.wolframalpha.com/input/?i=fish+curve
-            var m = new PlotModel { Title = "Fish curve", PlotType = PlotType.Cartesian };
+            var m = PlotModelUtilities.CreateModelWithDefaultAxes("Fish curve");
+            m.PlotType = PlotType.Cartesian;
+
             for (double a = 0.1; a < 1; a += 0.1)
             {
                 m.Series.Add(new FunctionSeries(t => a * (Math.Cos(t) - Math.Sin(t) * Math.Sin(t) / Math.Sqrt(2)), t => a * Math.Cos(t) * Math.Sin(t), 0, 2 * Math.PI, 1000));
@@ -234,8 +241,9 @@ namespace ExampleLibrary
         public static PlotModel HeavisideStepFunction()
         {
             // http://en.wikipedia.org/wiki/Heaviside_step_function
+            var m = PlotModelUtilities.CreateModelWithDefaultAxes("Heaviside step function");
+            m.PlotType = PlotType.Cartesian;
 
-            var m = new PlotModel { Title = "Heaviside step function", PlotType = PlotType.Cartesian };
             m.Series.Add(new FunctionSeries(x =>
             {
                 // make a gap in the curve at x=0
@@ -249,13 +257,10 @@ namespace ExampleLibrary
         [Example("FunctionSeries")]
         public static PlotModel FunctionSeries()
         {
-            var pm = new PlotModel
-            {
-                Title = "Trigonometric functions",
-                Subtitle = "Example using the FunctionSeries",
-                PlotType = PlotType.Cartesian,
-                PlotAreaBackground = OxyColors.White
-            };
+            var pm = PlotModelUtilities.CreateModelWithDefaultAxes("Trigonometric functions", "Example using the FunctionSeries");
+            pm.PlotType = PlotType.Cartesian;
+            pm.PlotAreaBackground = OxyColors.White;
+
             pm.Series.Add(new FunctionSeries(Math.Sin, -10, 10, 0.1, "sin(x)"));
             pm.Series.Add(new FunctionSeries(Math.Cos, -10, 10, 0.1, "cos(x)"));
             pm.Series.Add(new FunctionSeries(t => 5 * Math.Cos(t), t => 5 * Math.Sin(t), 0, 2 * Math.PI, 1000, "cos(t),sin(t)"));
@@ -265,7 +270,9 @@ namespace ExampleLibrary
         [Example("Squirqle")]
         public static PlotModel Squirqle()
         {
-            var plot = new PlotModel { Title = "Squirqle", PlotType = PlotType.Cartesian };
+            var plot = PlotModelUtilities.CreateModelWithDefaultAxes("Squirqle");
+            plot.PlotType = PlotType.Cartesian;
+
             plot.Series.Add(CreateSuperellipseSeries(4, 1, 1));
 
             return plot;
@@ -274,7 +281,9 @@ namespace ExampleLibrary
         [Example("Superellipse n=20")]
         public static PlotModel Superellipse20()
         {
-            var plot = new PlotModel { Title = "Superellipse", PlotType = PlotType.Cartesian };
+            var plot = PlotModelUtilities.CreateModelWithDefaultAxes("Superellipse");
+            plot.PlotType = PlotType.Cartesian;
+
             var s = CreateSuperellipseSeries(20, 1, 1);
             s.MarkerType = MarkerType.Circle;
             plot.Series.Add(s);
@@ -285,7 +294,9 @@ namespace ExampleLibrary
         [Example("Lamé curves")]
         public static PlotModel LameCurves()
         {
-            var plot = new PlotModel { Title = "Lamé curves", PlotType = PlotType.Cartesian };
+            var plot = PlotModelUtilities.CreateModelWithDefaultAxes("Lamé curves");
+            plot.PlotType = PlotType.Cartesian;
+
             var l = new Legend
             {
                 LegendPlacement = LegendPlacement.Outside
@@ -322,7 +333,8 @@ namespace ExampleLibrary
                                                       double t1, int n, string title, string subtitle = null,
                                                       string seriesTitle = null)
         {
-            var plot = new PlotModel { Title = title, Subtitle = subtitle, PlotType = PlotType.Cartesian };
+            var plot = PlotModelUtilities.CreateModelWithDefaultAxes(title, subtitle);
+            plot.PlotType = PlotType.Cartesian;
             plot.Series.Add(new FunctionSeries(fx, fy, t0, t1, n, seriesTitle));
             return plot;
         }

--- a/Source/Examples/ExampleLibrary/Series/HeatMapSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HeatMapSeriesExamples.cs
@@ -10,7 +10,7 @@
 namespace ExampleLibrary
 {
     using System;
-
+    using ExampleLibrary.Utilities;
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
@@ -36,8 +36,9 @@ namespace ExampleLibrary
             var yvalues = ArrayBuilder.CreateVector(y0, y1, n);
             var peaksData = ArrayBuilder.Evaluate(peaks, xvalues, yvalues);
 
-            var model = new PlotModel { Title = "Peaks" };
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = palette ?? OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Peaks");
+            // insert color axis at 0, because many examples depend on this (legacy from default axes)
+            model.Axes.Insert(0, new LinearColorAxis { Position = AxisPosition.Right, Palette = palette ?? OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
 
             var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
             model.Series.Add(hms);
@@ -410,8 +411,9 @@ namespace ExampleLibrary
             data[1, 1] = 0.3;
             data[1, 2] = 0.2;
 
-            var model = new PlotModel { Title = "HeatMapSeries", Subtitle = title };
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("HeatMapSeries", title);
+            // insert color axis at 0, because many examples depend on this (legacy from default axes)
+            model.Axes.Insert(0, new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
 
             // adding half cellwidth/cellheight to bounding box coordinates
             var hms = new HeatMapSeries

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -32,7 +32,7 @@ namespace ExampleLibrary
         [Example("Label Placement")]
         public static PlotModel HistogramLabelPlacement()
         {
-            var model = new PlotModel { Title = "Label Placement" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Label Placement");
 
             var s1 = new HistogramSeries { LabelPlacement = LabelPlacement.Base, LabelFormatString = "Base", StrokeThickness = 1, LabelMargin = 5 };
             var s2 = new HistogramSeries { LabelPlacement = LabelPlacement.Inside, LabelFormatString = "Inside", StrokeThickness = 1, LabelMargin = 5 };
@@ -89,7 +89,7 @@ namespace ExampleLibrary
         [Example("Custom Item Mapping")]
         public static PlotModel CustomItemMapping()
         {
-            var model = new PlotModel { Title = "Custom Item Mapping" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Custom Item Mapping");
 
             var s = new HistogramSeries { Mapping = obj => (HistogramItem)obj, TrackerFormatString = "{Description}"};
             s.Items.Add(new CustomHistogramItem(1, 2, 4, 4, "Item 1"));

--- a/Source/Examples/ExampleLibrary/Series/LineSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/LineSeriesExamples.cs
@@ -121,7 +121,7 @@ namespace ExampleLibrary
         [Example("Custom markers")]
         public static PlotModel CustomMarkers()
         {
-            var model = new PlotModel { Title = "LineSeries with custom markers" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("LineSeries with custom markers");
             var l = new Legend
             {
                 LegendSymbolLength = 30
@@ -373,6 +373,8 @@ namespace ExampleLibrary
                     }
                 }
             };
+            plotModel.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            plotModel.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
 
             return plotModel;
         }
@@ -382,7 +384,7 @@ namespace ExampleLibrary
         {
             var result = CreateRandomPoints();
 
-            var model = new PlotModel { Title = "Marker color options" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("Marker color options");
 
             // Dont specify line or marker color. Defaults will be used.
             var s1 = CreateExampleLineSeries(1);
@@ -457,7 +459,7 @@ namespace ExampleLibrary
 
         private static PlotModel CreateModel(string title, int n = 20)
         {
-            var model = new PlotModel { Title = title };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes(title);
             for (int i = 1; i <= n; i++)
             {
                 var s = new LineSeries { Title = "Series " + i };

--- a/Source/Examples/ExampleLibrary/Series/RectangleBarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/RectangleBarSeriesExamples.cs
@@ -9,6 +9,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("RectangleBarSeries"), Tags("Series")]
     public static class RectangleBarSeriesExamples
@@ -17,13 +18,14 @@ namespace ExampleLibrary
         [DocumentationExample("Series/RectangleBarSeries")]
         public static PlotModel RectangleBarSeries()
         {
-            var model = new PlotModel { Title = "RectangleBarSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("RectangleBarSeries");
+
             var l = new Legend
             {
                 LegendPlacement = LegendPlacement.Outside
             };
-
             model.Legends.Add(l);
+
             var s1 = new RectangleBarSeries { Title = "RectangleBarSeries 1" };
             s1.Items.Add(new RectangleBarItem { X0 = 2, X1 = 8, Y0 = 1, Y1 = 4 });
             s1.Items.Add(new RectangleBarItem { X0 = 6, X1 = 12, Y0 = 6, Y1 = 7 });

--- a/Source/Examples/ExampleLibrary/Series/RectangleSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/RectangleSeriesExamples.cs
@@ -1,7 +1,7 @@
 ﻿namespace ExampleLibrary
 {
     using System.Collections.Generic;
-
+    using ExampleLibrary.Utilities;
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
@@ -14,7 +14,7 @@
         public static PlotModel FromItems()
         {
             const int NumberOfItems = 10;
-            var model = new PlotModel { Title = "RectangleSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("RectangleSeries");
 
             // the RectangleSeries requires a color axis
             model.Axes.Add(new LinearColorAxis
@@ -39,7 +39,7 @@
         public static PlotModel FromItemsSource()
         {
             const int NumberOfItems = 10;
-            var model = new PlotModel { Title = "RectangleSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("RectangleSeries");
 
             // the RectangleSeries requires a color axis
             model.Axes.Add(new LinearColorAxis

--- a/Source/Examples/ExampleLibrary/Series/ScatterErrorSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ScatterErrorSeriesExamples.cs
@@ -16,6 +16,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("ScatterErrorSeries"), Tags("Series")]
     public class ScatterErrorSeriesExamples
@@ -37,7 +38,7 @@ namespace ExampleLibrary
         public static PlotModel ItemsSourceMapping()
         {
             const int N = 20;
-            var model = new PlotModel { Title = "ScatterErrorSeries, points defined by ItemsSource and Mapping", Subtitle = string.Format("Random data (n={0})", N) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterErrorSeries, points defined by ItemsSource and Mapping", string.Format("Random data (n={0})", N));
             var l = new Legend
             {
                 LegendPosition = LegendPosition.LeftTop
@@ -62,7 +63,7 @@ namespace ExampleLibrary
         public static PlotModel ItemsSourceList()
         {
             const int N = 20;
-            var model = new PlotModel { Title = "ScatterErrorSeries, points defined by ItemsSource (List)", Subtitle = string.Format("Random data (n={0})", N) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterErrorSeries, points defined by ItemsSource (List)", string.Format("Random data (n={0})", N));
             var l = new Legend
             {
                 LegendPosition = LegendPosition.LeftTop
@@ -78,7 +79,7 @@ namespace ExampleLibrary
         public static PlotModel ItemsSourceEnumerable()
         {
             const int N = 20;
-            var model = new PlotModel { Title = "ScatterErrorSeries, points defined by ItemsSource (IEnumerable)", Subtitle = string.Format("Random data (n={0})", N) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterErrorSeries, points defined by ItemsSource (IEnumerable)", string.Format("Random data (n={0})", N));
             var l = new Legend
             {
                 LegendPosition = LegendPosition.LeftTop
@@ -93,7 +94,7 @@ namespace ExampleLibrary
         public static PlotModel ItemsSourceReflection()
         {
             const int N = 20;
-            var model = new PlotModel { Title = "ScatterErrorSeries, points defined by ItemsSource (reflection)", Subtitle = string.Format("Random data (n={0})", N) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterErrorSeries, points defined by ItemsSource (reflection)", string.Format("Random data (n={0})", N));
             var l = new Legend
             {
                 LegendPosition = LegendPosition.LeftTop
@@ -119,7 +120,7 @@ namespace ExampleLibrary
         /// <returns>A plot model.</returns>
         private static PlotModel RandomPointsAndError(int n)
         {
-            var model = new PlotModel { Title = "ScatterErrorSeries", Subtitle = string.Format("Random data (n={0})", n) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("ScatterErrorSeries, points defined by ItemsSource (reflection)", string.Format("Random data (n={0})", n));
             var l = new Legend
             {
                 LegendPosition = LegendPosition.LeftTop

--- a/Source/Examples/ExampleLibrary/Series/ScatterSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ScatterSeriesExamples.cs
@@ -18,6 +18,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     [Examples("ScatterSeries"), Tags("Series")]
     public class ScatterSeriesExamples
@@ -503,7 +504,7 @@ namespace ExampleLibrary
         [Example("TrackerFormatString")]
         public static PlotModel TrackerFormatString()
         {
-            var model = new PlotModel { Title = "TrackerFormatString" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("TrackerFormatString");
 
             var s1 = new ScatterSeries { TrackerFormatString = "{Sum:0.0}", DataFieldX = "X", DataFieldY = "Y" };
             var myPoints = new List<MyPoint>
@@ -535,7 +536,7 @@ namespace ExampleLibrary
 
         private static PlotModel RandomScatter(int n, int binSize)
         {
-            var model = new PlotModel { Title = string.Format("ScatterSeries (n={0})", n), Subtitle = binSize > 0 ? "BinSize = " + binSize : "No 'binning'" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes(string.Format("ScatterSeries (n={0})", n), binSize > 0 ? "BinSize = " + binSize : "No 'binning'");
 
             var s1 = new ScatterSeries()
             {
@@ -557,7 +558,7 @@ namespace ExampleLibrary
 
         private static PlotModel CreateCorrelatedScatter(int n)
         {
-            var model = new PlotModel { Title = string.Format("Correlated ScatterSeries (n={0})", n) };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes(string.Format("Correlated ScatterSeries (n={0})", n));
 
             var s1 = new ScatterSeries
             {

--- a/Source/Examples/ExampleLibrary/Series/StairStepSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/StairStepSeriesExamples.cs
@@ -14,6 +14,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     /// <summary>
     /// Provides examples for the <see cref="StairStepSeries" />.
@@ -76,7 +77,7 @@ namespace ExampleLibrary
         /// <returns>A plot model.</returns>
         private static PlotModel CreateExampleModel(DataPointSeries series)
         {
-            var model = new PlotModel { Title = "StairStepSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("StairStepSeries");
             var l = new Legend
             {
                 LegendSymbolLength = 24

--- a/Source/Examples/ExampleLibrary/Series/StemSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/StemSeriesExamples.cs
@@ -14,6 +14,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using ExampleLibrary.Utilities;
 
     /// <summary>
     /// Provides examples for the <see cref="StemSeries" />.
@@ -43,7 +44,7 @@ namespace ExampleLibrary
         /// <returns>A plot model.</returns>
         private static PlotModel CreateExampleModel(DataPointSeries series)
         {
-            var model = new PlotModel { Title = "StemSeries" };
+            var model = PlotModelUtilities.CreateModelWithDefaultAxes("StemSeries");
             var l = new Legend
             {
                 LegendSymbolLength = 24

--- a/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
+++ b/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
@@ -237,5 +237,19 @@ namespace ExampleLibrary.Utilities
 
             return model;
         }
+
+        /// <summary>
+        /// Creates a <see cref="PlotModel"/> with 'default' axes.
+        /// </summary>
+        /// <param name="title">The title of plot.</param>
+        /// <param name="subtitle">The subtitle, if any, of the plot.</param>
+        /// <returns>A <see cref="PlotModel"/>.</returns>
+        public static PlotModel CreateModelWithDefaultAxes(string title, string subtitle = null)
+        {
+            var model = new PlotModel() { Title = title, Subtitle = subtitle };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            return model;
+        }
     }
 }


### PR DESCRIPTION
Fixes #1547 (just about).

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Introduce the `PlotModelUtilities.CreateDefaultPlotModel` method, which creates a `PlotModel` with 2 'default' linear axes.
- Change all examples that are not explicitly about default axes so that they no longer depend on default axes

### Outstanding concerns

 - I'm not entirely happy with the name `CreateDefaultPlotModel`.
 - Visual Studio kindly put all the `using ExampleLibrary.Utilities` statements in... but I'm not sure how we would want those formatted. StyleCop didn't have any strong feelings, but we don't use that for examples/tests anyway.

@oxyplot/admins
