### PR TITLE
Do not transpose annotation only plots (#1544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to this project will be documented in this file.
 - Possible out-of-bounds exception in HeatMapSeries HitTest (#1524)
 - WPF CanvasRenderContext draws ellipses too small by half stroke thickness (#1537)
 - Text measurement and rendering in OxyPlot.ImageSharp
+- ExampleLibrary reporting annotation-only PlotModels as transposable (#1544)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
+++ b/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
@@ -36,21 +36,34 @@ namespace ExampleLibrary.Utilities
         };
 
         /// <summary>
+        /// Lists all Annotations that need axes and are NOT transposable
+        /// </summary>
+        private static readonly HashSet<Type> NonTransposableDataSpaceAnnotationTypes = new HashSet<Type>
+        {
+            typeof(TileMapAnnotation),
+        };
+
+        /// <summary>
         /// Returns a value indicating whether a plot model is transposable.
         /// </summary>
         /// <param name="model">The plot model.</param>
         /// <returns>True if the plot model in transposable; false otherwise.</returns>
         public static bool IsTransposable(this PlotModel model)
-        {                   
-            return (model.Axes.Count > 0 || model.Series.Count > 0 || model.Annotations.Count > 0)
+        {
+            return (model.Axes.Count > 0 || model.Series.Count > 0)
                 && model.Axes.All(a => a.Position != AxisPosition.None)
                 && model.Series.All(s =>
-                   {
-                       var type = s.GetType();
-                       return s is XYAxisSeries
-                              && type.GetTypeInfo().Assembly == typeof(PlotModel).GetTypeInfo().Assembly
-                              && !NonTransposableSeriesTypes.Contains(type);
-                   });
+                {
+                    var type = s.GetType();
+                    return s is XYAxisSeries
+                           && type.GetTypeInfo().Assembly == typeof(PlotModel).GetTypeInfo().Assembly
+                           && !NonTransposableSeriesTypes.Contains(type);
+                })
+                && model.Annotations.All(a =>
+                {
+                    var type = a.GetType();
+                    return !NonTransposableDataSpaceAnnotationTypes.Contains(type);
+                });
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1544 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Don't assume that examples with annotations but not axes or series are transposable
- Don't transpose plots with TileMapAnnotations

Since `PlotModel.EnsureDefaultAxes` doesn't observe annotations, and annotations don't influence axes, this should be robust.

Looking through the example library, the only example I noticed that was obviously broken were the `TileMapAnnotation` examples which are a special case to say the least, and is handled as such.

@oxyplot/admins
