### PR TITLE
Improve ImageSharp.ImageRenderContext text alignment

### DIFF
--- a/Source/OxyPlot.ImageSharp.Tests/JpegExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/JpegExporterTests.cs
@@ -178,6 +178,16 @@ namespace OxyPlot.ImageSharp.Tests
             Assert.IsTrue(File.Exists(fileName));
         }
 
+        [Test]
+        public void TestMultilineAlignment()
+        {
+            var plotModel = ExampleLibrary.RenderingCapabilities.DrawMultilineTextAlignmentRotation();
+            var fileName = Path.Combine(this.outputDirectory, "Text.png");
+            JpegExporter.Export(plotModel, fileName, 700, 700);
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
         private static PlotModel CreateTestModel1()
         {
             var model = new PlotModel { Title = "Test 1" };

--- a/Source/OxyPlot.ImageSharp.Tests/PngExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/PngExporterTests.cs
@@ -179,6 +179,16 @@ namespace OxyPlot.ImageSharp.Tests
             Assert.IsTrue(File.Exists(fileName));
         }
 
+        [Test]
+        public void TestMultilineAlignment()
+        {
+            var plotModel = ExampleLibrary.RenderingCapabilities.DrawMultilineTextAlignmentRotation();
+            var fileName = Path.Combine(this.outputDirectory, "Text.png");
+            PngExporter.Export(plotModel, fileName, 700, 700);
+
+            Assert.IsTrue(File.Exists(fileName));
+        }
+
         private static PlotModel CreateTestModel1()
         {
             var model = new PlotModel { Title = "Test 1" };


### PR DESCRIPTION
Makes multi-line text alignment in `OxyPlot.ImageSharp` conform to the ideal described in #1554

### Checklist

- [x] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Perform horizontal text alignment on a per-line basis, so that the block of text is aligned internally as expected
- Significantly simplify the `DrawText` method, hopefully making it significantly less resource intensive in the process
- Remove some default parameters on private methods in `ImageSharp.ImageRenderContext` which will only harbour bugs

@oxyplot/admins
