### PR TITLE
Mark OxyPlot.Pdf.PdfExporter and OxyPlot.PdfExporter as Obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - WPF ExampleBrowser can switch between Canvas and SkiaSharp renderers (#1515)
 - OxyPlot.ImageSharp now targets .NET Standard 1.3 (#1530)
 - SkiaRenderContext does not apply pixel snapping when rendering to vector graphic (#1539)
+- Mark OxyPlot.PdfExporter and OxyPlot.Pdf.PdfExporter as obsolete (#1527)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
+++ b/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
@@ -6,6 +6,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Copyright>OxyPlot contributors</Copyright>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <NoWarn>CS0618</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Examples\ExampleLibrary\ExampleLibrary.csproj" />

--- a/Source/OxyPlot.Pdf/PdfExporter.cs
+++ b/Source/OxyPlot.Pdf/PdfExporter.cs
@@ -9,11 +9,13 @@
 
 namespace OxyPlot.Pdf
 {
+    using System;
     using System.IO;
 
     /// <summary>
     /// Provides functionality to export plots to pdf.
     /// </summary>
+    [Obsolete("OxyPlot.Pdf.PdfExporter will be removed in v4.0. Consider using OxyPlot.SkiaSharp.PdfExporter instead.")]
     public class PdfExporter : IExporter
     {
         /// <summary>

--- a/Source/OxyPlot/Pdf/PdfExporter.cs
+++ b/Source/OxyPlot/Pdf/PdfExporter.cs
@@ -9,11 +9,13 @@
 
 namespace OxyPlot
 {
+    using System;
     using System.IO;
 
     /// <summary>
     /// Provides functionality to export plots to pdf.
     /// </summary>
+    [Obsolete("OxyPlot.PdfExporter may be removed in a future version. Consider using OxyPlot.SkiaSharp.PdfExporter instead.")]
     public class PdfExporter : IExporter
     {
         /// <summary>


### PR DESCRIPTION
Fixes #1527.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Mark `OxyPlot.Pdf.PdfExporter` and `OxyPlot.PdfExporter` as Obsolete
- As we are not sure yet what will happen with `OxyPlot.PdfExporter` after v3.0, I used a slightly more vague wording here.

@oxyplot/admins
