### PR TITLE
Overhaul Text Arrangement and Trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - Expanded `IntervalBarSeries` and `TornadoBarSeries` to allow for varied label positions and angles (#2027)
 - VectorSeries (#107)
 - LogarithmicColorAxis (#92)
+- SvgExporter for OxyPlot.ImageSharp
+- Consistent support for DrawText's maxSize parameter (#1559)
 
 ### Changed
 - Make consistent BaseValue and BaseLine across BarSeries, LinearBarSeries, and HistogramSeries
@@ -26,10 +28,12 @@ All notable changes to this project will be documented in this file.
 - Add support for .NET 7.0 (#1937)
 - Update SkiaSharp to Version 2.88.6
 - AxisRendererBase is now generic
+- OxyPlot.Wpf to use common text arranging and trimming
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)
 - Unused LabelColor property from TornadoBarSeries, IntervalBarSeries, and RectangleBarSeries (#2030)
+- UseVerticalAlignmentWorkaround property of OxyPlot.SvgRenderContext
 
 ### Fixed
 - fixed issue with BarSeries, when the HitTest returns the wrong BarItem, when there are invalid items in the list. (#2038)
@@ -41,6 +45,9 @@ All notable changes to this project will be documented in this file.
 - Font weight not being applied in ImageSharp (#2006)
 - SkiaSharp - Fix use of obsolete functions (#1937)
 - Dashed lines are solid when exporting via SkiaSharp.SvgExporter (#1674)
+- Vertical text alignment in OxyPlot.SvgRenderContext (#1531)
+- Consistent horizontal text alignment for mutliline text (#1554)
+- Consistent implementation of MeasureText (#1551)
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/Examples/ExampleLibrary/Examples/PerformanceExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PerformanceExamples.cs
@@ -312,6 +312,18 @@ namespace ExampleLibrary
             return IntOverflow(100000);
         }
 
+        [Example("Rotated Text")]
+        public static PlotModel RotatedText()
+        {
+            return RotatedText("Rotated Text", null);
+        }
+
+        [Example("Rotated Text (trimmed)")]
+        public static PlotModel RotatedTextTrimmed()
+        {
+            return RotatedText("Rotated Text (trimmed)", new OxySize(100, 50));
+        }
+
         private static PlotModel IntOverflow(int n)
         {
             var model = new PlotModel { Title = "int overflow", Subtitle = "n = " + n };
@@ -349,6 +361,29 @@ namespace ExampleLibrary
                 double x = Math.PI * 10 * i / (n - 1);
                 points.Add(new ScatterPoint(x * Math.Cos(x), x * Math.Sin(x)));
             }
+        }
+
+        private static PlotModel RotatedText(string title, OxySize? maxSize)
+        {
+            var model = new PlotModel { Title = title };
+            var xaxis = new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 100 };
+            var yaxis = new LinearAxis { Position = AxisPosition.Left, Minimum = 0, Maximum = 100 };
+            model.Axes.Add(xaxis);
+            model.Axes.Add(yaxis);
+
+            model.Annotations.Add(new RenderingCapabilities.DelegateAnnotation(rc =>
+            {
+                for (int x = 0; x <= 100; x += 10)
+                {
+                    for (int y = 0; y <= 100; y += 10)
+                    {
+                        var p = xaxis.Transform(x, y, yaxis);
+                        rc.DrawText(p, $"({x}, {y}): A piece of multiline\ntext that can be trimmed.", OxyColors.Black, null, 16, 400, x + y, HorizontalAlignment.Center, VerticalAlignment.Middle, maxSize);
+                    }
+                }
+            }));
+
+            return model;
         }
     }
 }

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -289,6 +289,60 @@ namespace ExampleLibrary
         }
 
         /// <summary>
+        /// Shows max size capabilities for the DrawText method.
+        /// </summary>
+        /// <returns>A plot model.</returns>
+        [Example("DrawText - Bounded Multi-line Alignment/Rotation")]
+        public static PlotModel DrawBoundedMultilineTextAlignmentRotationWith()
+        {
+            var model = new PlotModel();
+            model.Annotations.Add(new DelegateAnnotation(rc =>
+            {
+                for (var ha = HorizontalAlignment.Left; ha <= HorizontalAlignment.Right; ha++)
+                {
+                    for (var va = VerticalAlignment.Top; va <= VerticalAlignment.Bottom; va++)
+                    {
+                        var origin = new ScreenPoint(((int)ha + 2) * 170, ((int)va + 2) * 170);
+                        rc.FillCircle(origin, 3, OxyColors.Blue, EdgeRenderingMode.Adaptive);
+                        for (var rotation = 0; rotation < 360; rotation += 90)
+                        {
+                            rc.DrawText(origin, $"R{rotation:000}\n{ha}\n{va}", OxyColors.Black, fontSize: 20d, rotation: rotation, horizontalAlignment: ha, verticalAlignment: va, maxSize: new OxySize(50, 70));
+                        }
+                    }
+                }
+            }));
+            return model;
+        }
+
+        /// <summary>
+        /// Shows max size capabilities for the DrawText method.
+        /// </summary>
+        /// <returns>A plot model.</returns>
+        [Example("DrawText - Horizontal Text Trimming")]
+        public static PlotModel DrawHorizontalTextTrimmed()
+        {
+            var text = "This is a long piece of text with many words that barely qualifies as a sentence.";
+            var multiLineText = "This is a long piece of multiline text\nwith many words that\nbarely qualifies as a sentence.";
+
+            var model = new PlotModel();
+            model.Annotations.Add(new DelegateAnnotation(rc =>
+            {
+                for (int i = 0; i < 20; i++)
+                {
+                    var p = new ScreenPoint(10, 10 + i * 20);
+                    rc.DrawText(p, text, OxyColors.Black, maxSize: new OxySize(i * 20, double.MaxValue));
+                }
+
+                for (int i = 0; i < 5; i++)
+                {
+                    var p = new ScreenPoint(10, 400 + i * 50);
+                    rc.DrawText(p, multiLineText, OxyColors.Black, maxSize: new OxySize(i * 25, double.MaxValue));
+                }
+            }));
+            return model;
+        }
+
+        /// <summary>
         /// Shows color capabilities for the DrawText method.
         /// </summary>
         /// <returns>A plot model.</returns>

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -293,7 +293,7 @@ namespace ExampleLibrary
         /// </summary>
         /// <returns>A plot model.</returns>
         [Example("DrawText - Bounded Multi-line Alignment/Rotation")]
-        public static PlotModel DrawBoundedMultilineTextAlignmentRotationWith()
+        public static PlotModel DrawBoundedMultilineTextAlignmentRotation()
         {
             var model = new PlotModel();
             model.Annotations.Add(new DelegateAnnotation(rc =>

--- a/Source/OxyPlot.ImageSharp.Tests/PngExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/PngExporterTests.cs
@@ -196,7 +196,7 @@ namespace OxyPlot.ImageSharp.Tests
         [Test]
         public void TestBoundedMultilineAlignment()
         {
-            var plotModel = ExampleLibrary.RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotationWith();
+            var plotModel = ExampleLibrary.RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotation();
             var fileName = Path.Combine(this.outputDirectory, "Bounded-Multiline-Alignment.png");
             PngExporter.Export(plotModel, fileName, 700, 700);
 

--- a/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
@@ -13,6 +13,7 @@ namespace OxyPlot.ImageSharp.Tests
     using OxyPlot.Series;
     using OxyPlot.ImageSharp;
     using OxyPlot.Annotations;
+    using ExampleLibrary;
 
     [TestFixture]
     public class SvgExporterTests
@@ -32,7 +33,7 @@ namespace OxyPlot.ImageSharp.Tests
         {
             var exporter = new SvgExporter(1000, 750);
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".svg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".svg");
         }
 
         [Test]

--- a/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
@@ -193,7 +193,7 @@ namespace OxyPlot.ImageSharp.Tests
         [Test]
         public void TestBoundedMultilineAlignment()
         {
-            var plotModel = ExampleLibrary.RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotationWith();
+            var plotModel = ExampleLibrary.RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotation();
             var fileName = Path.Combine(this.outputDirectory, "Bounded-Multiline-Alignment.svg");
             SvgExporter.Export(plotModel, fileName, 700, 700);
 

--- a/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
@@ -33,7 +33,7 @@ namespace OxyPlot.ImageSharp.Tests
         {
             var exporter = new SvgExporter(1000, 750);
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".svg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".svg");
         }
 
         [Test]

--- a/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/SvgExporterTests.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="PngExporterTests.cs" company="OxyPlot">
+// <copyright file="SvgExporterTests.cs" company="OxyPlot">
 //   Copyright (c) 2020 OxyPlot contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
@@ -13,37 +13,33 @@ namespace OxyPlot.ImageSharp.Tests
     using OxyPlot.Series;
     using OxyPlot.ImageSharp;
     using OxyPlot.Annotations;
-    using ExampleLibrary;
 
     [TestFixture]
-    public class PngExporterTests
+    public class SvgExporterTests
     {
-        private const string PNG_FOLDER = "PNG";
+        private const string SVG_FOLDER = "SVG";
         private string outputDirectory;
 
         [OneTimeSetUp]
         public void Setup()
         {
-            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, PNG_FOLDER);
+            this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, SVG_FOLDER);
             Directory.CreateDirectory(this.outputDirectory);
         }
 
         [Test]
         public void Export_SomeExamplesInExampleLibrary_CheckThatAllFilesExist()
         {
-            var exporter = new PngExporter(400, 300);
+            var exporter = new SvgExporter(1000, 750);
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".png");
-            exporter.Width = 800;
-            exporter.Height = 600;
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilitiesForAutomatedTest(), exporter, directory, ".png");
+            ExportTest.Export_FirstExampleOfEachExampleGroup_CheckThatAllFilesExist(exporter, directory, ".svg");
         }
 
         [Test]
         public void ExportToStream()
         {
             var plotModel = CreateTestModel1();
-            var exporter = new PngExporter(400, 300);
+            var exporter = new SvgExporter(1000, 750);
             var stream = new MemoryStream();
             exporter.Export(plotModel, stream);
 
@@ -54,8 +50,8 @@ namespace OxyPlot.ImageSharp.Tests
         public void ExportToFile()
         {
             var plotModel = CreateTestModel1();
-            var fileName = Path.Combine(this.outputDirectory, "Plot1.png");
-            PngExporter.Export(plotModel, fileName, 400, 300);
+            var fileName = Path.Combine(this.outputDirectory, "Plot1.svg");
+            SvgExporter.Export(plotModel, fileName, 1000, 750);
 
             Assert.IsTrue(File.Exists(fileName));
         }
@@ -65,8 +61,8 @@ namespace OxyPlot.ImageSharp.Tests
         {
             var plotModel = CreateTestModel1();
             plotModel.Background = OxyColors.Yellow;
-            var fileName = Path.Combine(this.outputDirectory, "Background_Yellow.png");
-            var exporter = new PngExporter(400, 300);
+            var fileName = Path.Combine(this.outputDirectory, "Background_Yellow.svg");
+            var exporter = new SvgExporter(1000, 750);
             using (var stream = File.OpenWrite(fileName))
             {
                 exporter.Export(plotModel, stream);
@@ -88,8 +84,8 @@ namespace OxyPlot.ImageSharp.Tests
             var directory = Path.Combine(this.outputDirectory, "Resolution");
             Directory.CreateDirectory(directory);
 
-            var fileName = Path.Combine(directory, $"Resolution{resolution}.png");
-            var exporter = new PngExporter((int)(400 * factor), (int)(300 * factor), resolution);
+            var fileName = Path.Combine(directory, $"Resolution{resolution}.svg");
+            var exporter = new SvgExporter((int)(400 * factor), (int)(300 * factor), resolution);
 
             using (var stream = File.OpenWrite(fileName))
             {
@@ -131,8 +127,8 @@ namespace OxyPlot.ImageSharp.Tests
             };
             plotModel.Annotations.Add(imageAnnotation);
 
-            var fileName = Path.Combine(this.outputDirectory, $"PlotBackground{(interpolate ? "Interpolated" : "Pixelated")}.png");
-            var exporter = new PngExporter(400, 300);
+            var fileName = Path.Combine(this.outputDirectory, $"PlotBackground{(interpolate ? "Interpolated" : "Pixelated")}.svg");
+            var exporter = new SvgExporter(1000, 750);
             using (var stream = File.OpenWrite(fileName))
             {
                 exporter.Export(plotModel, stream);
@@ -173,8 +169,8 @@ namespace OxyPlot.ImageSharp.Tests
             };
             plotModel.Annotations.Add(imageAnnotation);
 
-            var fileName = Path.Combine(this.outputDirectory, $"LargeImage{(interpolate ? "Interpolated" : "Pixelated")}.png");
-            var exporter = new PngExporter(400, 300);
+            var fileName = Path.Combine(this.outputDirectory, $"LargeImage{(interpolate ? "Interpolated" : "Pixelated")}.svg");
+            var exporter = new SvgExporter(1000, 750);
             using (var stream = File.OpenWrite(fileName))
             {
                 exporter.Export(plotModel, stream);
@@ -187,8 +183,8 @@ namespace OxyPlot.ImageSharp.Tests
         public void TestMultilineAlignment()
         {
             var plotModel = ExampleLibrary.RenderingCapabilities.DrawMultilineTextAlignmentRotation();
-            var fileName = Path.Combine(this.outputDirectory, "Multiline-Alignment.png");
-            PngExporter.Export(plotModel, fileName, 700, 700);
+            var fileName = Path.Combine(this.outputDirectory, "Multiline-Alignment.svg");
+            SvgExporter.Export(plotModel, fileName, 700, 700);
 
             Assert.IsTrue(File.Exists(fileName));
         }
@@ -197,18 +193,8 @@ namespace OxyPlot.ImageSharp.Tests
         public void TestBoundedMultilineAlignment()
         {
             var plotModel = ExampleLibrary.RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotationWith();
-            var fileName = Path.Combine(this.outputDirectory, "Bounded-Multiline-Alignment.png");
-            PngExporter.Export(plotModel, fileName, 700, 700);
-
-            Assert.IsTrue(File.Exists(fileName));
-        }
-
-        [Test]
-        public void TestEmoji()
-        {
-            var plotModel = ExampleLibrary.Issues.EmojiText();
-            var fileName = Path.Combine(this.outputDirectory, "Emoji.png");
-            PngExporter.Export(plotModel, fileName, 700, 700);
+            var fileName = Path.Combine(this.outputDirectory, "Bounded-Multiline-Alignment.svg");
+            SvgExporter.Export(plotModel, fileName, 700, 700);
 
             Assert.IsTrue(File.Exists(fileName));
         }

--- a/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
+++ b/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
@@ -189,7 +189,8 @@ namespace OxyPlot.ImageSharp
             var boundsHeight = this.Convert(bounds.Height);
             var offsetHeight = new PointF(boundsHeight * -sin, boundsHeight * cos);
 
-            // determine the font metrids for this font size at 96 DPI
+            // TODO: replace with using GetFontMetrics()
+            // determine the font metrics for this font size at 96 DPI
             var actualDescent = this.Convert(actualFontSize * this.MilliPointsToNominalResolution(font.FontMetrics.Descender));
             var offsetDescent = new PointF(actualDescent * -sin, actualDescent * cos);
 
@@ -449,11 +450,10 @@ namespace OxyPlot.ImageSharp
         public Rendering.FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
         {
             var font = this.GetFontOrThrow(fontFamily, fontSize, this.ToFontStyle(fontWeight));
-            var actualFontSize = this.NominalFontSizeToPoints(fontSize);
 
-            var ascender = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Ascender));
-            var descender = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Descender));
-            var leading = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.LineGap));
+            var ascender = fontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Ascender));
+            var descender = fontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Descender));
+            var leading = fontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.LineGap));
 
             return new Rendering.FontMetrics(ascender, descender, leading);
         }
@@ -461,13 +461,16 @@ namespace OxyPlot.ImageSharp
         /// <inheritdoc/>
         public double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight)
         {
-            text = text ?? string.Empty;
+            text ??= string.Empty;
 
             var font = this.GetFontOrThrow(fontFamily, fontSize, this.ToFontStyle(fontWeight));
-            var actualFontSize = this.NominalFontSizeToPoints(fontSize);
 
-            var result = TextMeasurer.Measure(text, new TextOptions(font)); // TODO: dpi
-            return this.ConvertBack(result.Width);
+            var result = TextMeasurer.Measure(text, new TextOptions(font)
+            {
+                Dpi = 96,
+                KerningMode = KerningMode.Auto,
+            });
+            return result.Width;
         }
 
         /// <inheritdoc/>

--- a/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
+++ b/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
@@ -189,7 +189,6 @@ namespace OxyPlot.ImageSharp
             var boundsHeight = this.Convert(bounds.Height);
             var offsetHeight = new PointF(boundsHeight * -sin, boundsHeight * cos);
 
-            // TODO: replace with using GetFontMetrics()
             // determine the font metrics for this font size at 96 DPI
             var actualDescent = this.Convert(actualFontSize * this.MilliPointsToNominalResolution(font.FontMetrics.Descender));
             var offsetDescent = new PointF(actualDescent * -sin, actualDescent * cos);
@@ -220,7 +219,6 @@ namespace OxyPlot.ImageSharp
                 OxyPlot.HorizontalAlignment.Right => -1.0f,
                 _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment)),
             };
-
 
             for (int li = 0; li < lines.Length; li++)
             {
@@ -450,10 +448,11 @@ namespace OxyPlot.ImageSharp
         public Rendering.FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
         {
             var font = this.GetFontOrThrow(fontFamily, fontSize, this.ToFontStyle(fontWeight));
+            var actualFontSize = this.NominalFontSizeToPoints(fontSize);
 
-            var ascender = fontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Ascender));
-            var descender = fontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Descender));
-            var leading = fontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.LineGap));
+            var ascender = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Ascender));
+            var descender = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Descender));
+            var leading = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.LineGap));
 
             return new Rendering.FontMetrics(ascender, descender, leading);
         }

--- a/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
+++ b/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
@@ -14,18 +14,18 @@ namespace OxyPlot.ImageSharp
     using System.IO;
     using System.Linq;
     using OxyPlot;
-    using SixLabors.ImageSharp;
+    using OxyPlot.Rendering;
     using SixLabors.Fonts;
+    using SixLabors.ImageSharp;
     using SixLabors.ImageSharp.Drawing.Processing;
     using SixLabors.ImageSharp.PixelFormats;
     using SixLabors.ImageSharp.Processing;
     using SixLabors.ImageSharp.Drawing;
-    using SixLabors.ImageSharp.Processing.Processors;
 
     /// <summary>
     /// Provides an implementation of IRenderContext which draws to a <see cref="Image"/>.
     /// </summary>
-    public class ImageRenderContext : ClippingRenderContext, IDisposable
+    public class ImageRenderContext : ClippingRenderContext, IDisposable, ITextMeasurer
     {
         /// <summary>
         /// The default font to use when a request font cannot be found.
@@ -82,7 +82,14 @@ namespace OxyPlot.ImageSharp
             this.RendersToScreen = false;
 
             this.clipping = false;
+
+            this.TextArranger = new TextArranger(this, new SimpleTextTrimmer());
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// </summary>
+        public TextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Gets the DPI scaling factor. A value of 1 corresponds to 96 DPI (dots per inch).
@@ -168,6 +175,8 @@ namespace OxyPlot.ImageSharp
             var font = this.GetFontOrThrow(fontFamily, fontSize, this.ToFontStyle(fontWeight));
             var actualFontSize = this.NominalFontSizeToPoints(fontSize);
 
+            this.TextArranger.ArrangeText(p, text, fontFamily, fontSize, fontWeight, rotation, horizontalAlignment, verticalAlignment, maxSize, OxyPlot.HorizontalAlignment.Left, TextVerticalAlignment.Baseline, out var lines, out var linePositions);
+
             var outputX = this.Convert(p.X);
             var outputY = this.Convert(p.Y);
             var outputPosition = new PointF(outputX, outputY);
@@ -211,10 +220,11 @@ namespace OxyPlot.ImageSharp
                 _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment)),
             };
 
-            var lines = StringHelper.SplitLines(text);
+
             for (int li = 0; li < lines.Length; li++)
             {
                 var line = lines[li];
+                var linePosition = this.Convert(linePositions[li]);
 
                 if (string.IsNullOrWhiteSpace(line))
                 {
@@ -229,7 +239,6 @@ namespace OxyPlot.ImageSharp
                 // find the left baseline position
                 var lineTop = topPosition + (offsetLineGap * li) + (offsetLineHeight * li);
                 var lineBaseLineLeft = lineTop + offsetLineWidth * deltaX + offsetLineHeight + offsetDescent;
-
                 // this seems to produce consistent and correct results, but we have to rotate it manually, so render it at the origin for simplicity
                 var textPath = new PathBuilder().AddLine(0f, 0f, lineBoundsWidth, 0).Build();
                 var glyphsAtOrigin = TextBuilder.GenerateGlyphs(line, textPath, new TextOptions(font)
@@ -240,9 +249,9 @@ namespace OxyPlot.ImageSharp
                     KerningMode = KerningMode.Auto,
                 });
 
-                // translate and rotate into possition
+                // translate and rotate into position
                 var transform = Matrix3x2Extensions.CreateRotationDegrees((float)rotation);
-                transform.Translation = lineBaseLineLeft;
+                transform.Translation = linePosition;
                 var glyphs = glyphsAtOrigin.Transform(transform);
 
                 // draw the glyphs
@@ -256,7 +265,7 @@ namespace OxyPlot.ImageSharp
         /// <inheritdoc/>
         public override OxySize MeasureText(string text, string fontFamily = null, double fontSize = 10, double fontWeight = 500)
         {
-            return this.MeasureTextLoose(text, fontFamily, fontSize, fontWeight);
+            return this.TextArranger.MeasureText(text, fontFamily, fontSize, fontWeight);
         }
 
         /// <inheritdoc/>
@@ -434,6 +443,31 @@ namespace OxyPlot.ImageSharp
             this.EnsureClippedRegion();
 
             this.clipping = false;
+        }
+
+        /// <inheritdoc/>
+        public Rendering.FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
+        {
+            var font = this.GetFontOrThrow(fontFamily, fontSize, this.ToFontStyle(fontWeight));
+            var actualFontSize = this.NominalFontSizeToPoints(fontSize);
+
+            var ascender = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Ascender));
+            var descender = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.Descender));
+            var leading = actualFontSize * this.MilliPointsToNominalResolution(Math.Abs(font.FontMetrics.LineGap));
+
+            return new Rendering.FontMetrics(ascender, descender, leading);
+        }
+
+        /// <inheritdoc/>
+        public double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight)
+        {
+            text = text ?? string.Empty;
+
+            var font = this.GetFontOrThrow(fontFamily, fontSize, this.ToFontStyle(fontWeight));
+            var actualFontSize = this.NominalFontSizeToPoints(fontSize);
+
+            var result = TextMeasurer.Measure(text, new TextOptions(font)); // TODO: dpi
+            return this.ConvertBack(result.Width);
         }
 
         /// <inheritdoc/>

--- a/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
+++ b/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
@@ -87,9 +87,9 @@ namespace OxyPlot.ImageSharp
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// Gets or sets the <see cref="ITextArranger"/> used by this instance.
         /// </summary>
-        public TextArranger TextArranger { get; set; }
+        public ITextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Gets the DPI scaling factor. A value of 1 corresponds to 96 DPI (dots per inch).

--- a/Source/OxyPlot.ImageSharp/SvgExporter.cs
+++ b/Source/OxyPlot.ImageSharp/SvgExporter.cs
@@ -1,0 +1,77 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SvgExporter.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides functionality to export plots to scalable vector graphics using <see cref="Graphics" /> for text measuring.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.ImageSharp
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Provides functionality to export plots to scalable vector graphics using ImageSharp for text measuring.
+    /// </summary>
+    public class SvgExporter : OxyPlot.SvgExporter, IDisposable
+    {
+        /// <summary>
+        /// The render context.
+        /// </summary>
+        private ImageRenderContext irc;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SvgExporter" /> class.
+        /// </summary>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <param name="resolution">The resolution in dots per inch.</param>
+        public SvgExporter(double width, double height, double resolution = 96)
+        {
+            this.Width = width;
+            this.Height = height;
+            this.irc = new ImageRenderContext(1, 1, OxyColors.Undefined, resolution);
+            this.TextMeasurer = this.irc;
+        }
+
+        /// <summary>
+        /// Exports the specified <see cref="PlotModel" /> to the specified file.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <param name="resolution">The resolution in dpi (defaults to 96dpi).</param>
+        public static void Export(IPlotModel model, string fileName, int width, int height, double resolution = 96)
+        {
+            var exporter = new SvgExporter(width, height, resolution);
+            using (var stream = File.Create(fileName))
+            {
+                exporter.Export(model, stream);
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the <see cref="SvgExporter"/>.
+        /// </summary>
+        /// <param name="disposing">Whether we are disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.irc.Dispose();
+            }
+        }
+    }
+}

--- a/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
@@ -35,6 +35,15 @@ namespace OxyPlot.SkiaSharp.Tests
             exporter.Export(model, stream);
         }
 
+        [Test]
+        public void TestBoundedMultilineAlignment()
+        {
+            var exporter = new SvgExporter { Width = 1000, Height = 750 };
+            var model = RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotationWith();
+            using var stream = File.Create(Path.Combine(this.outputDirectory, "Bounded-Multiline-Alignment.svg"));
+            exporter.Export(model, stream);
+        }
+
         [OneTimeSetUp]
         public void Setup()
         {

--- a/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
@@ -39,7 +39,7 @@ namespace OxyPlot.SkiaSharp.Tests
         public void TestBoundedMultilineAlignment()
         {
             var exporter = new SvgExporter { Width = 1000, Height = 750 };
-            var model = RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotationWith();
+            var model = RenderingCapabilities.DrawBoundedMultilineTextAlignmentRotation();
             using var stream = File.Create(Path.Combine(this.outputDirectory, "Bounded-Multiline-Alignment.svg"));
             exporter.Export(model, stream);
         }

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -6,18 +6,18 @@
 
 namespace OxyPlot.SkiaSharp
 {
-    using global::SkiaSharp;
-    using global::SkiaSharp.HarfBuzz;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using System.Reflection;
+    using global::SkiaSharp;
+    using global::SkiaSharp.HarfBuzz;
+    using OxyPlot.Rendering;
 
     /// <summary>
     /// Implements <see cref="IRenderContext" /> based on SkiaSharp.
     /// </summary>
-    public class SkiaRenderContext : IRenderContext, IDisposable
+    public class SkiaRenderContext : IRenderContext, IDisposable, ITextMeasurer
     {
         private readonly Dictionary<FontDescriptor, SKShaper> shaperCache = new Dictionary<FontDescriptor, SKShaper>();
         private readonly Dictionary<FontDescriptor, SKTypeface> typefaceCache = new Dictionary<FontDescriptor, SKTypeface>();
@@ -36,6 +36,19 @@ namespace OxyPlot.SkiaSharp
             [800] = "ExtraBold",
             [900] = "Black"
         };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkiaRenderContext" /> class.
+        /// </summary>
+        public SkiaRenderContext()
+        {
+            this.TextArranger = new TextArranger(this, new SimpleTextTrimmer());
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// </summary>
+        public TextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Gets or sets the DPI scaling factor. A value of 1 corresponds to 96 DPI (dots per inch).
@@ -250,7 +263,7 @@ namespace OxyPlot.SkiaSharp
             double[] dashArray = null,
             LineJoin lineJoin = LineJoin.Miter)
         {
-            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0) || points.Count < 2)
+            if ((!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0)) || points.Count < 2)
             {
                 return;
             }
@@ -283,7 +296,7 @@ namespace OxyPlot.SkiaSharp
             double[] dashArray = null,
             LineJoin lineJoin = LineJoin.Miter)
         {
-            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0) || polygons.Count == 0)
+            if ((!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0)) || polygons.Count == 0)
             {
                 return;
             }
@@ -340,7 +353,7 @@ namespace OxyPlot.SkiaSharp
         /// <inheritdoc/>
         public void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
-            if (!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0) || rectangles.Count == 0)
+            if ((!fill.IsVisible() && !(stroke.IsVisible() || thickness <= 0)) || rectangles.Count == 0)
             {
                 return;
             }
@@ -388,68 +401,50 @@ namespace OxyPlot.SkiaSharp
             var x = this.Convert(p.X);
             var y = this.Convert(p.Y);
 
-            var lines = StringHelper.SplitLines(text);
-            var lineHeight = paint.GetFontMetrics(out var metrics);
-
-            var deltaY = verticalAlignment switch
-            {
-                VerticalAlignment.Top => -metrics.Ascent,
-                VerticalAlignment.Middle => -(metrics.Ascent + metrics.Descent + lineHeight * (lines.Length - 1)) / 2,
-                VerticalAlignment.Bottom => -metrics.Descent - lineHeight * (lines.Length - 1),
-                _ => throw new ArgumentOutOfRangeException(nameof(verticalAlignment))
-            };
-
-            using var _ = new SKAutoCanvasRestore(this.SkCanvas);
+            using var canvasRestore = new SKAutoCanvasRestore(this.SkCanvas);
             this.SkCanvas.Translate(x, y);
             this.SkCanvas.RotateDegrees((float)rotation);
 
-            foreach (var line in lines)
+            var targetHorizontalAlignment = horizontalAlignment;
+            if (this.UseTextShaping)
             {
+                paint.TextAlign = SKTextAlign.Left;
+                targetHorizontalAlignment = HorizontalAlignment.Left;
+            }
+            else
+            {
+                paint.TextAlign = horizontalAlignment switch
+                {
+                    HorizontalAlignment.Left => SKTextAlign.Left,
+                    HorizontalAlignment.Center => SKTextAlign.Center,
+                    HorizontalAlignment.Right => SKTextAlign.Right,
+                    _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment)),
+                };
+            }
+
+            // arrange around the origin with no rotation, because SkCanvas does the rotation for us
+            this.TextArranger.ArrangeText(new ScreenPoint(0, 0), text, fontFamily, fontSize, fontWeight, 0.0, horizontalAlignment, verticalAlignment, maxSize, targetHorizontalAlignment, TextVerticalAlignment.Baseline, out var lines, out var linePositions);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                var linePosition = this.Convert(linePositions[i]);
+
                 if (this.UseTextShaping)
                 {
-                    var width = this.MeasureText(line, shaper, paint);
-                    var deltaX = horizontalAlignment switch
-                    {
-                        HorizontalAlignment.Left => 0,
-                        HorizontalAlignment.Center => -width / 2,
-                        HorizontalAlignment.Right => -width,
-                        _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
-                    };
-
-                    this.paint.TextAlign = SKTextAlign.Left;
-                    this.SkCanvas.DrawShapedText(shaper, line, deltaX, deltaY, paint);
+                    this.SkCanvas.DrawShapedText(shaper, line, linePosition.X, linePosition.Y, paint);
                 }
                 else
                 {
-                    paint.TextAlign = horizontalAlignment switch
-                    {
-                        HorizontalAlignment.Left => SKTextAlign.Left,
-                        HorizontalAlignment.Center => SKTextAlign.Center,
-                        HorizontalAlignment.Right => SKTextAlign.Right,
-                        _ => throw new ArgumentOutOfRangeException(nameof(horizontalAlignment))
-                    };
-
-                    this.SkCanvas.DrawText(line, 0, deltaY, paint);
+                    this.SkCanvas.DrawText(line, linePosition.X, linePosition.Y, paint);
                 }
-
-                deltaY += lineHeight;
             }
         }
 
         /// <inheritdoc/>
         public OxySize MeasureText(string text, string fontFamily = null, double fontSize = 10, double fontWeight = 500)
         {
-            if (text == null)
-            {
-                return new OxySize(0, 0);
-            }
-
-            var lines = StringHelper.SplitLines(text);
-            var paint = this.GetTextPaint(fontFamily, fontSize, fontWeight, out var shaper);
-            var height = paint.GetFontMetrics(out _) * lines.Length;
-            var width = lines.Max(line => this.MeasureText(line, shaper, paint)); 
-
-            return new OxySize(this.ConvertBack(width), this.ConvertBack(height));
+            return this.TextArranger.MeasureText(text, fontFamily, fontSize, fontWeight);
         }
 
         /// <inheritdoc/>
@@ -473,6 +468,26 @@ namespace OxyPlot.SkiaSharp
         /// <inheritdoc/>
         public void SetToolTip(string text)
         {
+        }
+
+        /// <inheritdoc/>
+        public FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
+        {
+            var lineSpacing = this.paint.GetFontMetrics(out var metrics);
+            var ascender = this.ConvertBack(Math.Abs(metrics.Ascent));
+            var descender = this.ConvertBack(Math.Abs(metrics.Descent));
+            var leading = this.ConvertBack(Math.Abs(metrics.Leading));
+
+            return new FontMetrics(ascender, descender, leading);
+        }
+
+        /// <inheritdoc/>
+        public double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight)
+        {
+            var paint = this.GetTextPaint(fontFamily, fontSize, fontWeight, out var shaper);
+            var width = this.MeasureText(text, shaper, paint);
+
+            return this.ConvertBack(width);
         }
 
         /// <summary>
@@ -794,7 +809,7 @@ namespace OxyPlot.SkiaSharp
                 LineJoin.Miter => SKStrokeJoin.Miter,
                 LineJoin.Round => SKStrokeJoin.Round,
                 LineJoin.Bevel => SKStrokeJoin.Bevel,
-                _ => throw new ArgumentOutOfRangeException(nameof(lineJoin))
+                _ => throw new ArgumentOutOfRangeException(nameof(lineJoin)),
             };
 
             return paint;
@@ -980,12 +995,12 @@ namespace OxyPlot.SkiaSharp
             }
 
             /// <summary>
-            /// The font family.
+            /// Gets the font family.
             /// </summary>
             public string FontFamily { get; }
 
             /// <summary>
-            /// The font weight.
+            /// Gets the font weight.
             /// </summary>
             public double FontWeight { get; }
 
@@ -999,8 +1014,8 @@ namespace OxyPlot.SkiaSharp
             public override int GetHashCode()
             {
                 var hashCode = -1030903623;
-                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.FontFamily);
-                hashCode = hashCode * -1521134295 + this.FontWeight.GetHashCode();
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.FontFamily);
+                hashCode = (hashCode * -1521134295) + this.FontWeight.GetHashCode();
                 return hashCode;
             }
         }

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -882,7 +882,7 @@ namespace OxyPlot.SkiaSharp
             if (!this.typefaceCache.TryGetValue(fontDescriptor, out var typeface))
             {
                 typeface = SKTypeface.FromFamilyName(fontFamily, new SKFontStyle((int)fontWeight, (int)SKFontStyleWidth.Normal, SKFontStyleSlant.Upright));
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER
                 if (typeface.FamilyName != fontFamily) // requested font not found or is WASM
                 {
                     try

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -46,9 +46,9 @@ namespace OxyPlot.SkiaSharp
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// Gets or sets the <see cref="ITextArranger"/> used by this instance.
         /// </summary>
-        public TextArranger TextArranger { get; set; }
+        public ITextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Gets or sets the DPI scaling factor. A value of 1 corresponds to 96 DPI (dots per inch).

--- a/Source/OxyPlot.Tests/Rendering/MockTextMeasurer.cs
+++ b/Source/OxyPlot.Tests/Rendering/MockTextMeasurer.cs
@@ -7,12 +7,12 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-using OxyPlot.Rendering;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace OxyPlot.Tests
 {
+    using OxyPlot.Rendering;
+    using System.Collections.Generic;
+    using System.Linq;
+
     public class MockTextMeasurer : ITextMeasurer
     {
         public MockTextMeasurer()

--- a/Source/OxyPlot.Tests/Rendering/MockTextMeasurer.cs
+++ b/Source/OxyPlot.Tests/Rendering/MockTextMeasurer.cs
@@ -1,0 +1,59 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MockTextMeasurer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides a predicatble implementation of ITextMeasurer.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+using OxyPlot.Rendering;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OxyPlot.Tests
+{
+    public class MockTextMeasurer : ITextMeasurer
+    {
+        public MockTextMeasurer()
+        {
+        }
+
+        public double Ascent { get; set; } = 0.6;
+        public double Descent { get; set; } = 0.3;
+        public double Leading { get; set; } = 0.1;
+        public double CharacterWidth { get; set; } = 0.8;
+
+        public HashSet<char> CharsWithWidth { get; } = new HashSet<char>();
+
+        public FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
+        {
+            return new FontMetrics(fontSize * this.Ascent, fontSize * this.Descent, fontSize * this.Leading);
+        }
+
+        public double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight)
+        {
+            return fontSize * this.CharacterWidth * text.Count(CharsWithWidth.Contains);
+        }
+
+        public void AddBasicAlphabet()
+        {
+            for (char c = 'a'; c <= 'z'; c++)
+            {
+                this.CharsWithWidth.Add(c);
+                this.CharsWithWidth.Add(char.ToUpperInvariant(c));
+            }
+        }
+
+        public void AddBasicWhitespace()
+        {
+            this.CharsWithWidth.Add(' ');
+        }
+
+        public void AddEllipsisChars()
+        {
+            this.CharsWithWidth.Add(SimpleTextTrimmer.AsciiEllipsis[0]);
+            this.CharsWithWidth.Add(SimpleTextTrimmer.UnicodeEllipsis[0]);
+        }
+    }
+}

--- a/Source/OxyPlot.Tests/Rendering/TextTrimmerTests.cs
+++ b/Source/OxyPlot.Tests/Rendering/TextTrimmerTests.cs
@@ -1,0 +1,280 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TextTrimmerTests.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Provides unit tests for the <see cref="SimpleTextTrimmer" /> class.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Tests
+{
+    using System.Linq;
+    using NUnit.Framework;
+    using OxyPlot.Rendering;
+
+    /// <summary>
+    /// Provides unit tests for the <see cref="SimpleTextTrimmer" /> class.
+    /// </summary>
+    [TestFixture]
+    public class TextTrimmerTests
+    {
+        /// <summary>
+        /// Tests word boundaries with boring ascii text.
+        /// </summary>
+        [Test]
+        public void CharacterBoundariesAscii()
+        {
+            CollectionAssert.AreEqual(new int[0], SimpleTextTrimmer.GetCharacterBoundaries(""));
+            CollectionAssert.AreEqual(new[] { 1 }, SimpleTextTrimmer.GetCharacterBoundaries("A"));
+            CollectionAssert.AreEqual(Range(1, 7), SimpleTextTrimmer.GetCharacterBoundaries("OxyPlot"));
+            CollectionAssert.AreEqual(Range(2, 7), SimpleTextTrimmer.GetCharacterBoundaries(" OxyPlot "));
+            CollectionAssert.AreEqual(new[] { 1, 3, 5, 7, 10 }, SimpleTextTrimmer.GetCharacterBoundaries("a b\tc\nd  ?"));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with boring ascii punctuation.
+        /// </summary>
+        [Test]
+        public void CharacterBoundariesPunctuation()
+        {
+            CollectionAssert.AreEqual(new[] { 1 } , SimpleTextTrimmer.GetCharacterBoundaries("."));
+            CollectionAssert.AreEqual(Range(1, 15), SimpleTextTrimmer.GetCharacterBoundaries(".!?#@£$%^&*()[]"));
+            CollectionAssert.AreEqual(Range(1, 8), SimpleTextTrimmer.GetCharacterBoundaries("OxyPlot!"));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with random western characters.
+        /// </summary>
+        [Test]
+        public void CharacterBoundariesWestern()
+        {
+            // non-combining
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, SimpleTextTrimmer.GetCharacterBoundaries("öüäßáéíóú"));
+
+            // combining
+            CollectionAssert.AreEqual(new[] { 2, 4, 6, 8, 10, 12, 14, 16 }, SimpleTextTrimmer.GetCharacterBoundaries("äöüáéíóú"));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with Zalgo text.
+        /// </summary>
+        [Test]
+        public void CharacterBoundariesZalgo()
+        {
+            var zalgo = "O̴͙͇͔̺̓̐x̶̹̙͕͕͈͚̫͂̇̑̌̒́̄͐̽̇̕y̴̡͕͗̔̆̈́̓̈́̚͝͠P̸̼̜̯͕̜̟̞̥̦͓̦̙̦͕̜̹͌̅̐̉̑̕̚ḽ̷̢͈͉͙̬̫̔͋̋͆͐͝o̷̘̪̒̏̈͊̂̿̀̀̒͗̿̅̀̉̑t̵̨̧̙͖͈̲̬͚̤̦͎͈̣̀͊";
+
+            Assert.AreEqual(7, SimpleTextTrimmer.GetCharacterBoundaries(zalgo).Count);
+        }
+
+        /// <summary>
+        /// Tests word boundaries with UTF-16 surrogate pairs.
+        /// </summary>
+        [Test]
+        public void CharacterBoundariesSurrogatePairs()
+        {
+            // TODO: more tests, ideally written by someone who knows about this stuff
+            CollectionAssert.AreEqual(new[] { 2 }, SimpleTextTrimmer.GetCharacterBoundaries("\uD852\uDF62"));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with UTF-16 surrogate pairs.
+        /// </summary>
+        [Test]
+        public void CharacterBoundariesEmoji()
+        {
+            // TODO: more tests, ideally written by someone who knows about this stuff
+
+            // one
+            CollectionAssert.AreEqual(new[] { 2 }, SimpleTextTrimmer.GetCharacterBoundaries("📊"));
+
+            // with zero width joiner
+            CollectionAssert.AreEqual(new[] { 5 }, SimpleTextTrimmer.GetCharacterBoundaries("👨‍🦰"));
+
+            // mixed
+            CollectionAssert.AreEqual(new[] { 2, 4, 9, 10 }, SimpleTextTrimmer.GetCharacterBoundaries("📊📈👨‍🦰."));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with only whitespace.
+        /// </summary>
+        [Test]
+        public void WordBoundariesNoWord()
+        {
+            var empty = new int[] { };
+            CollectionAssert.AreEqual(empty, SimpleTextTrimmer.GetWordBoundaries(""));
+            CollectionAssert.AreEqual(empty, SimpleTextTrimmer.GetWordBoundaries("\t"));
+            CollectionAssert.AreEqual(empty, SimpleTextTrimmer.GetWordBoundaries("  "));
+            CollectionAssert.AreEqual(empty, SimpleTextTrimmer.GetWordBoundaries("\r\n"));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with only one word.
+        /// </summary>
+        [Test]
+        public void WordBoundariesOneWord()
+        {
+            CollectionAssert.AreEqual(new[] { 1 }, SimpleTextTrimmer.GetWordBoundaries("A"));
+            CollectionAssert.AreEqual(new[] { 7 }, SimpleTextTrimmer.GetWordBoundaries("OxyPlot"));
+            CollectionAssert.AreEqual(new[] { 8 }, SimpleTextTrimmer.GetWordBoundaries(" OxyPlot "));
+            CollectionAssert.AreEqual(new[] { 9 }, SimpleTextTrimmer.GetWordBoundaries("  OxyPlot  "));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with boring ascii text.
+        /// </summary>
+        [Test]
+        public void WordBoundariesAscii()
+        {
+            CollectionAssert.AreEqual(new[] { 7, 10, 12, 21, 30 }, SimpleTextTrimmer.GetWordBoundaries("OxyPlot is a plotting library."));
+            CollectionAssert.AreEqual(new[] { 8, 12, 15, 25, 35 }, SimpleTextTrimmer.GetWordBoundaries(" OxyPlot  is  a  plotting  library.  "));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with western characters.
+        /// </summary>
+        [Test]
+        public void WordBoundariesWestern()
+        {
+            // non-combining
+            CollectionAssert.AreEqual(new[] { 3, 5, 11, 15 }, SimpleTextTrimmer.GetWordBoundaries("öäü ß áéíóú €20"));
+
+            // combining
+            CollectionAssert.AreEqual(new[] { 6, 17 }, SimpleTextTrimmer.GetWordBoundaries("äöü áéíóú"));
+        }
+
+        /// <summary>
+        /// Tests word boundaries with a mix of whitespace.
+        /// </summary>
+        [Test]
+        public void WordBoundariesWhiteSpace()
+        {
+            CollectionAssert.AreEqual(new[] { 7, 10, 12, 21, 31 }, SimpleTextTrimmer.GetWordBoundaries("OxyPlot\tis\na plotting  library.\r\n"));
+        }
+
+        /// <summary>
+        /// Comvenience method to return an array of sequential integers.
+        /// </summary>
+        /// <param name="start">The first value, if any, in the array.</param>
+        /// <param name="count">The number of values in this array.</param>
+        /// <returns>The array.</returns>
+        private static int[] Range(int start, int count)
+        {
+            return Enumerable.Range(start, count).ToArray();
+        }
+
+        /// <summary>
+        /// Tests the <see cref="MockTextMeasurer"/>.
+        /// </summary>
+        [Test]
+        public void MockTextMeasurerMeasureTextWidth()
+        {
+            var textMeasurer = new MockTextMeasurer();
+
+            var simpleTestString = "OxyPlot"; // 7 basic chars
+            var trickyTestString = "áéíóú"; // 10 chars, 5 characters with width
+            var fontSize = 10.0;
+
+            Assert.AreEqual(0.0, textMeasurer.MeasureTextWidth(simpleTestString, null, fontSize, 500));
+            Assert.AreEqual(0.0, textMeasurer.MeasureTextWidth(trickyTestString, null, fontSize, 500));
+
+            textMeasurer.AddBasicAlphabet();
+
+            Assert.AreEqual(fontSize * textMeasurer.CharacterWidth * 7, textMeasurer.MeasureTextWidth(simpleTestString, null, fontSize, 10));
+            Assert.AreEqual(fontSize * textMeasurer.CharacterWidth * 5, textMeasurer.MeasureTextWidth(trickyTestString, null, fontSize, 10));
+        }
+
+        /// <summary>
+        /// Basics tests of character trimming.
+        /// </summary>
+        [Test]
+        public void TrimmingByChar()
+        {
+            var textMeasurer = new MockTextMeasurer();
+            textMeasurer.AddBasicAlphabet();
+            textMeasurer.AddEllipsisChars();
+
+            var trimmer = new SimpleTextTrimmer();
+
+            trimmer.AppendEllipsis = false;
+            trimmer.TrimToWord = false;
+
+            var simpleTestString = "OxyPlot"; // 7 basic chars
+            var trickyTestString = "áéíóúaa"; // 12 chars, 5 characters with width
+            var fontSize = 10.0;
+
+            var widthZero = textMeasurer.MeasureTextWidth("", null, fontSize, 500);
+            var widthNearZero = textMeasurer.MeasureTextWidth("a", null, fontSize, 500) / 10.0;
+
+            var widthSmall = textMeasurer.MeasureTextWidth("aaa", null, fontSize, 500);
+            var widthNearSmall = textMeasurer.MeasureTextWidth("aaa", null, fontSize, 500) + widthNearZero;
+
+            var widthLarge = textMeasurer.MeasureTextWidth("aaaaaaa", null, fontSize, 500);
+            var widthVeryLarge = widthLarge * 2.0;
+
+            Assert.AreEqual("", trimmer.Trim(textMeasurer, simpleTestString, widthZero, null, fontSize, 500));
+            Assert.AreEqual("", trimmer.Trim(textMeasurer, trickyTestString, widthZero, null, fontSize, 500));
+
+            Assert.AreEqual("", trimmer.Trim(textMeasurer, simpleTestString, widthNearZero, null, fontSize, 500));
+            Assert.AreEqual("", trimmer.Trim(textMeasurer, trickyTestString, widthNearZero, null, fontSize, 500));
+
+            Assert.AreEqual(simpleTestString.Substring(0, 3), trimmer.Trim(textMeasurer, simpleTestString, widthSmall, null, fontSize, 500));
+            Assert.AreEqual(trickyTestString.Substring(0, 6), trimmer.Trim(textMeasurer, trickyTestString, widthSmall, null, fontSize, 500));
+
+            Assert.AreEqual(simpleTestString.Substring(0, 3), trimmer.Trim(textMeasurer, simpleTestString, widthNearSmall, null, fontSize, 500));
+            Assert.AreEqual(trickyTestString.Substring(0, 6), trimmer.Trim(textMeasurer, trickyTestString, widthNearSmall, null, fontSize, 500));
+
+            Assert.AreEqual(simpleTestString, trimmer.Trim(textMeasurer, simpleTestString, widthLarge, null, fontSize, 500));
+            Assert.AreEqual(trickyTestString, trimmer.Trim(textMeasurer, trickyTestString, widthLarge, null, fontSize, 500));
+
+            Assert.AreEqual(simpleTestString, trimmer.Trim(textMeasurer, simpleTestString, widthVeryLarge, null, fontSize, 500));
+            Assert.AreEqual(trickyTestString, trimmer.Trim(textMeasurer, trickyTestString, widthVeryLarge, null, fontSize, 500));
+        }
+
+        /// <summary>
+        /// Basics tests of word trimming.
+        /// </summary>
+        [Test]
+        public void TrimmingByWord()
+        {
+            var textMeasurer = new MockTextMeasurer();
+            textMeasurer.AddBasicAlphabet();
+            textMeasurer.AddEllipsisChars();
+            textMeasurer.AddBasicWhitespace();
+
+            var trimmer = new SimpleTextTrimmer();
+
+            trimmer.TrimToWord = true;
+
+            var text = "OxyPlot is a multiplatform plotting library";
+            var fontSize = 10.0;
+            var oneChar = textMeasurer.CharacterWidth * fontSize;
+            var tiny = textMeasurer.CharacterWidth * fontSize / 10;
+
+            var previousTarget = "";
+            int i = 0;
+            while (++i < text.Length && (i = text.IndexOf(' ', i)) > 0)
+            {
+                var target = text.Substring(0, i);
+                var width = textMeasurer.MeasureTextWidth(target, null, fontSize, 500);
+                var widthWithEllipsis = textMeasurer.MeasureTextWidth(target + trimmer.Ellipsis, null, fontSize, 500);
+
+                trimmer.AppendEllipsis = false;
+                Assert.AreEqual(previousTarget, trimmer.Trim(textMeasurer, text, width - tiny - oneChar, null, fontSize, 500));
+                Assert.AreEqual(previousTarget, trimmer.Trim(textMeasurer, text, width - tiny, null, fontSize, 500));
+                Assert.AreEqual(target, trimmer.Trim(textMeasurer, text, width, null, fontSize, 500));
+                Assert.AreEqual(target, trimmer.Trim(textMeasurer, text, width + tiny, null, fontSize, 500));
+                Assert.AreEqual(target, trimmer.Trim(textMeasurer, text, width + tiny + oneChar, null, fontSize, 500));
+
+                trimmer.AppendEllipsis = true;
+                Assert.AreEqual(previousTarget + trimmer.Ellipsis, trimmer.Trim(textMeasurer, text, widthWithEllipsis - tiny - oneChar, null, fontSize, 500));
+                Assert.AreEqual(previousTarget + trimmer.Ellipsis, trimmer.Trim(textMeasurer, text, widthWithEllipsis - tiny, null, fontSize, 500));
+                Assert.AreEqual(target + trimmer.Ellipsis, trimmer.Trim(textMeasurer, text, widthWithEllipsis, null, fontSize, 500));
+                Assert.AreEqual(target + trimmer.Ellipsis, trimmer.Trim(textMeasurer, text, widthWithEllipsis + tiny, null, fontSize, 500));
+                Assert.AreEqual(target + trimmer.Ellipsis, trimmer.Trim(textMeasurer, text, widthWithEllipsis + tiny + oneChar, null, fontSize, 500));
+
+                previousTarget = target;
+            }
+        }
+    }
+}

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -83,9 +83,9 @@ namespace OxyPlot.WindowsForms
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TextArranger"/> for this instance.
+        /// Gets or sets the <see cref="ITextArranger"/> for this instance.
         /// </summary>
-        public TextArranger TextArranger { get; set; }
+        public ITextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Sets the graphics target.

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -23,11 +23,12 @@ namespace OxyPlot.WindowsForms
     using System.Linq;
 
     using OxyPlot;
+    using OxyPlot.Rendering;
 
     /// <summary>
     /// The graphics render context.
     /// </summary>
-    public class GraphicsRenderContext : ClippingRenderContext, IDisposable
+    public class GraphicsRenderContext : ClippingRenderContext, IDisposable, ITextMeasurer
     {
         /// <summary>
         /// The font size factor.
@@ -77,7 +78,14 @@ namespace OxyPlot.WindowsForms
             }
 
             this.stringFormat = StringFormat.GenericTypographic;
+
+            this.TextArranger = new TextArranger(this, new SimpleTextTrimmer());
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TextArranger"/> for this instance.
+        /// </summary>
+        public TextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Sets the graphics target.
@@ -105,7 +113,7 @@ namespace OxyPlot.WindowsForms
             {
                 return;
             }
-            
+
             var pen = this.GetCachedPen(stroke, thickness);
             this.g.DrawEllipse(pen, (float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
         }
@@ -191,9 +199,9 @@ namespace OxyPlot.WindowsForms
         /// <param name="fontFamily">The font family.</param>
         /// <param name="fontSize">Size of the font.</param>
         /// <param name="fontWeight">The font weight.</param>
-        /// <param name="rotate">The rotation angle.</param>
-        /// <param name="halign">The horizontal alignment.</param>
-        /// <param name="valign">The vertical alignment.</param>
+        /// <param name="rotation">The rotation angle.</param>
+        /// <param name="horizontalAlignment">The horizontal alignment.</param>
+        /// <param name="verticalAlignment">The vertical alignment.</param>
         /// <param name="maxSize">The maximum size of the text.</param>
         public override void DrawText(
             ScreenPoint p,
@@ -202,9 +210,9 @@ namespace OxyPlot.WindowsForms
             string fontFamily,
             double fontSize,
             double fontWeight,
-            double rotate,
-            HorizontalAlignment halign,
-            VerticalAlignment valign,
+            double rotation,
+            HorizontalAlignment horizontalAlignment,
+            VerticalAlignment verticalAlignment,
             OxySize? maxSize)
         {
             if (text == null)
@@ -218,58 +226,26 @@ namespace OxyPlot.WindowsForms
             {
                 this.stringFormat.Alignment = StringAlignment.Near;
                 this.stringFormat.LineAlignment = StringAlignment.Near;
-                var size = Ceiling(this.g.MeasureString(text, font, int.MaxValue, this.stringFormat));
-                if (maxSize != null)
-                {
-                    if (size.Width > maxSize.Value.Width)
-                    {
-                        size.Width = (float)maxSize.Value.Width;
-                    }
-
-                    if (size.Height > maxSize.Value.Height)
-                    {
-                        size.Height = (float)maxSize.Value.Height;
-                    }
-                }
-
-                float dx = 0;
-                if (halign == HorizontalAlignment.Center)
-                {
-                    dx = -size.Width / 2;
-                }
-
-                if (halign == HorizontalAlignment.Right)
-                {
-                    dx = -size.Width;
-                }
-
-                float dy = 0;
-                this.stringFormat.LineAlignment = StringAlignment.Near;
-                if (valign == VerticalAlignment.Middle)
-                {
-                    dy = -size.Height / 2;
-                }
-
-                if (valign == VerticalAlignment.Bottom)
-                {
-                    dy = -size.Height;
-                }
 
                 var graphicsState = this.g.Save();
 
                 this.g.TranslateTransform((float)p.X, (float)p.Y);
 
-                var layoutRectangle = new RectangleF(0, 0, size.Width, size.Height);
-                if (Math.Abs(rotate) > double.Epsilon)
+                if (Math.Abs(rotation) > double.Epsilon)
                 {
-                    this.g.RotateTransform((float)rotate);
-
-                    layoutRectangle.Height += (float)(fontSize / 18.0);
+                    this.g.RotateTransform((float)rotation);
                 }
 
-                this.g.TranslateTransform(dx, dy);
+                // arrange around the origin with no rotation, because Graphics does the rotation for us
+                this.TextArranger.ArrangeText(new ScreenPoint(0, 0), text, fontFamily, fontSize, fontWeight, 0.0, horizontalAlignment, verticalAlignment, maxSize, HorizontalAlignment.Left, TextVerticalAlignment.Top, out var lines, out var linePositions);
 
-                this.g.DrawString(text, font, this.GetCachedBrush(fill), layoutRectangle, this.stringFormat);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    var line = lines[i];
+                    var linePosition = new PointF((float)linePositions[i].X, (float)linePositions[i].Y);
+
+                    this.g.DrawString(line, font, this.GetCachedBrush(fill), linePosition, this.stringFormat);
+                }
 
                 this.g.Restore(graphicsState);
             }
@@ -285,19 +261,7 @@ namespace OxyPlot.WindowsForms
         /// <returns>The text size.</returns>
         public override OxySize MeasureText(string text, string fontFamily, double fontSize, double fontWeight)
         {
-            if (text == null)
-            {
-                return OxySize.Empty;
-            }
-
-            var fontStyle = fontWeight < 700 ? FontStyle.Regular : FontStyle.Bold;
-            using (var font = CreateFont(fontFamily, fontSize, fontStyle))
-            {
-                this.stringFormat.Alignment = StringAlignment.Near;
-                this.stringFormat.LineAlignment = StringAlignment.Near;
-                var size = Ceiling(this.g.MeasureString(text, font, int.MaxValue, this.stringFormat));
-                return new OxySize(size.Width, size.Height);
-            }
+            return this.TextArranger.MeasureText(text, fontFamily, fontSize, fontWeight);
         }
 
         /// <summary>
@@ -374,10 +338,54 @@ namespace OxyPlot.WindowsForms
             this.g.ResetClip();
         }
 
+        /// <inheritdoc/>
+        public FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
+        {
+            // TODO: DPI support
+            var fontStyle = fontWeight < 700 ? FontStyle.Regular : FontStyle.Bold;
+            using (var font = CreateFont(fontFamily, fontSize, fontStyle))
+            {
+                var factor = font.Height / (double)Math.Abs(font.FontFamily.GetLineSpacing(fontStyle));
+
+                var ascender = factor * Math.Abs(font.FontFamily.GetCellAscent(fontStyle));
+                var descender = factor * Math.Abs(font.FontFamily.GetCellDescent(fontStyle));
+                var leading = font.Height - ascender - descender;
+
+                return new FontMetrics(ascender, descender, leading);
+            }
+        }
+
+        /// <inheritdoc/>
+        public double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight)
+        {
+            if (text == null)
+            {
+                return 0.0;
+            }
+
+            var fontStyle = fontWeight < 700 ? FontStyle.Regular : FontStyle.Bold;
+            using (var font = CreateFont(fontFamily, fontSize, fontStyle))
+            {
+                this.stringFormat.Alignment = StringAlignment.Near;
+                this.stringFormat.LineAlignment = StringAlignment.Near;
+                var size = this.g.MeasureString(text, font, int.MaxValue, this.stringFormat);
+                return size.Width;
+            }
+        }
+
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
         {
             // dispose images
             foreach (var i in this.imageCache)
@@ -492,7 +500,7 @@ namespace OxyPlot.WindowsForms
                 return pen;
             }
 
-            return this.pens[description] = CreatePen(stroke, thickness, dashArray, lineJoin);
+            return this.pens[description] = this.CreatePen(stroke, thickness, dashArray, lineJoin);
         }
 
         /// <summary>

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -9,6 +9,7 @@
 
 namespace OxyPlot.Wpf
 {
+    using OxyPlot.Rendering;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -27,7 +28,7 @@ namespace OxyPlot.Wpf
     /// <summary>
     /// Implements <see cref="IRenderContext" /> for <see cref="System.Windows.Controls.Canvas" />.
     /// </summary>
-    public class CanvasRenderContext : ClippingRenderContext
+    public class CanvasRenderContext : ClippingRenderContext, ITextMeasurer
     {
         /// <summary>
         /// The images in use
@@ -84,7 +85,16 @@ namespace OxyPlot.Wpf
             this.TextFormattingMode = TextFormattingMode.Display;
             this.TextMeasurementMethod = TextMeasurementMethod.TextBlock;
             this.RendersToScreen = true;
+            this.BalancedLineDrawingThicknessLimit = 3.5;
+            this.DefaultFontFamily = "Segoe UI";
+
+            this.TextArranger = new TextArranger(this, new SimpleTextTrimmer());
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// </summary>
+        public TextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Gets or sets the text measurement method.
@@ -97,6 +107,23 @@ namespace OxyPlot.Wpf
         /// </summary>
         /// <value>The text formatting mode. The default value is <see cref="System.Windows.Media.TextFormattingMode.Display"/>.</value>
         public TextFormattingMode TextFormattingMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the thickness limit for "balanced" line drawing.
+        /// </summary>
+        public double BalancedLineDrawingThicknessLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use stream geometry for lines and polygons rendering.
+        /// </summary>
+        /// <value><c>true</c> if stream geometry should be used; otherwise, <c>false</c> .</value>
+        /// <remarks>The XamlWriter does not serialize StreamGeometry, so set this to <c>false</c> if you want to export to XAML. Using stream geometry seems to be slightly faster than using path geometry.</remarks>
+        public bool UseStreamGeometry { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default font familiy.
+        /// </summary>
+        public string DefaultFontFamily { get; set; }
 
         ///<inheritdoc/>
         public override void DrawEllipse(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
@@ -306,127 +333,56 @@ namespace OxyPlot.Wpf
             string fontFamily,
             double fontSize,
             double fontWeight,
-            double rotate,
-            HorizontalAlignment halign,
-            VerticalAlignment valign,
+            double rotation,
+            HorizontalAlignment horizontalAlignment,
+            VerticalAlignment verticalAlignment,
             OxySize? maxSize)
         {
-            var tb = this.CreateAndAdd<TextBlock>();
-            tb.Text = text;
-            tb.Foreground = this.GetCachedBrush(fill);
-            if (fontFamily != null)
+            this.TextArranger.ArrangeText(p, text, fontFamily, fontSize, fontWeight, rotation, horizontalAlignment, verticalAlignment, maxSize, HorizontalAlignment.Left, TextVerticalAlignment.Top, out var lines, out var linePositions);
+
+            for (int i = 0; i < lines.Length; i++)
             {
+                var line = lines[i];
+                var linePosition = new Point(linePositions[i].X, linePositions[i].Y);
+
+                var tb = this.CreateAndAdd<TextBlock>();
+                tb.Text = line;
+                tb.Foreground = this.GetCachedBrush(fill);
                 tb.FontFamily = this.GetCachedFontFamily(fontFamily);
-            }
 
-            if (fontSize > 0)
-            {
-                tb.FontSize = fontSize;
-            }
-
-            if (fontWeight > 0)
-            {
-                tb.FontWeight = GetFontWeight(fontWeight);
-            }
-
-            TextOptions.SetTextFormattingMode(tb, this.TextFormattingMode);
-
-            double dx = 0;
-            double dy = 0;
-
-            if (maxSize != null || halign != HorizontalAlignment.Left || valign != VerticalAlignment.Top)
-            {
-                tb.Measure(new Size(1000, 1000));
-                var size = tb.DesiredSize;
-                if (maxSize != null)
+                if (fontSize > 0)
                 {
-                    if (size.Width > maxSize.Value.Width + 1e-3)
-                    {
-                        size.Width = Math.Max(maxSize.Value.Width, 0);
-                    }
-
-                    if (size.Height > maxSize.Value.Height + 1e-3)
-                    {
-                        size.Height = Math.Max(maxSize.Value.Height, 0);
-                    }
-
-                    tb.Width = size.Width;
-                    tb.Height = size.Height;
+                    tb.FontSize = fontSize;
                 }
 
-                if (halign == HorizontalAlignment.Center)
+                if (fontWeight > 0)
                 {
-                    dx = -size.Width / 2;
+                    tb.FontWeight = GetFontWeight(fontWeight);
                 }
 
-                if (halign == HorizontalAlignment.Right)
+                TextOptions.SetTextFormattingMode(tb, this.TextFormattingMode);
+
+                var transform = new TransformGroup();
+                if (Math.Abs(rotation) > double.Epsilon)
                 {
-                    dx = -size.Width;
+                    transform.Children.Add(new RotateTransform(rotation));
                 }
 
-                if (valign == VerticalAlignment.Middle)
+                transform.Children.Add(new TranslateTransform(linePosition.X, linePosition.Y));
+                tb.RenderTransform = transform;
+                if (tb.Clip != null)
                 {
-                    dy = -size.Height / 2;
+                    tb.Clip.Transform = tb.RenderTransform.Inverse as Transform;
                 }
 
-                if (valign == VerticalAlignment.Bottom)
-                {
-                    dy = -size.Height;
-                }
+                tb.SetValue(RenderOptions.ClearTypeHintProperty, ClearTypeHint.Enabled);
             }
-
-            var transform = new TransformGroup();
-            transform.Children.Add(new TranslateTransform(dx, dy));
-            if (Math.Abs(rotate) > double.Epsilon)
-            {
-                transform.Children.Add(new RotateTransform(rotate));
-            }
-
-            transform.Children.Add(new TranslateTransform(p.X, p.Y));
-            tb.RenderTransform = transform;
-            if (tb.Clip != null)
-            {
-                tb.Clip.Transform = tb.RenderTransform.Inverse as Transform;
-            }
-
-            tb.SetValue(RenderOptions.ClearTypeHintProperty, ClearTypeHint.Enabled);
         }
 
         ///<inheritdoc/>
         public override OxySize MeasureText(string text, string fontFamily, double fontSize, double fontWeight)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return OxySize.Empty;
-            }
-
-            if (this.TextMeasurementMethod == TextMeasurementMethod.GlyphTypeface)
-            {
-                return MeasureTextByGlyphTypeface(text, fontFamily, fontSize, fontWeight);
-            }
-
-            var tb = new TextBlock { Text = text };
-
-            TextOptions.SetTextFormattingMode(tb, this.TextFormattingMode);
-
-            if (fontFamily != null)
-            {
-                tb.FontFamily = new FontFamily(fontFamily);
-            }
-
-            if (fontSize > 0)
-            {
-                tb.FontSize = fontSize;
-            }
-
-            if (fontWeight > 0)
-            {
-                tb.FontWeight = GetFontWeight(fontWeight);
-            }
-
-            tb.Measure(new Size(1000, 1000));
-
-            return new OxySize(tb.DesiredSize.Width, tb.DesiredSize.Height);
+            return this.TextArranger.MeasureText(text, fontFamily, fontSize, fontWeight);
         }
 
         ///<inheritdoc/>
@@ -494,7 +450,66 @@ namespace OxyPlot.Wpf
             this.clip = null;
         }
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
+        public FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
+        {
+            var typeface = new Typeface(
+                new FontFamily(fontFamily), FontStyles.Normal, GetFontWeight(fontWeight), FontStretches.Normal);
+
+            if (!typeface.TryGetGlyphTypeface(out var glyphTypeface))
+            {
+                throw new InvalidOperationException("No glyph typeface found");
+            }
+
+            var lineHeight = Math.Abs(glyphTypeface.Height) * fontSize;
+            var ascender = Math.Abs(typeface.FontFamily.Baseline) * fontSize;
+            var descender = lineHeight - ascender;
+            var leading = (Math.Abs(typeface.FontFamily.LineSpacing) * fontSize) - lineHeight;
+
+            return new FontMetrics(ascender, descender, leading);
+        }
+
+        /// <inheritdoc/>
+        public double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0.0;
+            }
+
+            if (this.TextMeasurementMethod == TextMeasurementMethod.GlyphTypeface)
+            {
+                return MeasureTextByGlyphTypeface(text, fontFamily, fontSize, fontWeight).Width;
+            }
+
+            var tb = new TextBlock { Text = text };
+
+            TextOptions.SetTextFormattingMode(tb, this.TextFormattingMode);
+
+            if (fontFamily != null)
+            {
+                tb.FontFamily = new FontFamily(fontFamily);
+            }
+
+            if (fontSize > 0)
+            {
+                tb.FontSize = fontSize;
+            }
+
+            if (fontWeight > 0)
+            {
+                tb.FontWeight = GetFontWeight(fontWeight);
+            }
+
+            tb.Measure(new Size(1000, 1000));
+
+            return tb.DesiredSize.Width;
+        }
+
+        /// <summary>
+        /// Cleans up resources not in use.
+        /// </summary>
+        /// <remarks>This method is called at the end of each rendering.</remarks>
         public override void CleanUp()
         {
             // Find the images in the cache that has not been used since last call to this method
@@ -760,11 +775,11 @@ namespace OxyPlot.Wpf
         }
 
         /// <summary>
-        /// Converts an <see cref="OxyRect" /> to a <see cref="Rect" />.
+        /// Converts an <see cref="OxyRect" /> to a <see cref="System.Windows.Rect" />.
         /// </summary>
         /// <param name="r">The rectangle.</param>
-        /// <returns>A <see cref="Rect" />.</returns>
-        protected static Rect ToRect(OxyRect r)
+        /// <returns>A <see cref="System.Windows.Rect" />.</returns>
+        private static Rect ToRect(OxyRect r)
         {
             return new Rect(r.Left, r.Top, r.Width, r.Height);
         }
@@ -780,8 +795,8 @@ namespace OxyPlot.Wpf
         {
             switch (edgeRenderingMode)
             {
-                case EdgeRenderingMode.Adaptive when IsStraightLine(points):
-                case EdgeRenderingMode.Automatic when IsStraightLine(points):
+                case EdgeRenderingMode.Adaptive when RenderContextBase.IsStraightLine(points):
+                case EdgeRenderingMode.Automatic when RenderContextBase.IsStraightLine(points):
                 case EdgeRenderingMode.PreferSharpness:
                     return points.Select(p => PixelLayout.Snap(p.X, p.Y, strokeThickness, this.VisualOffset, this.DpiScale));
                 default:

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -338,6 +338,7 @@ namespace OxyPlot.Wpf
             VerticalAlignment verticalAlignment,
             OxySize? maxSize)
         {
+            fontFamily ??= this.DefaultFontFamily;
             this.TextArranger.ArrangeText(p, text, fontFamily, fontSize, fontWeight, rotation, horizontalAlignment, verticalAlignment, maxSize, HorizontalAlignment.Left, TextVerticalAlignment.Top, out var lines, out var linePositions);
 
             for (int i = 0; i < lines.Length; i++)
@@ -779,7 +780,7 @@ namespace OxyPlot.Wpf
         /// </summary>
         /// <param name="r">The rectangle.</param>
         /// <returns>A <see cref="System.Windows.Rect" />.</returns>
-        private static Rect ToRect(OxyRect r)
+        protected static Rect ToRect(OxyRect r)
         {
             return new Rect(r.Left, r.Top, r.Width, r.Height);
         }

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -92,9 +92,9 @@ namespace OxyPlot.Wpf
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// Gets or sets the <see cref="ITextArranger"/> used by this instance.
         /// </summary>
-        public TextArranger TextArranger { get; set; }
+        public ITextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Gets or sets the text measurement method.

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -460,7 +460,13 @@ namespace OxyPlot.Wpf
 
             if (!typeface.TryGetGlyphTypeface(out var glyphTypeface))
             {
-                throw new InvalidOperationException("No glyph typeface found");
+                var defaultTypeface = new Typeface(
+                    new FontFamily(this.DefaultFontFamily), FontStyles.Normal, GetFontWeight(fontWeight), FontStretches.Normal);
+
+                if (!defaultTypeface.TryGetGlyphTypeface(out glyphTypeface))
+                {
+                    throw new InvalidOperationException("No glyph typeface found");
+                }
             }
 
             var lineHeight = Math.Abs(glyphTypeface.Height) * fontSize;

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -121,7 +121,7 @@ namespace OxyPlot.Wpf
         public bool UseStreamGeometry { get; set; }
 
         /// <summary>
-        /// Gets or sets the default font familiy.
+        /// Gets or sets the default font family.
         /// </summary>
         public string DefaultFontFamily { get; set; }
 
@@ -383,6 +383,7 @@ namespace OxyPlot.Wpf
         ///<inheritdoc/>
         public override OxySize MeasureText(string text, string fontFamily, double fontSize, double fontWeight)
         {
+            fontFamily ??= this.DefaultFontFamily;
             return this.TextArranger.MeasureText(text, fontFamily, fontSize, fontWeight);
         }
 

--- a/Source/OxyPlot.Wpf/XamlRenderContext.cs
+++ b/Source/OxyPlot.Wpf/XamlRenderContext.cs
@@ -46,11 +46,6 @@ namespace OxyPlot.Wpf
             this.BalancedLineDrawingThicknessLimit = 3.5;
         }
 
-        /// <summary>
-        /// Gets or sets the thickness limit for "balanced" line drawing.
-        /// </summary>
-        public double BalancedLineDrawingThicknessLimit { get; set; }
-
         ///<inheritdoc/>
         public override void DrawEllipses(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {

--- a/Source/OxyPlot/Pdf/PdfRenderContext.cs
+++ b/Source/OxyPlot/Pdf/PdfRenderContext.cs
@@ -365,6 +365,7 @@ namespace OxyPlot
             this.doc.RestoreState();
         }
 
+        /// <inheritdoc/>
         public FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight)
         {
             var font = PortableDocument.GetFont(fontFamily, fontWeight > 500, false);

--- a/Source/OxyPlot/Pdf/PdfRenderContext.cs
+++ b/Source/OxyPlot/Pdf/PdfRenderContext.cs
@@ -55,9 +55,9 @@ namespace OxyPlot
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TextArranger"/> for this instance.
+        /// Gets or sets the <see cref="ITextArranger"/> for this instance.
         /// </summary>
-        public TextArranger TextArranger { get; set; }
+        public ITextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Saves the output to the specified stream.

--- a/Source/OxyPlot/Pdf/PortableDocument.cs
+++ b/Source/OxyPlot/Pdf/PortableDocument.cs
@@ -950,7 +950,7 @@ namespace OxyPlot
         /// <param name="bold">Use bold if set to <c>true</c>.</param>
         /// <param name="italic">Use italic if set to <c>true</c>.</param>
         /// <returns>The font.</returns>
-        private static PortableDocumentFont GetFont(string fontName, bool bold, bool italic)
+        public static PortableDocumentFont GetFont(string fontName, bool bold, bool italic)
         {
             if (fontName != null)
             {

--- a/Source/OxyPlot/Pdf/PortableDocumentFont.cs
+++ b/Source/OxyPlot/Pdf/PortableDocumentFont.cs
@@ -9,6 +9,10 @@
 
 namespace OxyPlot
 {
+    using System;
+
+    using OxyPlot.Rendering;
+
     /// <summary>
     /// Represents a font that can be used in a <see cref="PortableDocument" />.
     /// </summary>
@@ -131,6 +135,20 @@ namespace OxyPlot
 
             width = wmax * fontSize / 1000;
             height = lineCount * (this.Ascent - this.Descent) * fontSize / 1000;
+        }
+
+        /// <summary>
+        /// Gets minimal font metrics for the font.
+        /// </summary>
+        /// <param name="fontSize">The font size.</param>
+        /// <returns>The font metrics.</returns>
+        public FontMetrics GetFontMetrics(double fontSize)
+        {
+            var ascender = fontSize * Math.Abs(this.Ascent) / 1000;
+            var descender = fontSize * Math.Abs(this.Descent) / 1000;
+            var leading = 0.0;
+
+            return new FontMetrics(ascender, descender, leading);
         }
     }
 }

--- a/Source/OxyPlot/Rendering/FontMetrics.cs
+++ b/Source/OxyPlot/Rendering/FontMetrics.cs
@@ -1,0 +1,67 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TextVerticalAlignment.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Contains metrics for a given font.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace OxyPlot.Rendering
+{
+    /// <summary>
+    /// Contains metrics for a given font.
+    /// </summary>
+    public class FontMetrics
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FontMetrics" /> class.
+        /// </summary>
+        /// <param name="ascender">The ascender.</param>
+        /// <param name="descender">The descender.</param>
+        /// <param name="leading">The leading.</param>
+        public FontMetrics(double ascender, double descender, double leading)
+        {
+            if (ascender < 0)
+            {
+                throw new ArgumentException("Ascender must be non-negative.", nameof(ascender));
+            }
+
+            if (descender < 0)
+            {
+                throw new ArgumentException("Descender must be non-negative.", nameof(descender));
+            }
+
+            Ascender = ascender;
+            Descender = descender;
+            Leading = leading;
+        }
+
+        /// <summary>
+        /// Gets the distance from the baseline to the top of the font.
+        /// </summary>
+        public double Ascender { get; }
+
+        /// <summary>
+        /// Gets the distance from the baseline to the bottom of the font.
+        /// </summary>
+        public double Descender { get; }
+
+        /// <summary>
+        /// Gets the distance between the bottom of a line of text and the top of the next line of text.
+        /// </summary>
+        public double Leading { get; }
+
+        /// <summary>
+        /// Gets the cell height of the font, equal to the sum of the <see cref="Ascender"/> and <see cref="Descender"/>.
+        /// </summary>
+        public double CellHeight => this.Ascender + this.Descender;
+
+        /// <summary>
+        /// Gets the line height of the font, equal to the sum of the <see cref="CellHeight"/> and <see cref="Leading"/>.
+        /// </summary>
+        public double LineHeight => this.CellHeight + this.Leading;
+    }
+}

--- a/Source/OxyPlot/Rendering/FontMetrics.cs
+++ b/Source/OxyPlot/Rendering/FontMetrics.cs
@@ -7,10 +7,10 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
-
 namespace OxyPlot.Rendering
 {
+    using System;
+
     /// <summary>
     /// Contains metrics for a given font.
     /// </summary>
@@ -34,9 +34,9 @@ namespace OxyPlot.Rendering
                 throw new ArgumentException("Descender must be non-negative.", nameof(descender));
             }
 
-            Ascender = ascender;
-            Descender = descender;
-            Leading = leading;
+            this.Ascender = ascender;
+            this.Descender = descender;
+            this.Leading = leading;
         }
 
         /// <summary>

--- a/Source/OxyPlot/Rendering/FontMetrics.cs
+++ b/Source/OxyPlot/Rendering/FontMetrics.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="TextVerticalAlignment.cs" company="OxyPlot">
+// <copyright file="FontMetrics.cs" company="OxyPlot">
 //   Copyright (c) 2020 OxyPlot contributors
 // </copyright>
 // <summary>

--- a/Source/OxyPlot/Rendering/ITextArranger.cs
+++ b/Source/OxyPlot/Rendering/ITextArranger.cs
@@ -1,0 +1,56 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ITextArranger.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Arranges text.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Rendering
+{
+    /// <summary>
+    /// Arranges text.
+    /// </summary>
+    public interface ITextArranger
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ITextMeasurer"/> used by this instance.
+        /// </summary>
+        ITextMeasurer TextMeasurer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ITextTrimmer"/> used by this instance.
+        /// </summary>
+        ITextTrimmer TextTrimmer { get; set; }
+
+        /// <summary>
+        /// Splits the text into multiple lines, and indicates where they should be rendered given the given target alignment.
+        /// </summary>
+        /// <param name="p">The position.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <param name="rotation">The rotation angle.</param>
+        /// <param name="horizontalAlignment">The horizontal alignment.</param>
+        /// <param name="verticalAlignment">The vertical alignment.</param>
+        /// <param name="maxSize">The maximum size of the text (in device independent units, 1/96 inch). If set to <c>null</c>, the text will not be clipped.</param>
+        /// <param name="targetHorizontalAlignment">The horizontal alignment used to render the text.</param>
+        /// <param name="targetVerticalAlignment">The vertical alignment used to render the text.</param>
+        /// <param name="lines">The separate lines of text.</param>
+        /// <param name="linePositions">The point at which to render each line.</param>
+        void ArrangeText(ScreenPoint p, string text, string fontFamily, double fontSize, double fontWeight, double rotation, HorizontalAlignment horizontalAlignment, VerticalAlignment verticalAlignment, OxySize? maxSize, HorizontalAlignment targetHorizontalAlignment, TextVerticalAlignment targetVerticalAlignment, out string[] lines, out ScreenPoint[] linePositions);
+
+        /// <summary>
+        /// Measures the size of the text as it would be when arranged by the ArrangeText method."/>.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <returns>The size of the text.</returns>
+        /// <remarks>Returns an <see cref="OxySize"/> with no width and height if the text is <c>null</c> or empty.</remarks>
+        OxySize MeasureText(string text, string fontFamily, double fontSize, double fontWeight);
+    }
+}

--- a/Source/OxyPlot/Rendering/ITextMeasurer.cs
+++ b/Source/OxyPlot/Rendering/ITextMeasurer.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ITextMeasurer.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Measures text.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Rendering
+{
+    /// <summary>
+    /// Measures text.
+    /// </summary>
+    public interface ITextMeasurer
+    {
+        /// <summary>
+        /// Determines basic font metrics for the given font.
+        /// </summary>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">The font size in 1/96ths of an inch.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <returns>The font metrics.</returns>
+        FontMetrics GetFontMetrics(string fontFamily, double fontSize, double fontWeight);
+
+        /// <summary>
+        /// Measures the width of one line of text.
+        /// </summary>
+        /// <param name="text">The single line of text to measure.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">The font size in 1/96ths of an inch.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <returns>The width in pixels of the text.</returns>
+        double MeasureTextWidth(string text, string fontFamily, double fontSize, double fontWeight);
+    }
+}

--- a/Source/OxyPlot/Rendering/ITextTrimmer.cs
+++ b/Source/OxyPlot/Rendering/ITextTrimmer.cs
@@ -1,0 +1,29 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ITextTrimmer.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Trims text.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Rendering
+{
+    /// <summary>
+    /// Trims text.
+    /// </summary>
+    public interface ITextTrimmer
+    {
+        /// <summary>
+        /// Trims the given line of text so that it fits in the given width.
+        /// </summary>
+        /// <param name="textMeasurer">The <see cref="ITextMeasurer"/> to use.</param>
+        /// <param name="line">The line of text to trim.</param>
+        /// <param name="width">The width in which the text must fix.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">The font size in 1/96ths of an inch.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <returns>The trimmed line of text.</returns>
+        string Trim(ITextMeasurer textMeasurer, string line, double width, string fontFamily, double fontSize, double fontWeight);
+    }
+}

--- a/Source/OxyPlot/Rendering/SimpleTextTrimmer.cs
+++ b/Source/OxyPlot/Rendering/SimpleTextTrimmer.cs
@@ -1,0 +1,216 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SimpleTextTrimmer.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   A simple trimmer that doesn't use glyph information.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Rendering
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// A simple trimmer that doesn't use glyph information.
+    /// </summary>
+    public class SimpleTextTrimmer : ITextTrimmer
+    {
+        /// <summary>
+        /// The default ellipsis, comprising three ascii stop symbols.
+        /// </summary>
+        public static readonly string AsciiEllipsis = "...";
+
+        /// <summary>
+        /// The unicode horizontal ellipsis.
+        /// </summary>
+        public static readonly string UnicodeEllipsis = "…";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleTextTrimmer" /> class.
+        /// </summary>
+        public SimpleTextTrimmer()
+        {
+            this.TrimToWord = false;
+            this.Ellipsis = UnicodeEllipsis;
+            this.AppendEllipsis = true;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether text should be trimmed to word boundaries.
+        /// </summary>
+        public bool TrimToWord { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value to append to any trimmed text when <see cref="AppendEllipsis"/> is <c>true</c>.
+        /// </summary>
+        public string Ellipsis { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an ellipsis should be appended to any trimmed text.
+        /// </summary>
+        public bool AppendEllipsis { get; set; }
+
+        /// <summary>
+        /// Gets a list of indexes that correspond to the first <char>c</char> after a character in the single line of text given.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <returns>The list of character boundaries.</returns>
+        public static IList<int> GetCharacterBoundaries(string text)
+        {
+            var res = new List<int>();
+
+            // handle surrogate pairs explicitly (U+200D is zero-width-joiner for emoji)
+            var matches = Regex.Matches(text, @"([\uD800-\uDBFF}][\uDC00-\uDFFF](\u200D[\uD800-\uDBFF}][\uDC00-\uDFFF])*|[^\s])\p{M}*", RegexOptions.Singleline);
+            for (int i = 0; i < matches.Count; i++)
+            {
+                var m = matches[i];
+                res.Add(m.Index + m.Length);
+            }
+
+            return res;
+        }
+
+        /// <summary>
+        /// Gets a list of indexes that correspond to the first <c>char</c> after a word in the single line of text given.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <returns>The list of word boundaries.</returns>
+        public static IList<int> GetWordBoundaries(string text)
+        {
+            var res = new List<int>();
+
+            var matches = Regex.Matches(text, @"[^\s]+", RegexOptions.Singleline);
+            for (int i = 0; i < matches.Count; i++)
+            {
+                var m = matches[i];
+                res.Add(m.Index + m.Length);
+            }
+
+            return res;
+        }
+
+        /// <summary>
+        /// Trims the given text at the given boundaries.
+        /// </summary>
+        /// <param name="textMeasurer">The <see cref="ITextMeasurer"/> to use.</param>
+        /// <param name="line">The line of text to trim.</param>
+        /// <param name="width">The width in which the text must fix.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">The font size in 1/96ths of an inch.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <param name="ellipsis">The ellipsis, if any, to append to the end of the text.</param>
+        /// <param name="boundaries">The word boundaries at which to trim.</param>
+        /// <returns>The trimmed line of text.</returns>
+        public static string TrimAtBoundaries(ITextMeasurer textMeasurer, string line, double width, string fontFamily, double fontSize, double fontWeight, string ellipsis, IList<int> boundaries)
+        {
+            if (BoundaryCheck(textMeasurer, line, width, fontFamily, fontSize, fontWeight, ellipsis, out var boundaryResult))
+            {
+                return boundaryResult;
+            }
+
+            ellipsis = ellipsis ?? string.Empty;
+
+            int s = -1;
+            int e = boundaries.Count - 1;
+
+            while (e > s)
+            {
+                var m = s + ((e - s + 1) / 2);
+                var lineWidth = textMeasurer.MeasureTextWidth(line.Substring(0, boundaries[m]) + ellipsis, fontFamily, fontSize, fontWeight);
+
+                if (lineWidth > width)
+                {
+                    e = m - 1;
+                }
+                else
+                {
+                    s = m;
+                }
+            }
+
+            if (s == -1)
+            {
+                // TODO: need to think about this condition?
+                return ellipsis;
+            }
+            else
+            {
+                return line.Substring(0, boundaries[s]) + ellipsis;
+            }
+        }
+
+        /// <inheritdoc/>
+        public string Trim(ITextMeasurer textMeasurer, string line, double width, string fontFamily, double fontSize, double fontWeight)
+        {
+            var ellipsis = this.AppendEllipsis ? this.Ellipsis : null;
+
+            if (this.TrimToWord)
+            {
+                var boundaries = GetWordBoundaries(line);
+                return TrimAtBoundaries(textMeasurer, line, width, fontFamily, fontSize, fontWeight, ellipsis, boundaries);
+            }
+            else
+            {
+                var boundaries = GetCharacterBoundaries(line);
+                return TrimAtBoundaries(textMeasurer, line, width, fontFamily, fontSize, fontWeight, ellipsis, boundaries);
+            }
+        }
+
+        /// <summary>
+        /// Performs common boundary condition checks. Returns true if the <paramref name="boundaryResult"/> should be returned immediately in lieu of other trimming.
+        /// </summary>
+        /// <param name="textMeasurer">The <see cref="ITextMeasurer"/> to use.</param>
+        /// <param name="line">The line of text to trim.</param>
+        /// <param name="width">The width in which the text must fix.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">The font size in 1/96ths of an inch.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <param name="ellipsis">The ellipsis, if any, to append to the end of the text.</param>
+        /// <param name="boundaryResult">The resulting text if a boundary condition was observed, otherwise <c>null</c>.</param>
+        /// <returns><c>true</c> if a boundary condition was met, otherwise <c>false</c>.</returns>
+        private static bool BoundaryCheck(ITextMeasurer textMeasurer, string line, double width, string fontFamily, double fontSize, double fontWeight, string ellipsis, out string boundaryResult)
+        {
+            if (textMeasurer == null)
+            {
+                throw new ArgumentNullException(nameof(textMeasurer));
+            }
+
+            if (line == null)
+            {
+                throw new ArgumentNullException(nameof(line));
+            }
+
+            if (width <= 0)
+            {
+                // nothing will fit
+                boundaryResult = string.Empty;
+                return true;
+            }
+
+            var lineWidth = textMeasurer.MeasureTextWidth(line, fontFamily, fontSize, fontWeight);
+            if (lineWidth <= width)
+            {
+                // do nothing
+                boundaryResult = line;
+                return true;
+            }
+
+            if (ellipsis != null)
+            {
+                var ellipsisWidth = textMeasurer.MeasureTextWidth(ellipsis, fontFamily, fontSize, fontWeight);
+                if (width < ellipsisWidth)
+                {
+                    // ellipsis won't fit
+                    boundaryResult = string.Empty;
+                    return true;
+                }
+            }
+
+            boundaryResult = null;
+            return false;
+        }
+    }
+}

--- a/Source/OxyPlot/Rendering/TextArranger.cs
+++ b/Source/OxyPlot/Rendering/TextArranger.cs
@@ -1,0 +1,259 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TextArranger.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Arranges text.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Rendering
+{
+    using System;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Arranges text.
+    /// </summary>
+    public class TextArranger
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextArranger" /> class.
+        /// </summary>
+        /// <param name="textMeasurer">The <see cref="ITextMeasurer"/> to be used by this instance.</param>
+        /// <param name="textTrimmer">The <see cref="ITextTrimmer"/> to be used by this instance.</param>
+        public TextArranger(ITextMeasurer textMeasurer, ITextTrimmer textTrimmer)
+        {
+            this.TextMeasurer = textMeasurer ?? throw new ArgumentNullException(nameof(textMeasurer));
+            this.TextTrimmer = textTrimmer ?? throw new ArgumentNullException(nameof(textTrimmer));
+
+            this.SquashTrimmedTextBounds = false;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ITextMeasurer"/> used by this instance.
+        /// </summary>
+        public ITextMeasurer TextMeasurer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ITextTrimmer"/> used by this instance.
+        /// </summary>
+        public ITextTrimmer TextTrimmer { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to squash the bounds of trimmed text to the size the text.
+        /// </summary>
+        public bool SquashTrimmedTextBounds { get; set; }
+
+        /// <summary>
+        /// Splits the text into multiple lines, and indicates where they should be rendered given the given target alignment.
+        /// </summary>
+        /// <param name="p">The position.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <param name="rotation">The rotation angle.</param>
+        /// <param name="horizontalAlignment">The horizontal alignment.</param>
+        /// <param name="verticalAlignment">The vertical alignment.</param>
+        /// <param name="maxSize">The maximum size of the text (in device independent units, 1/96 inch). If set to <c>null</c>, the text will not be clipped.</param>
+        /// <param name="targetHorizontalAlignment">The horixontal alignment used to render the text.</param>
+        /// <param name="targetVerticalAlignment">The vertical alignment used to render the text.</param>
+        /// <param name="lines">The separate lines of text.</param>
+        /// <param name="linePositions">The point at which to render each line.</param>
+        /// <remarks>
+        /// Non-null <paramref name="maxSize"/> is not supported.
+        /// </remarks>
+        public void ArrangeText(
+            ScreenPoint p,
+            string text,
+            string fontFamily,
+            double fontSize,
+            double fontWeight,
+            double rotation,
+            HorizontalAlignment horizontalAlignment,
+            VerticalAlignment verticalAlignment,
+            OxySize? maxSize,
+            HorizontalAlignment targetHorizontalAlignment,
+            TextVerticalAlignment targetVerticalAlignment,
+            out string[] lines,
+            out ScreenPoint[] linePositions)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            // measure the size of the whole text
+            var wholeSize = this.MeasureText(text, fontFamily, fontSize, fontWeight);
+
+            // infer font metrics from wholeSize
+            var metrics = this.TextMeasurer.GetFontMetrics(fontFamily, fontSize, fontWeight);
+            var lineHeight = metrics.CellHeight;
+            var leading = metrics.Leading;
+            var descender = metrics.Descender;
+
+            // get the rendering bounds from maxSize if necessary
+            var bounds = wholeSize;
+            if (maxSize != null)
+            {
+                bounds = new OxySize(Math.Ceiling(Math.Min(bounds.Width, maxSize.Value.Width)), Math.Ceiling(Math.Min(bounds.Height, maxSize.Value.Height)));
+            }
+
+            // split into lines
+            lines = StringHelper.SplitLines(text);
+
+            // if the text is too tall, we need to remove some lines
+            if (bounds.Height < wholeSize.Height && lines.Length > 1)
+            {
+                var clippedLineCount = 1 + (int)((bounds.Height - lineHeight) / (lineHeight + leading));
+                lines = lines.Take(clippedLineCount).ToArray();
+
+                if (this.SquashTrimmedTextBounds)
+                {
+                    bounds = new OxySize(bounds.Width, ((lineHeight + leading) * lines.Length) - leading);
+                }
+            }
+
+            // if the text is too wide, we need to trim the lines down a bit
+            if (bounds.Width < wholeSize.Width)
+            {
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    lines[i] = this.TextTrimmer.Trim(this.TextMeasurer, lines[i], bounds.Width, fontFamily, fontSize, fontWeight);
+                }
+
+                if (this.SquashTrimmedTextBounds)
+                {
+                    bounds = new OxySize(lines.Max(l => this.TextMeasurer.MeasureTextWidth(l, fontFamily, fontSize, fontWeight)), bounds.Height);
+                }
+            }
+
+            // do these once
+            var sin = Math.Sin(rotation / 180.0 * Math.PI);
+            var cos = Math.Cos(rotation / 180.0 * Math.PI);
+
+            // turn metrics into vectors
+            var offsetBoundsWidth = new ScreenVector(cos * bounds.Width, sin * bounds.Width);
+            var offsetBoundsHeight = new ScreenVector(-sin * bounds.Height, cos * bounds.Height);
+
+            var offsetLineHeight = new ScreenVector(-sin * lineHeight, cos * lineHeight);
+            var offsetLeading = new ScreenVector(-sin * leading, cos * leading);
+            var offsetDescender = new ScreenVector(-sin * descender, cos * descender);
+
+            // align to bounds
+            var offsetBoundsX = offsetBoundsWidth * 0.0; // keep centerline
+            var offsetBoundsY = offsetBoundsHeight * (ResolveOffset(verticalAlignment) - 0.5); // find the top of the top line
+
+            p += offsetBoundsX + offsetBoundsY;
+
+            // align lines within bounds
+            bool useBaselineOffset = targetVerticalAlignment == TextVerticalAlignment.Baseline;
+            if (useBaselineOffset)
+            {
+                targetVerticalAlignment = TextVerticalAlignment.Bottom;
+            }
+
+            var offsetLineXRelative = ResolveOffset(targetHorizontalAlignment) - ResolveOffset(horizontalAlignment); // multiply later when we know the line width
+            var offsetLineY = offsetLineHeight * (0.5 - ResolveOffset((VerticalAlignment)targetVerticalAlignment));
+
+            if (useBaselineOffset)
+            {
+                offsetLineY -= offsetDescender;
+            }
+
+            // position the lines
+            linePositions = new ScreenPoint[lines.Length];
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                var lineWidth = this.TextMeasurer.MeasureTextWidth(line, fontFamily, fontSize, fontWeight);
+
+                var offsetLineWidth = new ScreenVector(cos * lineWidth, sin * lineWidth);
+
+                var offsetLineX = offsetLineWidth * offsetLineXRelative;
+
+                linePositions[i] = p + ((offsetLineHeight + offsetLeading) * i) + offsetLineX + offsetLineY;
+            }
+        }
+
+        /// <summary>
+        /// Measures the size of the text as it would be when arranged by the ArrangeText method."/>.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <returns>The size of the text.</returns>
+        /// <remarks>Returns an <see cref="OxySize"/> with no width and height if the text is <c>null</c> or empty.</remarks>
+        public OxySize MeasureText(
+            string text,
+            string fontFamily,
+            double fontSize,
+            double fontWeight)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                // It is a bit of a lie to do this here, but otherwise everyone else has to do it
+                return OxySize.Empty;
+            }
+
+            var lines = StringHelper.SplitLines(text);
+
+            var width = lines.Max(l => this.TextMeasurer.MeasureTextWidth(l, fontFamily, fontSize, fontWeight));
+
+            var metrics = this.TextMeasurer.GetFontMetrics(fontFamily, fontSize, fontWeight);
+
+            var cellHeight = metrics.CellHeight;
+            var leading = metrics.Leading;
+            var lineCount = lines.Length;
+
+            var height = ((cellHeight  + leading) * lineCount) - leading;
+
+            return new OxySize(width, height);
+        }
+
+        /// <summary>
+        /// Translates a <see cref="HorizontalAlignment"/> into a relative offset.
+        /// </summary>
+        /// <param name="horizontalAlignment">The horizontal alignent.</param>
+        /// <returns>The offset.</returns>
+        /// <remarks>
+        /// Left   -> -0.5
+        /// Center ->  0.0
+        /// Right  -> +0.5
+        /// </remarks>
+        private static double ResolveOffset(HorizontalAlignment horizontalAlignment)
+        {
+            return horizontalAlignment switch
+            {
+                HorizontalAlignment.Left => -0.5,
+                HorizontalAlignment.Center => 0.0,
+                HorizontalAlignment.Right => 0.5,
+                _ => throw new ArgumentException(nameof(horizontalAlignment)),
+            };
+        }
+
+        /// <summary>
+        /// Translates a <see cref="VerticalAlignment"/> into a relative offset.
+        /// </summary>
+        /// <param name="verticalAlignment">The vertical alignment.</param>
+        /// <returns>The offset.</returns>
+        /// <remarks>
+        /// Top    -> +0.5
+        /// Middle ->  0.0
+        /// Bottom -> -0.5
+        /// </remarks>
+        private static double ResolveOffset(VerticalAlignment verticalAlignment)
+        {
+            return verticalAlignment switch
+            {
+                VerticalAlignment.Top => 0.5,
+                VerticalAlignment.Middle => 0.0,
+                VerticalAlignment.Bottom => -0.5,
+                _ => throw new ArgumentException(nameof(verticalAlignment)),
+            };
+        }
+    }
+}

--- a/Source/OxyPlot/Rendering/TextArranger.cs
+++ b/Source/OxyPlot/Rendering/TextArranger.cs
@@ -192,7 +192,7 @@ namespace OxyPlot.Rendering
             var leading = metrics.Leading;
             var lineCount = lines.Length;
 
-            var height = ((cellHeight  + leading) * lineCount) - leading;
+            var height = ((cellHeight + leading) * lineCount) - leading;
 
             return new OxySize(width, height);
         }

--- a/Source/OxyPlot/Rendering/TextArranger.cs
+++ b/Source/OxyPlot/Rendering/TextArranger.cs
@@ -50,7 +50,7 @@ namespace OxyPlot.Rendering
         /// <param name="horizontalAlignment">The horizontal alignment.</param>
         /// <param name="verticalAlignment">The vertical alignment.</param>
         /// <param name="maxSize">The maximum size of the text (in device independent units, 1/96 inch). If set to <c>null</c>, the text will not be clipped.</param>
-        /// <param name="targetHorizontalAlignment">The horixontal alignment used to render the text.</param>
+        /// <param name="targetHorizontalAlignment">The horizontal alignment used to render the text.</param>
         /// <param name="targetVerticalAlignment">The vertical alignment used to render the text.</param>
         /// <param name="lines">The separate lines of text.</param>
         /// <param name="linePositions">The point at which to render each line.</param>
@@ -200,7 +200,7 @@ namespace OxyPlot.Rendering
         /// <summary>
         /// Translates a <see cref="HorizontalAlignment"/> into a relative offset.
         /// </summary>
-        /// <param name="horizontalAlignment">The horizontal alignent.</param>
+        /// <param name="horizontalAlignment">The horizontal alignment.</param>
         /// <returns>The offset.</returns>
         /// <remarks>
         /// Left   -> -0.5

--- a/Source/OxyPlot/Rendering/TextArranger.cs
+++ b/Source/OxyPlot/Rendering/TextArranger.cs
@@ -15,7 +15,7 @@ namespace OxyPlot.Rendering
     /// <summary>
     /// Arranges text.
     /// </summary>
-    public class TextArranger
+    public class TextArranger : ITextArranger
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TextArranger" /> class.

--- a/Source/OxyPlot/Rendering/TextVerticalAlignment.cs
+++ b/Source/OxyPlot/Rendering/TextVerticalAlignment.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TextVerticalAlignment.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Specifies vertical alignment for text.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot
+{
+    /// <summary>
+    /// Specifies vertical alignment for text.
+    /// </summary>
+    public enum TextVerticalAlignment
+    {
+        /// <summary>
+        /// Aligned at the top.
+        /// </summary>
+        Top = -1,
+
+        /// <summary>
+        /// Aligned in the middle.
+        /// </summary>
+        Middle = 0,
+
+        /// <summary>
+        /// Aligned at the bottom.
+        /// </summary>
+        Bottom = 1,
+
+        /// <summary>
+        /// Aligned at the baseline.
+        /// </summary>
+        Baseline = 2,
+    }
+}

--- a/Source/OxyPlot/Svg/SvgExporter.cs
+++ b/Source/OxyPlot/Svg/SvgExporter.cs
@@ -9,6 +9,7 @@
 
 namespace OxyPlot
 {
+    using OxyPlot.Rendering;
     using System.IO;
 
     /// <summary>
@@ -42,14 +43,9 @@ namespace OxyPlot
         public bool IsDocument { get; set; }
         
         /// <summary>
-        /// Gets or sets a value indicating whether to use a workaround for vertical text alignment to support renderers with limited support for the dominate-baseline attribute.
-        /// </summary>
-        public bool UseVerticalTextAlignmentWorkaround { get; set; }
-
-        /// <summary>
         /// Gets or sets the text measurer.
         /// </summary>
-        public IRenderContext TextMeasurer { get; set; }
+        public ITextMeasurer TextMeasurer { get; set; }
 
         /// <summary>
         /// Exports the specified model to a stream.
@@ -60,15 +56,14 @@ namespace OxyPlot
         /// <param name="height">The height (points).</param>
         /// <param name="isDocument">if set to <c>true</c>, the xml headers will be included (?xml and !DOCTYPE).</param>
         /// <param name="textMeasurer">The text measurer.</param>
-        /// <param name="useVerticalTextAlignmentWorkaround">Whether to use the workaround for vertical text alignment</param>
-        public static void Export(IPlotModel model, Stream stream, double width, double height, bool isDocument, IRenderContext textMeasurer = null, bool useVerticalTextAlignmentWorkaround = false)
+        public static void Export(IPlotModel model, Stream stream, double width, double height, bool isDocument, ITextMeasurer textMeasurer = null)
         {
             if (textMeasurer == null)
             {
                 textMeasurer = new PdfRenderContext(width, height, model.Background);
             }
 
-            using (var rc = new SvgRenderContext(stream, width, height, isDocument, textMeasurer, model.Background, useVerticalTextAlignmentWorkaround))
+            using (var rc = new SvgRenderContext(stream, width, height, isDocument, textMeasurer, model.Background))
             {
                 model.Update(true);
                 model.Render(rc, new OxyRect(0, 0, width, height));
@@ -86,13 +81,12 @@ namespace OxyPlot
         /// <param name="isDocument">if set to <c>true</c>, the xml headers will be included (?xml and !DOCTYPE).</param>
         /// <param name="textMeasurer">The text measurer.</param>
         /// <returns>The plot as an <c>SVG</c> string.</returns>
-        /// <param name="useVerticalTextAlignmentWorkaround">Whether to use the workaround for vertical text alignment</param>
-        public static string ExportToString(IPlotModel model, double width, double height, bool isDocument, IRenderContext textMeasurer = null, bool useVerticalTextAlignmentWorkaround = false)
+        public static string ExportToString(IPlotModel model, double width, double height, bool isDocument, ITextMeasurer textMeasurer = null)
         {
             string svg;
             using (var ms = new MemoryStream())
             {
-                Export(model, ms, width, height, isDocument, textMeasurer, useVerticalTextAlignmentWorkaround);
+                Export(model, ms, width, height, isDocument, textMeasurer);
                 ms.Flush();
                 ms.Position = 0;
                 var sr = new StreamReader(ms);
@@ -109,7 +103,7 @@ namespace OxyPlot
         /// <param name="stream">The target stream.</param>
         public void Export(IPlotModel model, Stream stream)
         {
-            Export(model, stream, this.Width, this.Height, this.IsDocument, this.TextMeasurer, this.UseVerticalTextAlignmentWorkaround);
+            Export(model, stream, this.Width, this.Height, this.IsDocument, this.TextMeasurer);
         }
 
         /// <summary>
@@ -119,7 +113,7 @@ namespace OxyPlot
         /// <returns>the SVG content as a string.</returns>
         public string ExportToString(IPlotModel model)
         {
-            return ExportToString(model, this.Width, this.Height, this.IsDocument, this.TextMeasurer, this.UseVerticalTextAlignmentWorkaround);
+            return ExportToString(model, this.Width, this.Height, this.IsDocument, this.TextMeasurer);
         }
     }
 }

--- a/Source/OxyPlot/Svg/SvgRenderContext.cs
+++ b/Source/OxyPlot/Svg/SvgRenderContext.cs
@@ -55,10 +55,10 @@ namespace OxyPlot
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TextArranger"/> used by this instance.
+        /// Gets or sets the <see cref="ITextArranger"/> used by this instance.
         /// </summary>
         /// <value>The text arranger.</value>
-        public TextArranger TextArranger { get; set; }
+        public ITextArranger TextArranger { get; set; }
 
         /// <summary>
         /// Closes the svg writer.


### PR DESCRIPTION
Fixes #1531, #1559, and #1554

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log (will do so if/when this is striped back and becomes a set of meaningful commits)
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds the `ITextMeasurer` interface, and implementations for all RenderContexts that can support it
- Adds the `ITextTrimmer` interface, and `SimpleTextTrimmer` implementation which uses 'character ellipsis' trimming mode as its default
- Adds the `TextArranger` class, which arranges multiline text as per #1554 and #1551 
- Changes all platforms in this repo to use `TextArranger` for text arrangement (thereby resolving #1531 and #1559 )
- Adds an SvgExporter to `OxyPlot.ImageSharp` with additional tests
- Removes the `UseVerticalAlignmentWorkaround` property from `OxyPlot.Svg` as it is redundant and will only get in the way

### Big Issues

- API for `ITextTrimmer` is weak: the render context determines the type of trimming that is done, which may not be ideal

@oxyplot/admins
