### PR TITLE
added clip title based on issue #1510 with examples in the plotmodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Example for Issue #1545 showing the use of different line endings
 - Support for unix line endings in OxyPlot.ImageSharp, OxyPlot.Svg, and OxyPlot.Pdf (#1545)
 - Multi-Line Text support to SkiaRenderContext (#1538)
+- Added Title clipping to PlotModel (#1510)
 
 ### Changed
 - Legends model (#644)
@@ -44,7 +45,6 @@ All notable changes to this project will be documented in this file.
 - WPF ExampleBrowser can switch between Canvas and SkiaSharp renderers (#1515)
 - OxyPlot.ImageSharp now targets .NET Standard 1.3 (#1530)
 - SkiaRenderContext does not apply pixel snapping when rendering to vector graphic (#1539)
-- Mark OxyPlot.PdfExporter and OxyPlot.Pdf.PdfExporter as obsolete (#1527)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Cyril Martin <cyril.martin.cm@gmail.com>
 Dan Aizenstros
 danpaul88 <danpaul88@users.noreply.github.com>
 darrelbrown
+David Funk <funk.david1985@gmail.com>
 David Laundav <davelaundav@gmail.com>
 David Wong <dvkwong0@gmail.com>
 DJDAS

--- a/Source/Examples/ExampleLibrary/Examples/PlotModelExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PlotModelExamples.cs
@@ -67,6 +67,24 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("TitleClippingLength")]
+        public static PlotModel TitleClippingLength()
+        {
+            var model = new PlotModel { Title = "This is a very long title, to illustrate that the clipping works and that the title is clipped currently to 60% of the title area", TitleClippingLength = 0.6 };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            return model;
+        }
+
+        [Example("TitleClippingOff")]
+        public static PlotModel TitleClippingOff()
+        {
+            var model = new PlotModel { Title = "This is a very long title, to illustrate that the clipping is necessary if the title is too long and that the title will overlay other controls without clipping", ClipTitle = false };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            return model;
+        }
+
         [Example("PlotMargins = (100,20,100,50)")]
         public static PlotModel PlotMargins()
         {

--- a/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
@@ -435,9 +435,9 @@ namespace OxyPlot
         {
             OxySize? maxSize = null;
 
-            if (ClipTitle)
+            if (this.ClipTitle)
             {
-                maxSize = new OxySize(this.TitleArea.Width * TitleClippingLength, double.MaxValue);
+                maxSize = new OxySize(this.TitleArea.Width * this.TitleClippingLength, double.MaxValue);
             }
 
             var titleSize = rc.MeasureText(this.Title, this.ActualTitleFont, this.TitleFontSize, this.TitleFontWeight);

--- a/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
@@ -433,6 +433,13 @@ namespace OxyPlot
         /// <param name="rc">The render context.</param>
         private void RenderTitle(IRenderContext rc)
         {
+            OxySize? maxSize = null;
+
+            if (ClipTitle)
+            {
+                maxSize = new OxySize(this.TitleArea.Width * TitleClippingLength, double.MaxValue);
+            }
+
             var titleSize = rc.MeasureText(this.Title, this.ActualTitleFont, this.TitleFontSize, this.TitleFontWeight);
 
             double x = (this.TitleArea.Left + this.TitleArea.Right) * 0.5;
@@ -451,7 +458,8 @@ namespace OxyPlot
                     this.TitleFontWeight,
                     0,
                     HorizontalAlignment.Center,
-                    VerticalAlignment.Top);
+                    VerticalAlignment.Top,
+                    maxSize);
                 y += titleSize.Height;
 
                 rc.SetToolTip(null);
@@ -468,7 +476,8 @@ namespace OxyPlot
                     this.SubtitleFontWeight,
                     0,
                     HorizontalAlignment.Center,
-                    VerticalAlignment.Top);
+                    VerticalAlignment.Top,
+                    maxSize);
             }
         }
 

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -116,6 +116,8 @@ namespace OxyPlot
             this.SubtitleFontSize = 14;
             this.SubtitleFontWeight = FontWeights.Normal;
             this.TitlePadding = 6;
+            this.ClipTitle = true;
+            this.TitleClippingLength = 0.9;
 
             this.PlotAreaBorderColor = OxyColors.Black;
             this.PlotAreaBorderThickness = new OxyThickness(1);
@@ -379,6 +381,16 @@ namespace OxyPlot
         /// <value>The color of the title.</value>
         /// <remarks>If the value is <c>null</c>, the TextColor will be used.</remarks>
         public OxyColor TitleColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to clip the title. The default value is <c>true</c>.
+        /// </summary>
+        public bool ClipTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length of the title clipping rectangle (fraction of the available length of the title area). The default value is <c>0.9</c>.
+        /// </summary>
+        public double TitleClippingLength { get; set; }
 
         /// <summary>
         /// Gets or sets the color of the subtitle.


### PR DESCRIPTION
Fixes #1510  .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- added clip title feature to plotmodel (see issues #1510), same functionality like clip axis title

this will change the default behaviour of the title of the plotmodels, since the default clipping length is 0.9 (analogue to the axis title clipping length). If this is not desired, we could set the default value to 1.

@oxyplot/admins
