### PR TITLE
added LabelSpacing, MultiLabel and LabelStep properties to contours series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Support for unix line endings in OxyPlot.ImageSharp, OxyPlot.Svg, and OxyPlot.Pdf (#1545)
 - Multi-Line Text support to SkiaRenderContext (#1538)
 - Added title clipping to PlotModel (#1510)
+- Added LabelStep and LabelSpacing to contour series (#1511)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -35,6 +35,106 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Peaks LabelStep = 1, ContourLevelStep = PI/2")]
+        public static PlotModel PeaksLabelStep1LevelStepPI2()
+        {
+            var model = new PlotModel { Title = "Peaks LabelStep = 1, ContourLevelStep = PI/2" };
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3.1, 3.1, 0.05),
+                ContourLevelStep = Math.PI / 2,
+                LabelStep = 1
+            };
+            cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Peaks LabelStep = 2, ContourLevelStep = 0.5")]
+        public static PlotModel PeaksLabelStep2()
+        {
+            var model = new PlotModel { Title = "Peaks LabelStep = 2, ContourLevelStep = 0.5" };
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3.1, 3.1, 0.05),
+                ContourLevelStep = 0.5,
+                LabelStep = 2
+            };
+            cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Peaks LabelStep = 2, ContourLevelStep = 0.33")]
+        public static PlotModel PeaksLabelStep2LevelStep033()
+        {
+            var model = new PlotModel { Title = "Peaks LabelStep = 2, ContourLevelStep = 0.33" };
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3.1, 3.1, 0.05),
+                ContourLevelStep = 0.33,
+                LabelStep = 2
+            };
+            cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Peaks LabelStep = 3, ContourLevelStep = 1")]
+        public static PlotModel PeaksLabelStep3()
+        {
+            var model = new PlotModel { Title = "Peaks LabelStep = 3, ContourLevelStep = 1" };
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3.1, 3.1, 0.05),
+                LabelStep = 3
+            };
+            cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Peaks MultiLabel")]
+        public static PlotModel PeaksMultiLabel()
+        {
+            var model = new PlotModel { Title = "Peaks MultiLabel" };
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3.1, 3.1, 0.05),
+                MultiLabel = true
+            };
+            cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Peaks LabelSpacing = 400")]
+        public static PlotModel PeaksLabelSpacing400()
+        {
+            var model = new PlotModel { Title = "Peaks LabelSpacing = 400" };
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3.1, 3.1, 0.05),
+                MultiLabel = true,
+                LabelSpacing = 400
+            };
+            cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
         [Example("Peaks (different contour colors)")]
         [DocumentationExample("Series/ContourSeries")]
         public static PlotModel PeaksWithColors()


### PR DESCRIPTION
Fixes #1511 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- implemented LabelSpacing and LabelStep to contour series
- in order to not change default behaviour added property MultiLabel, to enable several labels per contour to make use of LabelSpacing
-

@oxyplot/admins
