### PR TITLE
Fix WpfExamples' CustomTrackerDemo

### DIFF
--- a/Source/Examples/WPF/WpfExamples/Examples/CustomTrackerDemo/MainWindow.xaml
+++ b/Source/Examples/WPF/WpfExamples/Examples/CustomTrackerDemo/MainWindow.xaml
@@ -1,25 +1,25 @@
 ﻿<Window x:Class="CustomTrackerDemo.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Wpf"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Wpf" xmlns:oxyshared="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Wpf.Shared" 
         Title="CustomTrackerDemo" Height="480" Width="640">
     <Window.Resources>
-        <oxy:OxyColorConverter x:Key="OxyColorConverter" />
+        <oxyshared:OxyColorConverter x:Key="OxyColorConverter" />
     </Window.Resources>
     <TabControl Margin="4">
         <TabItem Header="Custom background brush">
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.DefaultTrackerTemplate>
                     <ControlTemplate>
-                        <oxy:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
-                            <oxy:TrackerControl.Background>
+                        <oxyshared:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
+                            <oxyshared:TrackerControl.Background>
                                 <LinearGradientBrush EndPoint="0,1">
                                     <GradientStop Color="#f0e0e0ff" />
                                     <GradientStop Offset="1" Color="#f0ffffff" />
                                 </LinearGradientBrush>
-                            </oxy:TrackerControl.Background>
-                            <oxy:TrackerControl.Content>
+                            </oxyshared:TrackerControl.Background>
+                            <oxyshared:TrackerControl.Content>
                                 <TextBlock Text="{Binding}" Margin="7" />
-                            </oxy:TrackerControl.Content>
-                        </oxy:TrackerControl>
+                            </oxyshared:TrackerControl.Content>
+                        </oxyshared:TrackerControl>
                     </ControlTemplate>
                 </oxy:PlotView.DefaultTrackerTemplate>
             </oxy:PlotView>
@@ -28,11 +28,11 @@
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.DefaultTrackerTemplate>
                     <ControlTemplate>
-                        <oxy:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}" BorderBrush="{Binding Series.ActualColor, Converter={StaticResource OxyColorConverter}}" BorderThickness="3">
-                            <oxy:TrackerControl.Content>
+                        <oxyshared:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}" BorderBrush="{Binding Series.ActualColor, Converter={StaticResource OxyColorConverter}}" BorderThickness="3">
+                            <oxyshared:TrackerControl.Content>
                                 <TextBlock Text="{Binding}" Margin="7" />
-                            </oxy:TrackerControl.Content>
-                        </oxy:TrackerControl>
+                            </oxyshared:TrackerControl.Content>
+                        </oxyshared:TrackerControl>
                     </ControlTemplate>
                 </oxy:PlotView.DefaultTrackerTemplate>
             </oxy:PlotView>
@@ -44,11 +44,11 @@
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.DefaultTrackerTemplate>
                     <ControlTemplate>
-                        <oxy:TrackerControl Position="{Binding Position}" ShowPointer="False" CornerRadius="8" BorderEdgeMode="Unspecified" LineExtents="{Binding PlotModel.PlotArea}">
-                            <oxy:TrackerControl.Content>
+                        <oxyshared:TrackerControl Position="{Binding Position}" ShowPointer="False" CornerRadius="8" BorderEdgeMode="Unspecified" LineExtents="{Binding PlotModel.PlotArea}">
+                            <oxyshared:TrackerControl.Content>
                                 <TextBlock Text="{Binding}" Margin="7" />
-                            </oxy:TrackerControl.Content>
-                        </oxy:TrackerControl>
+                            </oxyshared:TrackerControl.Content>
+                        </oxyshared:TrackerControl>
                     </ControlTemplate>
                 </oxy:PlotView.DefaultTrackerTemplate>
             </oxy:PlotView>
@@ -57,11 +57,11 @@
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.DefaultTrackerTemplate>
                     <ControlTemplate>
-                        <oxy:TrackerControl Position="{Binding Position}" VerticalLineVisibility="Collapsed" LineExtents="{Binding PlotModel.PlotArea}">
-                            <oxy:TrackerControl.Content>
+                        <oxyshared:TrackerControl Position="{Binding Position}" VerticalLineVisibility="Collapsed" LineExtents="{Binding PlotModel.PlotArea}">
+                            <oxyshared:TrackerControl.Content>
                                 <TextBlock Text="{Binding}" Margin="7" />
-                            </oxy:TrackerControl.Content>
-                        </oxy:TrackerControl>
+                            </oxyshared:TrackerControl.Content>
+                        </oxyshared:TrackerControl>
                     </ControlTemplate>
                 </oxy:PlotView.DefaultTrackerTemplate>
             </oxy:PlotView>
@@ -112,9 +112,9 @@
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.DefaultTrackerTemplate>
                     <ControlTemplate>
-                        <oxy:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
+                        <oxyshared:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
 
-                            <oxy:TrackerControl.Content>
+                            <oxyshared:TrackerControl.Content>
                                 <UniformGrid Columns="2" Canvas.Left="{Binding Position.X}" Canvas.Top="{Binding Position.Y}" Margin="6">
                                     <TextBlock Text="X:" FontWeight="Bold" />
                                     <TextBlock Text="{Binding DataPoint.X, StringFormat='{}{0:0.000}'}" />
@@ -123,8 +123,8 @@
                                     <TextBlock Text="Dataset:" FontWeight="Bold" />
                                     <TextBlock Text="{Binding Series.Title}" />
                                 </UniformGrid>
-                            </oxy:TrackerControl.Content>
-                        </oxy:TrackerControl>
+                            </oxyshared:TrackerControl.Content>
+                        </oxyshared:TrackerControl>
                     </ControlTemplate>
                 </oxy:PlotView.DefaultTrackerTemplate>
             </oxy:PlotView>
@@ -132,24 +132,24 @@
         <TabItem Header="Different trackers">
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.TrackerDefinitions>
-                    <oxy:TrackerDefinition TrackerKey="Tracker1">
-                        <oxy:TrackerDefinition.TrackerTemplate>
+                    <oxyshared:TrackerDefinition TrackerKey="Tracker1">
+                        <oxyshared:TrackerDefinition.TrackerTemplate>
                             <ControlTemplate>
                                 <Canvas>
                                     <TextBlock Canvas.Left="{Binding Position.X}" Canvas.Top="{Binding Position.Y}" Padding="5" Margin="10" Background="LightBlue" Text="{Binding}" />
                                 </Canvas>
                             </ControlTemplate>
-                        </oxy:TrackerDefinition.TrackerTemplate>
-                    </oxy:TrackerDefinition>
-                    <oxy:TrackerDefinition TrackerKey="Tracker2">
-                        <oxy:TrackerDefinition.TrackerTemplate>
+                        </oxyshared:TrackerDefinition.TrackerTemplate>
+                    </oxyshared:TrackerDefinition>
+                    <oxyshared:TrackerDefinition TrackerKey="Tracker2">
+                        <oxyshared:TrackerDefinition.TrackerTemplate>
                             <ControlTemplate>
                                 <Canvas>
                                     <TextBlock Canvas.Left="{Binding Position.X}" Canvas.Top="{Binding Position.Y}" Padding="5" Margin="10" Background="LightGreen" Text="{Binding}" />
                                 </Canvas>
                             </ControlTemplate>
-                        </oxy:TrackerDefinition.TrackerTemplate>
-                    </oxy:TrackerDefinition>
+                        </oxyshared:TrackerDefinition.TrackerTemplate>
+                    </oxyshared:TrackerDefinition>
                 </oxy:PlotView.TrackerDefinitions>
             </oxy:PlotView>
         </TabItem>
@@ -157,12 +157,12 @@
             <oxy:PlotView Model="{Binding Model}">
                 <oxy:PlotView.DefaultTrackerTemplate>
                     <ControlTemplate>
-                        <oxy:TrackerControl Position="{Binding Position}" LineExtents="{Binding LineExtents}">
-                            <oxy:TrackerControl.Content>
+                        <oxyshared:TrackerControl Position="{Binding Position}" LineExtents="{Binding LineExtents}">
+                            <oxyshared:TrackerControl.Content>
                                 <!-- We can bind to the items from the ItemsSource -->
                                 <TextBlock Text="{Binding Item, StringFormat='Item={0}'}" Margin="8"/>
-                            </oxy:TrackerControl.Content>
-                        </oxy:TrackerControl>
+                            </oxyshared:TrackerControl.Content>
+                        </oxyshared:TrackerControl>
                     </ControlTemplate>
                 </oxy:PlotView.DefaultTrackerTemplate>
             </oxy:PlotView>

--- a/Source/OxyPlot.CI.sln
+++ b/Source/OxyPlot.CI.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp.Wpf", "Ox
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.ImageSharp.Tests", "OxyPlot.ImageSharp.Tests\OxyPlot.ImageSharp.Tests.csproj", "{47409F61-4C0C-4A1A-812D-DDED0DA319A0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfExamples", "Examples\WPF\WpfExamples\WpfExamples.csproj", "{5F0234B5-EF4C-4314-AE01-A59722B92C39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -447,6 +449,30 @@ Global
 		{47409F61-4C0C-4A1A-812D-DDED0DA319A0}.Release|x64.Build.0 = Release|Any CPU
 		{47409F61-4C0C-4A1A-812D-DDED0DA319A0}.Release|x86.ActiveCfg = Release|Any CPU
 		{47409F61-4C0C-4A1A-812D-DDED0DA319A0}.Release|x86.Build.0 = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|ARM.Build.0 = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|ARM.ActiveCfg = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|ARM.Build.0 = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|iPhone.Build.0 = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|x64.Build.0 = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -461,6 +487,7 @@ Global
 		{2A482337-AEB4-4E22-BB35-0E363BAE98BD} = {E124D189-92DF-4A3C-BFA9-6687F4878C12}
 		{E58D0F70-2E8C-44C9-B16E-CBB30FC9FF73} = {215581EE-098A-488B-91CE-980D94EED5A2}
 		{47409F61-4C0C-4A1A-812D-DDED0DA319A0} = {215581EE-098A-488B-91CE-980D94EED5A2}
+		{5F0234B5-EF4C-4314-AE01-A59722B92C39} = {E124D189-92DF-4A3C-BFA9-6687F4878C12}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {282C7D1F-6AA7-4D54-8C6C-C83C2927F9FE}


### PR DESCRIPTION
### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix the demo - which need access to `OxyPlot.Wpf.Shared` in the XAML to access the `TrackerControl` - so that the WpfExamples project builds.

@oxyplot/admins
