### PR TITLE
Implement native clipping for SvgRenderContext (#1564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Added title clipping to PlotModel (#1510)
 - Added LabelStep and LabelSpacing to contour series (#1511)
 - Example for Issue #1481 showing text rendering with emoji
+- Native Clipping for OxyPlot.SvgRenderContext (#1564)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -16,7 +16,6 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Annotations;
     using System.Linq;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Provides rendering capability examples.
@@ -458,6 +457,59 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Clipping")]
+        public static PlotModel Clipping()
+        {
+            var model = new PlotModel();
+            model.Annotations.Add(new DelegateAnnotation(rc =>
+            {
+                // reset a couple of times without any clipping being set to see that nothing explodes
+                rc.ResetClip();
+                rc.ResetClip();
+                rc.ResetClip();
+
+                var p1 = new ScreenPoint(150, 150);
+                var clip = 100d;
+                var radiusFactor = 1.1;
+                var clipShrink = .15 * clip;
+
+                var rect = new OxyRect(p1.X - clip, p1.Y - clip, clip * 2, clip * 2);
+                rc.DrawRectangle(rect, OxyColors.Undefined, OxyColors.Red, 1, EdgeRenderingMode.Automatic);
+                rc.SetClip(rect);
+                rc.DrawCircle(p1, clip * radiusFactor, OxyColors.Red, OxyColors.Undefined, 0, EdgeRenderingMode.Automatic);
+
+                clip -= clipShrink;
+                rect = new OxyRect(p1.X - clip, p1.Y - clip, clip * 2, clip * 2);
+                rc.DrawRectangle(rect, OxyColors.Undefined, OxyColors.Green, 1, EdgeRenderingMode.Automatic);
+                rc.SetClip(rect);
+                rc.DrawCircle(p1, clip * radiusFactor, OxyColors.Green, OxyColors.Undefined, 0, EdgeRenderingMode.Automatic);
+
+                clip -= clipShrink;
+                rect = new OxyRect(p1.X - clip, p1.Y - clip, clip * 2, clip * 2);
+                rc.DrawRectangle(rect, OxyColors.Undefined, OxyColors.Blue, 1, EdgeRenderingMode.Automatic);
+                rc.SetClip(rect);
+                rc.DrawCircle(p1, clip * radiusFactor, OxyColors.Blue, OxyColors.Undefined, 0, EdgeRenderingMode.Automatic);
+                rc.ResetClip();
+
+                rc.DrawText(p1, "Clipped Circles", OxyColors.White, fontSize: 12, horizontalAlignment: HorizontalAlignment.Center, verticalAlignment: VerticalAlignment.Middle);
+                
+                rc.DrawText(new ScreenPoint(p1.X * 2, 50), "Not clipped", OxyColors.Black, fontSize: 40);
+
+                rect = new OxyRect(p1.X * 2 + 10, 100, 80, 60);
+                rc.DrawRectangle(rect, OxyColors.Undefined, OxyColors.Black, 1, EdgeRenderingMode.Automatic);
+
+                // set the same clipping a couple of times to see that nothing explodes
+                rc.SetClip(rect);
+                rc.SetClip(rect);
+                using (rc.AutoResetClip(rect))
+                {
+                    rc.DrawText(new ScreenPoint(p1.X * 2, 100), "Clipped", OxyColors.Black, fontSize: 40);
+                }
+            }));
+
+            return model;
+        }
+
         private const double GRID_SIZE = 40;
         private const double TILE_SIZE = 30;
         private const int THICKNESS_STEPS = 10;
@@ -466,10 +518,6 @@ namespace ExampleLibrary
         private const double OFFSET_TOP = 20;
         private static readonly OxyColor FILL_COLOR = OxyColors.LightBlue;
 
-        /// <summary>
-        /// Shows capabilities for the MeasureText method.
-        /// </summary>
-        /// <returns>A plot model.</returns>
         [Example("Rectangles - EdgeRenderingMode")]
         public static PlotModel Rectangles()
         {
@@ -500,10 +548,6 @@ namespace ExampleLibrary
             return model;
         }
 
-        /// <summary>
-        /// Shows capabilities for the MeasureText method.
-        /// </summary>
-        /// <returns>A plot model.</returns>
         [Example("Lines - EdgeRenderingMode")]
         public static PlotModel Lines()
         {
@@ -540,10 +584,6 @@ namespace ExampleLibrary
             return model;
         }
 
-        /// <summary>
-        /// Shows capabilities for the MeasureText method.
-        /// </summary>
-        /// <returns>A plot model.</returns>
         [Example("Polygons - EdgeRenderingMode")]
         public static PlotModel Polygons()
         {
@@ -582,10 +622,6 @@ namespace ExampleLibrary
             return model;
         }
 
-        /// <summary>
-        /// Shows capabilities for the MeasureText method.
-        /// </summary>
-        /// <returns>A plot model.</returns>
         [Example("Ellipses - EdgeRenderingMode")]
         public static PlotModel Ellipses()
         {
@@ -619,7 +655,7 @@ namespace ExampleLibrary
         /// <summary>
         /// Represents an annotation that renders by a delegate.
         /// </summary>
-        private class DelegateAnnotation : Annotation
+        public class DelegateAnnotation : Annotation
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="DelegateAnnotation"/> class.

--- a/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
+++ b/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
@@ -9,7 +9,7 @@ namespace OxyPlot.Tests
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
-
+    using System.Linq;
     using ExampleLibrary;
     using NUnit.Framework;
 
@@ -121,6 +121,55 @@ namespace OxyPlot.Tests
                 rc.Complete();
                 rc.Flush();
             }
+        }
+
+        [Test]
+        public void Test_Clipping()
+        {
+            var plotModel = new PlotModel { Title = "Clipping" };
+
+            var clipRect = new OxyRect(100, 100, 100, 100);
+            var center = new ScreenPoint(150, 150);
+            var radius = 60;
+
+            plotModel.Annotations.Add(new RenderingCapabilities.DelegateAnnotation(rc =>
+            {
+                using (rc.AutoResetClip(clipRect))
+                {
+                    rc.DrawCircle(center, radius, OxyColors.Black, OxyColors.Undefined, 0, EdgeRenderingMode.Automatic);
+                }
+            }));
+
+            byte[] baseline;
+            using (var stream = new MemoryStream())
+            {
+                SvgExporter.Export(plotModel, stream, 400, 400, false);
+                baseline = stream.ToArray();
+            }
+
+            plotModel.Annotations.Clear();
+            plotModel.Annotations.Add(new RenderingCapabilities.DelegateAnnotation(rc =>
+            {
+                // reset without a clipping rect being set
+                rc.ResetClip();
+                rc.ResetClip();
+
+                // set clipping multiple times
+                rc.SetClip(clipRect);
+                rc.SetClip(clipRect);
+                rc.SetClip(clipRect);
+                rc.DrawCircle(center, radius, OxyColors.Black, OxyColors.Undefined, 0, EdgeRenderingMode.Automatic);
+                rc.ResetClip();
+            }));
+
+            byte[] setMultiple;
+            using (var stream = new MemoryStream())
+            {
+                SvgExporter.Export(plotModel, stream, 400, 400, false);
+                setMultiple = stream.ToArray();
+            }
+
+            Assert.IsTrue(baseline.SequenceEqual(setMultiple));
         }
     }
 }

--- a/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
+++ b/Source/OxyPlot/Rendering/RenderContext/RenderingExtensions.cs
@@ -897,6 +897,17 @@ namespace OxyPlot
         }
 
         /// <summary>
+        /// Applies the specified clipping rectangle the the render context and returns a reset token. The clipping is reset once this token is disposed.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="clippingRectangle">The clipping rectangle.</param>
+        /// <returns>The reset token. Clipping is reset once this is disposed.</returns>
+        public static IDisposable AutoResetClip(this IRenderContext rc, OxyRect clippingRectangle)
+        {
+            return new AutoResetClipToken(rc, clippingRectangle);
+        }
+
+        /// <summary>
         /// Adds a marker geometry to the specified collections.
         /// </summary>
         /// <param name="p">The position of the marker.</param>
@@ -1123,6 +1134,25 @@ namespace OxyPlot
                     outputBuffer.Add(new ScreenPoint(sc1.X, sc1.Y));
                     lastPointIndex = i;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Represents the token that is used to automatically reset the clipping in the <see cref="AutoResetClip(IRenderContext, OxyRect)"/> method.
+        /// </summary>
+        private class AutoResetClipToken : IDisposable
+        {
+            private readonly IRenderContext renderContext;
+
+            public AutoResetClipToken(IRenderContext renderContext, OxyRect clippingRectangle)
+            {
+                this.renderContext = renderContext;
+                renderContext.SetClip(clippingRectangle);
+            }
+
+            void IDisposable.Dispose()
+            {
+                this.renderContext.ResetClip();
             }
         }
     }

--- a/Source/OxyPlot/Svg/SvgRenderContext.cs
+++ b/Source/OxyPlot/Svg/SvgRenderContext.cs
@@ -29,6 +29,11 @@ namespace OxyPlot
         private bool disposed;
 
         /// <summary>
+        /// The current clipping rectangle.
+        /// </summary>
+        private OxyRect? clipRect;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SvgRenderContext" /> class.
         /// </summary>
         /// <param name="s">The stream.</param>
@@ -262,11 +267,43 @@ namespace OxyPlot
             this.w.WriteImage(srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight, source);
         }
 
+        /// <inheritdoc/>
+        public override bool SetClip(OxyRect rect)
+        {
+            if (this.clipRect != null)
+            {
+                if (rect.Equals(this.clipRect.Value))
+                {
+                    return true;
+                }
+                else
+                {
+                    this.ResetClip();
+                }
+            }
+
+            this.clipRect = rect;
+            this.w.BeginClip(rect.Left, rect.Top, rect.Width, rect.Height);
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void ResetClip()
+        {
+            if (this.clipRect == null)
+            {
+                return;
+            }
+
+            this.clipRect = null;
+            this.w.EndClip();
+        }
+
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (!this.disposed)
             {

--- a/Source/OxyPlot/Svg/SvgWriter.cs
+++ b/Source/OxyPlot/Svg/SvgWriter.cs
@@ -26,11 +26,6 @@ namespace OxyPlot
         private bool endIsWritten;
 
         /// <summary>
-        /// The clip path
-        /// </summary>
-        private string clipPath;
-
-        /// <summary>
         /// The clip path number
         /// </summary>
         private int clipPathNumber = 1;
@@ -175,7 +170,6 @@ namespace OxyPlot
             this.WriteAttributeString("ry", height / 2);
             this.WriteAttributeString("style", style);
             this.WriteEdgeRenderingModeAttribute(edgeRenderingMode);
-            this.WriteClipPathAttribute();
             this.WriteEndElement();
         }
 
@@ -191,11 +185,11 @@ namespace OxyPlot
             // http://www.w3.org/TR/SVG/masking.html
             // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/clipPath
             // http://www.svgbasics.com/clipping.html
-            this.clipPath = "clipPath" + (this.clipPathNumber++);
-            this.WriteStartElement("g");
-            this.WriteAttributeString("clip-rule", "nonzero");
+            var clipPath = "clipPath" + this.clipPathNumber++;
+
+            this.WriteStartElement("defs");
             this.WriteStartElement("clipPath");
-            this.WriteAttributeString("id", this.clipPath);
+            this.WriteAttributeString("id", clipPath);
             this.WriteStartElement("rect");
             this.WriteAttributeString("x", x);
             this.WriteAttributeString("y", y);
@@ -203,6 +197,10 @@ namespace OxyPlot
             this.WriteAttributeString("height", height);
             this.WriteEndElement(); // rect
             this.WriteEndElement(); // clipPath
+            this.WriteEndElement(); // defs
+
+            this.WriteStartElement("g");
+            this.WriteAttributeString("clip-path", $"url(#{clipPath})");
         }
 
         /// <summary>
@@ -211,7 +209,6 @@ namespace OxyPlot
         public void EndClip()
         {
             this.WriteEndElement(); // g
-            this.clipPath = null;
         }
 
         /// <summary>
@@ -270,7 +267,6 @@ namespace OxyPlot
             encodedImage.Append(";base64,");
             encodedImage.Append(Convert.ToBase64String(imageData));
             this.WriteAttributeString("xlink", "href", null, encodedImage.ToString());
-            this.WriteClipPathAttribute();
             this.WriteEndElement();
         }
 
@@ -292,7 +288,6 @@ namespace OxyPlot
             this.WriteAttributeString("y2", p2.Y);
             this.WriteAttributeString("style", style);
             this.WriteEdgeRenderingModeAttribute(edgeRenderingMode);
-            this.WriteClipPathAttribute();
             this.WriteEndElement();
         }
 
@@ -309,7 +304,6 @@ namespace OxyPlot
             this.WriteAttributeString("points", this.PointsToString(points));
             this.WriteAttributeString("style", style);
             this.WriteEdgeRenderingModeAttribute(edgeRenderingMode);
-            this.WriteClipPathAttribute();
             this.WriteEndElement();
         }
 
@@ -326,7 +320,6 @@ namespace OxyPlot
             this.WriteAttributeString("points", this.PointsToString(pts));
             this.WriteAttributeString("style", style);
             this.WriteEdgeRenderingModeAttribute(edgeRenderingMode);
-            this.WriteClipPathAttribute();
             this.WriteEndElement();
         }
 
@@ -349,7 +342,6 @@ namespace OxyPlot
             this.WriteAttributeString("height", height);
             this.WriteAttributeString("style", style);
             this.WriteEdgeRenderingModeAttribute(edgeRenderingMode);
-            this.WriteClipPathAttribute();
             this.WriteEndElement();
         }
 
@@ -444,8 +436,6 @@ namespace OxyPlot
                 }
             }
 
-            this.WriteClipPathAttribute();
-
             // WriteAttributeString("style", style);
             this.WriteString(text);
             this.WriteEndElement();
@@ -475,19 +465,6 @@ namespace OxyPlot
         protected void WriteAttributeString(string name, double value)
         {
             this.WriteAttributeString(name, value.ToString(this.NumberFormat, CultureInfo.InvariantCulture));
-        }
-
-        /// <summary>
-        /// Writes the clip path attribute.
-        /// </summary>
-        private void WriteClipPathAttribute()
-        {
-            if (this.clipPath == null)
-            {
-                return;
-            }
-
-            this.WriteAttributeString("clip-path", string.Format("url(#{0})", this.clipPath));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1564.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Enable native clipping for SvgRenderContext
- I slightly changed the implementation of clipping in `SvgWriter` (inspired by SkiaSharp SVG output), as the existing implementation did not work well with text
- Added a clipping example to the Rendering Capabilities

@oxyplot/admins
