### PR TITLE
Make PlotView's zoomControl non-focussable (#1440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to this project will be documented in this file.
 - Text measurement and rendering in OxyPlot.ImageSharp
 - ExampleLibrary reporting annotation-only PlotModels as transposable (#1544)
 - Auto plot margin not taking width of labels into account (#453)
+- WPF PlotView still focusable when Focusable is false (#1440)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot.Wpf.Shared/PlotViewBase.cs
+++ b/Source/OxyPlot.Wpf.Shared/PlotViewBase.cs
@@ -191,6 +191,7 @@ namespace OxyPlot.Wpf
             this.grid.Children.Add(this.overlays);
 
             this.zoomControl = new ContentControl();
+            this.zoomControl.Focusable = false;
             this.overlays.Children.Add(this.zoomControl);
 
             // add additional grid on top of everthing else to fix issue of mouse events getting lost


### PR DESCRIPTION
Fixes #1440 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Make the `zoomControl` of `PlotViewBase` non-focusable

The only behavioural impact seems to be to remove a 'redundant' focusable element, which results in the `PlotView` requiring extra tab presses to navigate.

@oxyplot/admins
