### PR TITLE
Improve auto plot margins (#1577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 - Mark OxyPlot.PdfExporter and OxyPlot.Pdf.PdfExporter as obsolete (#1527)
 - Replace Axis.DesiredSize by Axis.DesiredMargin, change signature of Axis.Measure(...) (#453)
 - Axis renderers now render all ticks they are provided (#1580)
+- Auto margins don't reserve space for axis labels if axis range is fixed (#1577)
 
 ### Removed
 - Remove PlotModel.Legends (#644)
@@ -77,6 +78,7 @@ All notable changes to this project will be documented in this file.
 - Disposing a SkiaRenderContext can mess up fonts from another SkiaRenderContext instance (#1573)
 - Display of ampersands in OxyPlot.WindowsForms Tracker (#1585)
 - Full Plotarea Polar plot rendering with non-zero minimum values (#1586)
+- Auto margins are set incorrectly if Axis.TitleFontSize is set to non-default value (related to #1577)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
@@ -795,69 +795,6 @@ namespace ExampleLibrary
             return model;
         }
 
-        [Example("Auto adjusting plot margins")]
-        public static PlotModel AutoAdjustingMargins()
-        {
-            var model = new PlotModel
-            {
-                Title = "Auto adjusting plot margins",
-            };
-
-            Legend l = new Legend
-            {
-                LegendPosition = LegendPosition.RightBottom
-            };
-            model.Legends.Add(l);
-
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "X", TickStyle = TickStyle.Outside });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Y", TickStyle = TickStyle.Outside });
-            model.Series.Add(new LineSeries { Title = "Butterfly curve", ItemsSource = ButterflyCurve(0, Math.PI * 4, 1000) });
-            return model;
-        }
-
-        [Example("Auto adjusting left plot margin")]
-        public static PlotModel AutoAdjustingLeftMargin()
-        {
-            var model = new PlotModel
-            {
-                Title = "Auto adjusting left plot margin",
-                PlotMargins = new OxyThickness(double.NaN, 40, 40, 40)
-            };
-
-            Legend l = new Legend
-            {
-                LegendPosition = LegendPosition.RightBottom
-            };
-            model.Legends.Add(l);
-
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "X", TickStyle = TickStyle.Outside });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Y", TickStyle = TickStyle.Outside });
-            model.Series.Add(new LineSeries { Title = "Butterfly curve", ItemsSource = ButterflyCurve(0, Math.PI * 4, 1000) });
-            return model;
-        }
-
-
-        [Example("Manual plot margins")]
-        public static PlotModel ManualAdjustingMargins()
-        {
-            var model = new PlotModel
-            {
-                Title = "Manual plot margins",
-                PlotMargins = new OxyThickness(60, 4, 4, 40)
-            };
-
-            Legend l = new Legend
-            {
-                LegendPosition = LegendPosition.RightBottom
-            };
-            model.Legends.Add(l);
-
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "X", TickStyle = TickStyle.Outside });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Y", TickStyle = TickStyle.Outside });
-            model.Series.Add(new LineSeries { Title = "Butterfly curve", ItemsSource = ButterflyCurve(0, Math.PI * 4, 1000) });
-            return model;
-        }
-
         [Example("Current culture")]
         public static PlotModel CurrentCulture()
         {
@@ -1408,6 +1345,82 @@ namespace ExampleLibrary
             }
 
             return plotModel;
+        }
+
+        [Example("Auto Margins")]
+        public static PlotModel AutoMargin()
+        {
+            var plotModel = new PlotModel() { Title = "Auto-adjusting plot margins", Subtitle = "When zooming in and out the plot margins should adjust accordingly" };
+            plotModel.Axes.Add(new LinearAxis() { Position = AxisPosition.Bottom, Title = "X Axis", TitleFontSize = 16 });
+            return plotModel;
+        }
+
+        [Example("Manual Margins")]
+        public static PlotModel ManualMargins()
+        {
+            var plotModel = new PlotModel() { Title = "Manual Margins", Subtitle = "PlotMargins = 40", PlotMargins = new OxyThickness(40) };
+            plotModel.Axes.Add(new LinearAxis() { Position = AxisPosition.Bottom });
+            return plotModel;
+        }
+
+        [Example("Manual Left Margin")]
+        public static PlotModel ManualLeftMargin()
+        {
+            var plotModel = new PlotModel() { Title = "Manual Left Margin", Subtitle = "PlotMargins = 40,NaN,NaN,NaN", PlotMargins = new OxyThickness(40, double.NaN, double.NaN, double.NaN) };
+            plotModel.Axes.Add(new LinearAxis() { Position = AxisPosition.Bottom });
+            return plotModel;
+        }
+
+        [Example("Auto Margins - Wide Labels")]
+        public static PlotModel AutoMarginWideLabels()
+        {
+            var plotModel = new PlotModel() { Title = "Auto-adjusting plot margins - wide axis labels", Subtitle = "There should be enough space reserved such that the axis labels always fit in the viewport" };
+            plotModel.Axes.Add(GetLongLabelSeries());
+            return plotModel;
+        }
+
+        [Example("Auto Margins - Wide Labels, rotated")]
+        public static PlotModel AutoMarginWideLabelsRotated()
+        {
+            var plotModel = new PlotModel() { Title = "Auto-adjusting plot margins - wide rotated axis labels", Subtitle = "There should be enough space reserved such that the axis labels always fit in the viewport" };
+            var axis = GetLongLabelSeries();
+            axis.Angle = -90;
+            plotModel.Axes.Add(axis);
+            return plotModel;
+        }
+
+        [Example("Auto Margins - Wide Labels, fixed Range")]
+        public static PlotModel AutoMarginWideLabelsFixedRange()
+        {
+            var plotModel = new PlotModel() { Title = "Auto-adjusting plot margins - wide axis labels, fixed range", Subtitle = "When the axis range is fixed there should be no unnecessary space reserved for axis labels" };
+            var axis = GetLongLabelSeries();
+            axis.IsPanEnabled = false;
+            axis.IsZoomEnabled = false;
+            plotModel.Axes.Add(axis);
+            return plotModel;
+        }
+
+        [Example("Auto Margins - Wide Labels, fixed Range 2")]
+        public static PlotModel AutoMarginWideLabelsFixedRange2()
+        {
+            var plotModel = new PlotModel() { Title = "Auto-adjusting plot margins - wide axis labels, fixed range", Subtitle = "The axis labels should exactly fit in the viewport" };
+            var axis = GetLongLabelSeries();
+            axis.IsPanEnabled = false;
+            axis.IsZoomEnabled = false;
+            axis.Minimum = -0.01;
+            axis.Maximum = 3.01;
+            plotModel.Axes.Add(axis);
+            return plotModel;
+        }
+
+        private static CategoryAxis GetLongLabelSeries()
+        {
+            var axis = new CategoryAxis() { Position = AxisPosition.Bottom };
+            axis.Labels.Add("Label");
+            axis.Labels.Add("Long Label");
+            axis.Labels.Add("Longer Label");
+            axis.Labels.Add("Even Longer Label");
+            return axis;
         }
     }
 }

--- a/Source/Examples/ExampleLibrary/Examples/PlotModelExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PlotModelExamples.cs
@@ -85,25 +85,6 @@ namespace ExampleLibrary
             return model;
         }
 
-        [Example("PlotMargins = (100,20,100,50)")]
-        public static PlotModel PlotMargins()
-        {
-            var model = new PlotModel { Title = "PlotMargins = (100,20,100,50)", PlotMargins = new OxyThickness(100, 20, 100, 50) };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-            return model;
-        }
-
-        [Example("Auto PlotMargins")]
-        public static PlotModel AutoPlotMarginAndAxisLabelWidths()
-        {
-            var plotModel1 = new PlotModel { Title = "PlotMargins = (NaN,NaN,NaN,NaN)" };
-            plotModel1.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 1e8, EndPosition = 0.5, StringFormat = "f0" });
-            plotModel1.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 80, StartPosition = 0.5, StringFormat = "f0" });
-            plotModel1.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = 0, Maximum = 1e8, StringFormat = "f0", Angle = -90 });
-            return plotModel1;
-        }
-
         [Example("No model")]
         public static PlotModel NoModel()
         {

--- a/Source/OxyPlot/Axes/CategoryAxis.cs
+++ b/Source/OxyPlot/Axes/CategoryAxis.cs
@@ -201,13 +201,20 @@ namespace OxyPlot.Axes
 
             if (!this.IsTickCentered)
             {
+                const double epsilon = 1e-3;
+
                 // Subtract 0.5 from the label values to get the tick values.
                 // Add one extra tick at the end.
-                var mv = new List<double>(majorLabelValues.Count);
-                mv.AddRange(majorLabelValues.Select(v => v - 0.5));
+                var mv = new List<double>(majorLabelValues.Count + 1);
+                mv.AddRange(majorLabelValues.Select(v => v - 0.5).Where(v => v > this.ActualMinimum - epsilon));
+
                 if (mv.Count > 0)
                 {
-                    mv.Add(mv[mv.Count - 1] + 1);
+                    var lastTick = mv[mv.Count - 1] + 1;
+                    if (lastTick < this.ActualMaximum + epsilon)
+                    {
+                        mv.Add(lastTick);
+                    }
                 }
 
                 majorTickValues = mv;

--- a/Source/OxyPlot/Utilities/Helpers.cs
+++ b/Source/OxyPlot/Utilities/Helpers.cs
@@ -1,0 +1,27 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Helpers.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Utilities
+{
+    /// <summary>
+    /// Provides general helper functions.
+    /// </summary>
+    public static class Helpers
+    {
+        /// <summary>
+        /// Switches the values of two specified variables.
+        /// </summary>
+        /// <typeparam name="T">The type of the variables.</typeparam>
+        /// <param name="value">The first value.</param>
+        /// <param name="other">The second value.</param>
+        public static void Swap<T>(ref T value, ref T other)
+        {
+            var tmp = value;
+            value = other;
+            other = tmp;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1577.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Improve auto plot margins when axis range is fixed
- Fix a small bug where the `ActualFont` etc. would be used for measuring the axis title instead of `AxisTitleFont` etc.
- Consolidate margin examples - instead of having them scattered over the PlotModel and Axis categories, I placed them all in one spot in the Axis category.

@oxyplot/admins
