### PR TITLE
Implement ExampleInfo reversibility

### DIFF
--- a/Source/Examples/ExampleLibrary/ExampleFlags.cs
+++ b/Source/Examples/ExampleLibrary/ExampleFlags.cs
@@ -1,0 +1,27 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ExampleFlags.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ExampleLibrary
+{
+    using System;
+
+    /// <summary>
+    /// Properties of an example.
+    /// </summary>
+    [Flags]
+    public enum ExampleFlags
+    {
+        /// <summary>
+        /// Transpose the axes, so that horizontal axes become vertical and vice versa.
+        /// </summary>
+        Transpose = 1,
+
+        /// <summary>
+        /// Reverse the axes, so that their start and end positions are mirrored within the plot area.
+        /// </summary>
+        Reverse = 2,
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml
@@ -122,6 +122,7 @@
                 <TextBlock Text="Renderer:" VerticalAlignment="Center" />
                 <ComboBox SelectedItem="{Binding Renderer}" ItemsSource="{Binding Renderers}" Margin="3,0,0,0" Width="80" />
                 <CheckBox IsChecked="{Binding Transposed}" Content="Transposed" VerticalAlignment="Center" Margin="10,0,5,0" IsEnabled="{Binding CanTranspose}" />
+                <CheckBox IsChecked="{Binding Reversed}" Content="Reversed" VerticalAlignment="Center" Margin="10,0,5,0" IsEnabled="{Binding CanReverse}" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/Source/Examples/WindowsForms/ExampleBrowser/MainForm.Designer.cs
+++ b/Source/Examples/WindowsForms/ExampleBrowser/MainForm.Designer.cs
@@ -36,12 +36,12 @@ namespace ExampleBrowser
         /// </summary>
         private void InitializeComponent()
         {
-            OxyPlot.PlotModel plotModel1 = new OxyPlot.PlotModel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.treeView1 = new System.Windows.Forms.TreeView();
-            this.plot1 = new OxyPlot.WindowsForms.PlotView();
             this.panel1 = new System.Windows.Forms.Panel();
             this.transposedCheck = new System.Windows.Forms.CheckBox();
+            this.reversedCheck = new System.Windows.Forms.CheckBox();
+            this.plot1 = new OxyPlot.WindowsForms.PlotView();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -76,43 +76,9 @@ namespace ExampleBrowser
             this.treeView1.Size = new System.Drawing.Size(314, 554);
             this.treeView1.TabIndex = 1;
             // 
-            // plot1
-            // 
-            this.plot1.BackColor = System.Drawing.Color.White;
-            this.plot1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.plot1.Location = new System.Drawing.Point(0, 0);
-            plotModel1.AxisTierDistance = 4D;
-            plotModel1.Culture = null;
-            plotModel1.DefaultColors = null;
-            plotModel1.DefaultFont = "Segoe UI";
-            plotModel1.DefaultFontSize = 12D;
-            plotModel1.EdgeRenderingMode = OxyPlot.EdgeRenderingMode.Automatic;
-            plotModel1.IsLegendVisible = true;
-            plotModel1.PlotType = OxyPlot.PlotType.XY;
-            plotModel1.RenderingDecorator = null;
-            plotModel1.Subtitle = null;
-            plotModel1.SubtitleFont = null;
-            plotModel1.SubtitleFontSize = 14D;
-            plotModel1.SubtitleFontWeight = 400D;
-            plotModel1.Title = null;
-            plotModel1.TitleFont = null;
-            plotModel1.TitleFontSize = 18D;
-            plotModel1.TitleFontWeight = 700D;
-            plotModel1.TitleHorizontalAlignment = OxyPlot.TitleHorizontalAlignment.CenteredWithinPlotArea;
-            plotModel1.TitlePadding = 6D;
-            plotModel1.TitleToolTip = null;
-            this.plot1.Model = plotModel1;
-            this.plot1.Name = "plot1";
-            this.plot1.PanCursor = System.Windows.Forms.Cursors.Hand;
-            this.plot1.Size = new System.Drawing.Size(625, 525);
-            this.plot1.TabIndex = 0;
-            this.plot1.Text = "plot1";
-            this.plot1.ZoomHorizontalCursor = System.Windows.Forms.Cursors.SizeWE;
-            this.plot1.ZoomRectangleCursor = System.Windows.Forms.Cursors.SizeNWSE;
-            this.plot1.ZoomVerticalCursor = System.Windows.Forms.Cursors.SizeNS;
-            // 
             // panel1
             // 
+            this.panel1.Controls.Add(this.reversedCheck);
             this.panel1.Controls.Add(this.transposedCheck);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.panel1.Location = new System.Drawing.Point(0, 525);
@@ -122,14 +88,41 @@ namespace ExampleBrowser
             // 
             // transposedCheck
             // 
+            this.transposedCheck.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.transposedCheck.AutoSize = true;
-            this.transposedCheck.Location = new System.Drawing.Point(531, 6);
+            this.transposedCheck.Location = new System.Drawing.Point(453, 6);
             this.transposedCheck.Name = "transposedCheck";
             this.transposedCheck.Size = new System.Drawing.Size(82, 17);
             this.transposedCheck.TabIndex = 0;
             this.transposedCheck.Text = "Transposed";
             this.transposedCheck.UseVisualStyleBackColor = true;
             this.transposedCheck.CheckedChanged += new System.EventHandler(this.transposedCheck_CheckedChanged);
+            // 
+            // reversedCheck
+            // 
+            this.reversedCheck.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.reversedCheck.AutoSize = true;
+            this.reversedCheck.Location = new System.Drawing.Point(541, 6);
+            this.reversedCheck.Name = "reversedCheck";
+            this.reversedCheck.Size = new System.Drawing.Size(72, 17);
+            this.reversedCheck.TabIndex = 1;
+            this.reversedCheck.Text = "Reversed";
+            this.reversedCheck.UseVisualStyleBackColor = true;
+            this.reversedCheck.CheckedChanged += new System.EventHandler(this.reversedCheck_CheckedChanged);
+            // 
+            // plot1
+            // 
+            this.plot1.BackColor = System.Drawing.Color.White;
+            this.plot1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.plot1.Location = new System.Drawing.Point(0, 0);
+            this.plot1.Name = "plot1";
+            this.plot1.PanCursor = System.Windows.Forms.Cursors.Hand;
+            this.plot1.Size = new System.Drawing.Size(625, 525);
+            this.plot1.TabIndex = 0;
+            this.plot1.Text = "plot1";
+            this.plot1.ZoomHorizontalCursor = System.Windows.Forms.Cursors.SizeWE;
+            this.plot1.ZoomRectangleCursor = System.Windows.Forms.Cursors.SizeNWSE;
+            this.plot1.ZoomVerticalCursor = System.Windows.Forms.Cursors.SizeNS;
             // 
             // MainForm
             // 
@@ -156,5 +149,6 @@ namespace ExampleBrowser
         private OxyPlot.WindowsForms.PlotView plot1;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.CheckBox transposedCheck;
+        private System.Windows.Forms.CheckBox reversedCheck;
     }
 }

--- a/Source/Examples/WindowsForms/ExampleBrowser/MainForm.cs
+++ b/Source/Examples/WindowsForms/ExampleBrowser/MainForm.cs
@@ -49,6 +49,7 @@ namespace ExampleBrowser
             this.InitPlot();
 
             this.transposedCheck.Enabled = this.vm.SelectedExample?.IsTransposable ?? false;
+            this.reversedCheck.Enabled = this.vm.SelectedExample?.IsReversible ?? false;
         }
 
         private void InitPlot()
@@ -58,19 +59,23 @@ namespace ExampleBrowser
                 this.plot1.Model = null;
                 this.plot1.Controller = null;
             }
-            else if (transposedCheck.Checked && this.vm.SelectedExample.IsTransposable)
-            {
-                this.plot1.Model = this.vm.SelectedExample.TransposedPlotModel;
-                this.plot1.Controller = this.vm.SelectedExample.TransposedPlotController;
-            }
             else
             {
-                this.plot1.Model = this.vm.SelectedExample.PlotModel;
-                this.plot1.Controller = this.vm.SelectedExample.PlotController;
+                var flags = ExampleInfo.PrepareFlags(
+                    this.transposedCheck.Enabled && this.transposedCheck.Checked,
+                    this.reversedCheck.Enabled && this.reversedCheck.Checked);
+
+                this.plot1.Model = this.vm.SelectedExample.GetModel(flags);
+                this.plot1.Controller = this.vm.SelectedExample.GetController(flags);
             }
         }
 
         private void transposedCheck_CheckedChanged(object sender, System.EventArgs e)
+        {
+            InitPlot();
+        }
+
+        private void reversedCheck_CheckedChanged(object sender, System.EventArgs e)
         {
             InitPlot();
         }

--- a/Source/OxyPlot.ImageSharp.Tests/ExportTest.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/ExportTest.cs
@@ -39,7 +39,6 @@ namespace OxyPlot.ImageSharp.Tests
                 }
 
                 ExportModelAndCheckFileExists(example.PlotModel, $"{example.Category} - {example.Title}");
-                ExportModelAndCheckFileExists(example.TransposedPlotModel, $"{example.Category} - {example.Title} - Transposed");
             }
         }
     }

--- a/Source/OxyPlot.Pdf.Tests/PdfExporterTests.cs
+++ b/Source/OxyPlot.Pdf.Tests/PdfExporterTests.cs
@@ -52,7 +52,6 @@ namespace OxyPlot.Pdf.Tests
                 }
 
                 ExportModelAndCheckFileExists(example.PlotModel, $"{example.Category} - {example.Title}");
-                ExportModelAndCheckFileExists(example.TransposedPlotModel, $"{example.Category} - {example.Title} - Transposed");
             }
         }
 

--- a/Source/OxyPlot.SkiaSharp.Tests/ExportTest.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/ExportTest.cs
@@ -39,7 +39,6 @@ namespace OxyPlot.SkiaSharp.Tests
                 }
 
                 ExportModelAndCheckFileExists(example.PlotModel, $"{example.Category} - {example.Title}");
-                ExportModelAndCheckFileExists(example.TransposedPlotModel, $"{example.Category} - {example.Title} - Transposed");
             }
         }
     }

--- a/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
+++ b/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
@@ -37,7 +37,6 @@ namespace OxyPlot.Tests
                 }
 
                 CheckCode(ei.PlotModel);
-                CheckCode(ei.TransposedPlotModel);
             }
         }
     }

--- a/Source/OxyPlot.Tests/Pdf/PdfExporterTests.cs
+++ b/Source/OxyPlot.Tests/Pdf/PdfExporterTests.cs
@@ -50,7 +50,6 @@ namespace OxyPlot.Tests
                 }
 
                 ExportModelAndCheckFileExists(example.PlotModel, $"{example.Category} - {example.Title}");
-                ExportModelAndCheckFileExists(example.TransposedPlotModel, $"{example.Category} - {example.Title} - Transposed");
             }
         }
     }

--- a/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
+++ b/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
@@ -32,7 +32,14 @@ namespace OxyPlot.Tests
             foreach (var example in Examples.GetList())
             {
                 ((IPlotModel)example.PlotModel)?.Update(true);
-                ((IPlotModel)example.TransposedPlotModel)?.Update(true);
+
+                var first = 1; // skip the 'none', since we do that above for clarity
+                var all = (int)(ExampleFlags.Transpose | ExampleFlags.Reverse);
+
+                for (int flags = first; flags < all; flags++)
+                {
+                    ((IPlotModel)example.GetModel((ExampleFlags)flags))?.Update(true);
+                }
             }
         }
 

--- a/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
+++ b/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
@@ -81,7 +81,16 @@ namespace OxyPlot.Tests
                 }
 
                 ExportModelAndCheckFileExists(example.PlotModel, $"{example.Category} - {example.Title}");
-                ExportModelAndCheckFileExists(example.TransposedPlotModel, $"{example.Category} - {example.Title} - Transposed");
+
+                if (example.IsTransposable)
+                {
+                    ExportModelAndCheckFileExists(example.GetModel(ExampleFlags.Transpose), $"{example.Category} - {example.Title} - Transposed");
+                }
+
+                if (example.IsReversible)
+                {
+                    ExportModelAndCheckFileExists(example.GetModel(ExampleFlags.Reverse), $"{example.Category} - {example.Title} - Reversed");
+                }
             }
         }
 

--- a/Source/OxyPlot.Wpf.Tests/ExampleLibraryTests.cs
+++ b/Source/OxyPlot.Wpf.Tests/ExampleLibraryTests.cs
@@ -70,7 +70,6 @@ namespace OxyPlot.Wpf.Tests
                 }
 
                 ExportAndCompareToBaseline(example.PlotModel, CreateValidFileName($"{example.Category} - {example.Title}", ".png"));
-                ExportAndCompareToBaseline(example.TransposedPlotModel, CreateValidFileName($"{example.Category} - {example.Title} - Transposed", ".png"));
             }
         }
 


### PR DESCRIPTION
The idea is to make it easier to test axis reversal by performing this automatically where appropriate in tests, and add 'reversed' checkboxes to the example libraries.

# Checklist

- [x] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove the existing code in `ExampleInfo` to support transposable plots
- Add `ExampleFlags` enum to describe simple transformations that can be applied to a plot (i.e. transpose and reverse)
- Implement support for `ExampleFlags` to `ExampleInfo`, along with the Wpf and WinForms example browsers
- Add additional tests for reversed plots in the Svg exporter tests and simple 'Update' tests
- Remove existing transpose tests in other exporters to reduce how long the unit tests take to run

@oxyplot/admins
