### PR TITLE
Fix #1580 Axis renderers do not render all tick values they are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - SkiaRenderContext does not apply pixel snapping when rendering to vector graphic (#1539)
 - Mark OxyPlot.PdfExporter and OxyPlot.Pdf.PdfExporter as obsolete (#1527)
 - Replace Axis.DesiredSize by Axis.DesiredMargin, change signature of Axis.Measure(...) (#453)
+- Axis renderers now render all ticks they are provided (#1580)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/OxyPlot/Axes/AngleAxis.cs
+++ b/Source/OxyPlot/Axes/AngleAxis.cs
@@ -57,6 +57,8 @@ namespace OxyPlot.Axes
             minorTickValues = this.CreateTickValues(minimum, maximum, this.ActualMinorStep);
             majorTickValues = this.CreateTickValues(minimum, maximum, this.ActualMajorStep);
             majorLabelValues = this.CreateTickValues(this.Minimum, this.Maximum, this.ActualMajorStep);
+
+            minorTickValues = AxisUtilities.FilterRedundantMinorTicks(majorTickValues, minorTickValues);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -719,6 +719,8 @@ namespace OxyPlot.Axes
             minorTickValues = this.CreateTickValues(this.ActualMinimum, this.ActualMaximum, this.ActualMinorStep);
             majorTickValues = this.CreateTickValues(this.ActualMinimum, this.ActualMaximum, this.ActualMajorStep);
             majorLabelValues = majorTickValues;
+
+            minorTickValues = AxisUtilities.FilterRedundantMinorTicks(majorTickValues, minorTickValues);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Axes/DateTimeAxis.cs
+++ b/Source/OxyPlot/Axes/DateTimeAxis.cs
@@ -163,6 +163,8 @@ namespace OxyPlot.Axes
             majorTickValues = this.CreateDateTimeTickValues(
                 this.ActualMinimum, this.ActualMaximum, this.ActualMajorStep, this.actualIntervalType);
             majorLabelValues = majorTickValues;
+
+            minorTickValues = AxisUtilities.FilterRedundantMinorTicks(majorTickValues, minorTickValues);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Axes/LogarithmicAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicAxis.cs
@@ -113,6 +113,7 @@ namespace OxyPlot.Axes
             }
 
             majorLabelValues = majorTickValues;
+            minorTickValues = AxisUtilities.FilterRedundantMinorTicks(majorTickValues, minorTickValues);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
@@ -56,11 +56,8 @@ namespace OxyPlot.Axes
                 var tickCount = Math.Abs((int)(axisLength / axis.ActualMinorStep));
 
                 var screenPoints = this.MinorTickValues
-                            .Where(x => x > Math.Min(scaledStartAngle, scaledEndAngle) - eps &&
-                                   x < Math.Max(scaledStartAngle, scaledEndAngle) + eps &&
-                                   !this.MajorTickValues.Contains(x))
                             .Take(tickCount + 1)
-                            .Select(x => TransformToClientRectangle(magnitudeAxis.ActualMaximum, x, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint));
+                            .Select(x => this.TransformToClientRectangle(magnitudeAxis.ActualMaximum, x, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint));
 
                 foreach (var screenPoint in screenPoints)
                 {
@@ -78,10 +75,8 @@ namespace OxyPlot.Axes
             if (this.MajorPen != null)
             {
                 var screenPoints = this.MajorTickValues
-                                .Where(x => x > Math.Min(scaledStartAngle, scaledEndAngle) - eps && x < Math.Max(scaledStartAngle, scaledEndAngle) + eps)
                                 .Take(majorTickCount)
-                                .Select(x => TransformToClientRectangle(magnitudeAxis.ActualMaximum, x, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint))
-                                .ToArray();
+                                .Select(x => this.TransformToClientRectangle(magnitudeAxis.ActualMaximum, x, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint));
 
                 foreach (var point in screenPoints)
                 {

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisRenderer.cs
@@ -55,9 +55,6 @@ namespace OxyPlot.Axes
             {
                 var tickCount = Math.Abs((int)(axisLength / axis.ActualMinorStep));
                 var screenPoints = this.MinorTickValues
-                    .Where(x => x > Math.Min(scaledStartAngle, scaledEndAngle) - eps &&
-                           x < Math.Max(scaledStartAngle, scaledEndAngle) + eps &&
-                           !this.MajorTickValues.Contains(x))
                     .Take(tickCount + 1)
                     .Select(x => magnitudeAxis.Transform(magnitudeAxis.ActualMaximum, x, axis));
 
@@ -77,10 +74,8 @@ namespace OxyPlot.Axes
             if (this.MajorPen != null)
             {
                 var screenPoints = this.MajorTickValues
-                    .Where(x => x > Math.Min(scaledStartAngle, scaledEndAngle) - eps && x < Math.Max(scaledStartAngle, scaledEndAngle) + eps)
                     .Take(majorTickCount)
-                    .Select(x => magnitudeAxis.Transform(magnitudeAxis.ActualMaximum, x, axis))
-                    .ToArray();
+                    .Select(x => magnitudeAxis.Transform(magnitudeAxis.ActualMaximum, x, axis));
 
                 foreach (var point in screenPoints)
                 {

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -322,11 +322,6 @@ namespace OxyPlot.Axes
 
             foreach (double value in this.MajorTickValues)
             {
-                if (value < actualMinimum - eps || value > actualMaximum + eps)
-                {
-                    continue;
-                }
-
                 if (dontRenderZero && Math.Abs(value) < eps)
                 {
                     continue;
@@ -542,16 +537,6 @@ namespace OxyPlot.Axes
 
             foreach (double value in this.MinorTickValues)
             {
-                if (value < actualMinimum - eps || value > actualMaximum + eps)
-                {
-                    continue;
-                }
-
-                if (this.MajorTickValues.Contains(value))
-                {
-                    continue;
-                }
-
                 if (axis.PositionAtZeroCrossing && Math.Abs(value) < eps)
                 {
                     continue;

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
@@ -11,9 +11,6 @@ namespace OxyPlot.Axes
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Text;
 
     /// <summary>
     /// Provides functionality to render <see cref="MagnitudeAxis" /> using the full plot area.
@@ -65,7 +62,6 @@ namespace OxyPlot.Axes
             double bottomdistance = Math.Abs(axis.PlotModel.PlotArea.Bottom - magnitudeAxis.MidPoint.Y);
             double leftdistance = Math.Abs(axis.PlotModel.PlotArea.Left - magnitudeAxis.MidPoint.X);
             double rightdistance = Math.Abs(axis.PlotModel.PlotArea.Right - magnitudeAxis.MidPoint.X);
-            OxyRect plotrect = axis.PlotModel.PlotArea;
             OxyRect distancerect = axis.PlotModel.PlotArea.Offset(-magnitudeAxis.MidPoint.X, -magnitudeAxis.MidPoint.Y);
             OxyRect maxtickrect = new OxyRect(new ScreenPoint(axis.InverseTransform(distancerect.Left), axis.InverseTransform(distancerect.Top)), new ScreenPoint(axis.InverseTransform(distancerect.Right), axis.InverseTransform(distancerect.Bottom)));
 
@@ -85,39 +81,11 @@ namespace OxyPlot.Axes
             double cornerdistance_bottomleft = Math.Sqrt(Math.Pow(distancerect.Bottom, 2) + Math.Pow(distancerect.Left, 2));
             double cornerdistance_bottomright = Math.Sqrt(Math.Pow(distancerect.Bottom, 2) + Math.Pow(distancerect.Right, 2));
 
-            double maxtick_topright = axis.InverseTransform(cornerdistance_topright);
-            double maxtick_topleft = axis.InverseTransform(cornerdistance_topleft);
-            double maxtick_bottomleft = axis.InverseTransform(cornerdistance_bottomleft);
-            double maxtick_bottomright = axis.InverseTransform(cornerdistance_bottomright);
-
-            double maxdistance = Math.Max(cornerdistance_topright, Math.Max(cornerdistance_topleft, Math.Max(cornerdistance_bottomleft, cornerdistance_bottomright)));
-            double maxtick = new double[] { maxtick_topright, maxtick_topleft, maxtick_bottomleft, maxtick_bottomright }.Max();
-            double mintick = new double[] { maxtick_topright, maxtick_topleft, maxtick_bottomleft, maxtick_bottomright }.Min();
-
-            List<double> majorticks = new List<double>();
-            majorticks.AddRange(this.MajorTickValues);
-            ExtendTickList(ref majorticks, maxtick);
-
-            List<double> minorticks = new List<double>();
-            minorticks.AddRange(this.MinorTickValues);
-            ExtendTickList(ref minorticks, maxtick);
-
-            List<double> textticks = new List<double>();
-            //now the axis angle is relevant
-            double axisorientation = (360 + angleAxis.StartAngle) % 360;
-            double textticklength = GetTickLength(axisorientation, maxtickrect);
-            textticks.AddRange(this.MajorTickValues);
-            ExtendTickList(ref textticks, textticklength);
-
-            var majorTicks = majorticks.Where(x => x > axis.ActualMinimum && x <= maxtick).ToArray();
-
             if (pass == 0 && this.MinorPen != null)
             {
                 OxyPen pen = this.MinorPen;
-                //var minorTicks = this.MinorTickValues.Where(x => x >= axis.ActualMinimum && x <= axis.ActualMaximum && !majorTicks.Contains(x)).ToArray();
-                var minorTicks = minorticks.Where(x => x >= axis.ActualMinimum && x <= maxtick && !majorTicks.Contains(x)).ToArray();
 
-                foreach (var tickValue in minorTicks)
+                foreach (var tickValue in this.MinorTickValues)
                 {
                     //a circle consists - in this case - of 4 arcs
                     //the start and end of each arc has to be computed
@@ -125,11 +93,6 @@ namespace OxyPlot.Axes
                     double r = axis.Transform(tickValue);
 
                     //this works by putting the limits of the plotarea into the circular equation and solving it to gain t for each intersection
-
-                    //y=r*sin(t)+ym
-                    //t=asin((y-ym)/r)
-                    //x=r*cos(t)+xm
-                    //t=acos((x-xm)/r)
 
                     double startangle_0_90 = 0;
                     double endangle_0_90 = 90;
@@ -211,7 +174,7 @@ namespace OxyPlot.Axes
             if (pass == 0 && this.MajorPen != null)
             {
                 OxyPen pen = this.MajorPen;
-                foreach (var tickValue in majorTicks)
+                foreach (var tickValue in this.MajorTickValues)
                 {
                     //a circle consists - in this case - of 4 arcs
                     //the start and end of each arc has to be computed
@@ -219,11 +182,6 @@ namespace OxyPlot.Axes
                     double r = axis.Transform(tickValue);
 
                     //this works by putting the limits of the plotarea into the circular equation and solving it to gain t for each intersection
-
-                    //y=r*sin(t)+ym
-                    //t=asin((y-ym)/r)
-                    //x=r*cos(t)+xm
-                    //t=acos((x-xm)/r)
 
                     double startangle_0_90 = 0;
                     double endangle_0_90 = 90;
@@ -304,71 +262,11 @@ namespace OxyPlot.Axes
 
             if (pass == 1)
             {
-                foreach (double tickValue in textticks)
+                foreach (var tickValue in this.MajorLabelValues)
                 {
                     this.RenderTickText(axis, tickValue, angleAxis);
                 }
             }
-        }
-
-        /// <summary>
-        /// Computes the length in ticks at which the maxtickrect is reached
-        /// </summary>
-        /// <param name="axisorientation">angluar orientation of the axis in degrees</param>
-        /// <param name="maxtickrect">the boundsrect including offset by midpoint converted to ticks</param>
-        /// <returns></returns>
-        private double GetTickLength(double axisorientation, OxyRect maxtickrect)
-        {
-            axisorientation %= 360d;
-            if(axisorientation < 0)
-                axisorientation += 360d;
-            double result = 0;
-
-            double sin = 0;
-            double cos = 0;
-            if (axisorientation > 270)
-            {
-                //below
-                sin = -Math.Sin(rad * axisorientation) * maxtickrect.Bottom;
-                //right
-                cos = Math.Cos(rad * axisorientation) * maxtickrect.Right;
-                result = Math.Sqrt(sin * sin + cos * cos);
-            }
-            else if (axisorientation > 180)
-            {
-                //below
-                sin = -Math.Sin(rad * axisorientation) * maxtickrect.Bottom;
-                //left
-                cos = -Math.Cos(rad * axisorientation) * maxtickrect.Left;
-                result = Math.Sqrt(sin * sin + cos * cos);
-            }
-            else if (axisorientation > 90)
-            {
-                //above
-                sin = Math.Sin(rad * axisorientation) * maxtickrect.Top;
-                //left
-                cos = -Math.Cos(rad * axisorientation) * maxtickrect.Left;
-                result = Math.Sqrt(sin * sin + cos * cos);
-            }
-            else
-            {
-                //above
-                sin = Math.Sin(rad * axisorientation) * maxtickrect.Top;
-                //right
-                cos = Math.Cos(rad * axisorientation) * maxtickrect.Right;
-                result = Math.Sqrt(sin * sin + cos * cos);
-            }
-            return result;
-        }
-
-        private void ExtendTickList(ref List<double> ticks, double maximum)
-        {
-            double tickdelta = ticks[ticks.Count - 1] - ticks[ticks.Count - 2];
-            while (ticks.Last() < maximum)
-            {
-                ticks.Add(ticks.Last() + tickdelta);
-            }
-            ticks.Remove(ticks.Last());
         }
 
         /// <summary>
@@ -484,10 +382,10 @@ namespace OxyPlot.Axes
             var pt = axis.Transform(x, angleAxis.Angle, angleAxis);
             pt = new ScreenPoint(pt.X + dx, pt.Y + dy);
 
-            //check if point is outside the plot area
 
             string text = axis.FormatValue(x);
-            this.RenderContext.DrawMathText(
+            this.RenderContext.DrawClippedMathText(
+                new OxyRect(axis.ScreenMin, axis.ScreenMax),
                 pt,
                 text,
                 axis.ActualTextColor,

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisRenderer.cs
@@ -47,8 +47,6 @@ namespace OxyPlot.Axes
 
             angleAxis.UpdateActualMaxMin();
 
-            var majorTicks = this.MajorTickValues.Where(x => x > axis.ActualMinimum && x <= axis.ActualMaximum).ToArray();
-
             if (pass == 0 && this.ExtraPen != null)
             {
                 var extraTicks = axis.ExtraGridlines;
@@ -63,9 +61,7 @@ namespace OxyPlot.Axes
 
             if (pass == 0 && this.MinorPen != null)
             {
-                var minorTicks = this.MinorTickValues.Where(x => x >= axis.ActualMinimum && x <= axis.ActualMaximum && !majorTicks.Contains(x)).ToArray();
-
-                foreach (var tickValue in minorTicks)
+                foreach (var tickValue in this.MinorTickValues)
                 {
                     this.RenderTick(axis, angleAxis, tickValue, this.MinorPen);
                 }
@@ -73,7 +69,7 @@ namespace OxyPlot.Axes
 
             if (pass == 0 && this.MajorPen != null)
             {
-                foreach (var tickValue in majorTicks)
+                foreach (var tickValue in this.MajorTickValues)
                 {
                     this.RenderTick(axis, angleAxis, tickValue, this.MajorPen);
                 }
@@ -81,7 +77,7 @@ namespace OxyPlot.Axes
 
             if (pass == 1)
             {
-                foreach (double tickValue in majorTicks)
+                foreach (var tickValue in this.MajorTickValues)
                 {
                     this.RenderTickText(axis, tickValue, angleAxis);
                 }


### PR DESCRIPTION
Fixes #1580.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove tick value checks from the axis renderers
- Change `AxisUtilities.CreateTickValues(...)` such that it only returns tick values inside the requested range
- Add `AxisUtilities.FilterRedundantMinorTicks(...)` which can be used to filter out minor ticks that are not needed because they are 'on top of' a major tick

Because these changes affect pretty much all kinds of plots, there is a lot of possibility of breaking things. Therefore I would be thankful if someone could second-guess this and tell me what I have forgotten...

@oxyplot/admins
