### PR TITLE
Fix ampersands in windows forms tracker (#1585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to this project will be documented in this file.
 - Auto plot margin not taking width of labels into account (#453)
 - WPF PlotView still focusable when Focusable is false (#1440)
 - Disposing a SkiaRenderContext can mess up fonts from another SkiaRenderContext instance (#1573)
+- Display of ampersands in OxyPlot.WindowsForms Tracker (#1585)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot.WindowsForms/PlotView.cs
+++ b/Source/OxyPlot.WindowsForms/PlotView.cs
@@ -321,6 +321,7 @@ namespace OxyPlot.WindowsForms
             this.trackerLabel.Top = (int)data.Position.Y - this.trackerLabel.Height;
             this.trackerLabel.Left = (int)data.Position.X - (this.trackerLabel.Width / 2);
             this.trackerLabel.Visible = true;
+            this.trackerLabel.UseMnemonic = false;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1585 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Set `UseMneumonic = false` on the OxyPlot.WindowsForms tracker label so that all ampersands are preserved

@oxyplot/admins
