### PR TITLE
Add examples of full plot area polar plots with non-zero minimums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Added LabelStep and LabelSpacing to contour series (#1511)
 - Example for Issue #1481 showing text rendering with emoji
 - Native Clipping for OxyPlot.SvgRenderContext (#1564)
+- Examples of full plot area polar plots with non-zero minimums (#1586)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Axes/PolarPlotExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/PolarPlotExamples.cs
@@ -44,7 +44,7 @@ namespace ExampleLibrary
             model.Axes.Add(new MagnitudeAxis
             {
                 MajorGridlineStyle = LineStyle.Solid,
-                MinorGridlineStyle = LineStyle.Solid
+                MinorGridlineStyle = LineStyle.Solid,
             });
             model.Series.Add(new FunctionSeries(t => t, t => t, 0, Math.PI * 6, 0.01));
             return model;
@@ -277,6 +277,31 @@ namespace ExampleLibrary
         [Example("Spiral full plot area")]
         public static PlotModel ArchimedeanSpiralFullPlotArea()
         {
+            var model = CreateFullPlotAreaPlotModel();
+            model.Series.Add(new FunctionSeries(t => t, t => t, 0, Math.PI * 6, 0.01));
+            return model;
+        }
+
+        [Example("Spiral full plot area with negative minimum")]
+        public static PlotModel SpiralWithNegativeMinium()
+        {
+            var model = CreateFullPlotAreaPlotModel();
+            model.Title += " with a negative minimum";
+            model.Series.Add(new FunctionSeries(t => t, t => t, -Math.PI * 6, Math.PI * 6, 0.01));
+            return model;
+        }
+
+        [Example("Spiral full plot area with positive minimum")]
+        public static PlotModel SpiralWithPositiveMinium()
+        {
+            var model = CreateFullPlotAreaPlotModel();
+            model.Title += " with a positive minimum";
+            model.Series.Add(new FunctionSeries(t => t, t => t, Math.PI * 6, Math.PI * 12, 0.01));
+            return model;
+        }
+
+        private static PlotModel CreateFullPlotAreaPlotModel()
+        {
             var model = new PlotModel
             {
                 Title = "Polar plot filling the plot area",
@@ -284,6 +309,7 @@ namespace ExampleLibrary
                 PlotType = PlotType.Polar,
                 PlotAreaBorderThickness = new OxyThickness(1),
             };
+
             model.Axes.Add(
                 new AngleAxisFullPlotArea
                 {
@@ -297,6 +323,7 @@ namespace ExampleLibrary
                     Minimum = 0,
                     Maximum = 2 * Math.PI
                 });
+
             model.Axes.Add(new MagnitudeAxisFullPlotArea
             {
                 MidshiftH = -0.1d,
@@ -304,7 +331,7 @@ namespace ExampleLibrary
                 MajorGridlineStyle = LineStyle.Solid,
                 MinorGridlineStyle = LineStyle.Solid
             });
-            model.Series.Add(new FunctionSeries(t => t, t => t, 0, Math.PI * 6, 0.01));
+
             return model;
         }
     }


### PR DESCRIPTION
Adds two examples of a full plot area polar plot, one with a large positive minimum, and one with a large negative minimum. Exposes Issue #1586.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

I've put these in the main example section for polar plots because they aren't edge cases and we probably want to keep an eye on them in the future; I'm happy to move them if someone thinks they should be in the issues.

@oxyplot/admins
