### PR TITLE
Fix full plot-area polar plot rendering with non-zero minimum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 - WPF PlotView still focusable when Focusable is false (#1440)
 - Disposing a SkiaRenderContext can mess up fonts from another SkiaRenderContext instance (#1573)
 - Display of ampersands in OxyPlot.WindowsForms Tracker (#1585)
+- Full Plotarea Polar plot rendering with non-zero minimum values (#1586)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
@@ -63,14 +63,13 @@ namespace OxyPlot.Axes
             double leftdistance = Math.Abs(axis.PlotModel.PlotArea.Left - magnitudeAxis.MidPoint.X);
             double rightdistance = Math.Abs(axis.PlotModel.PlotArea.Right - magnitudeAxis.MidPoint.X);
             OxyRect distancerect = axis.PlotModel.PlotArea.Offset(-magnitudeAxis.MidPoint.X, -magnitudeAxis.MidPoint.Y);
-            OxyRect maxtickrect = new OxyRect(new ScreenPoint(axis.InverseTransform(distancerect.Left), axis.InverseTransform(distancerect.Top)), new ScreenPoint(axis.InverseTransform(distancerect.Right), axis.InverseTransform(distancerect.Bottom)));
 
-            double cornerangle_topright = -degree * Math.Atan2(maxtickrect.Top, maxtickrect.Right);
-            double cornerangle_topleft = -degree * Math.Atan2(maxtickrect.Top, maxtickrect.Left);
-            double cornerangle_bottomleft = 360-degree * Math.Atan2(maxtickrect.Bottom, maxtickrect.Left);
-            double cornerangle_bottomright = 360-degree * Math.Atan2(maxtickrect.Bottom, maxtickrect.Right);
+            double cornerangle_topright = -degree * Math.Atan2(distancerect.Top, distancerect.Right);
+            double cornerangle_topleft = -degree * Math.Atan2(distancerect.Top, distancerect.Left);
+            double cornerangle_bottomleft = 360-degree * Math.Atan2(distancerect.Bottom, distancerect.Left);
+            double cornerangle_bottomright = 360-degree * Math.Atan2(distancerect.Bottom, distancerect.Right);
 
-            // detect and filter dodgy values (these checks appear to be sufficient)
+            // detect and filter dodgy values caused by zero values
             if (cornerangle_topleft < 0)
                 cornerangle_topleft += 360;
             if (cornerangle_bottomleft > 360)


### PR DESCRIPTION
Fixes #1586

### Checklist

- [ ] I have included examples or tests (see #1588 ) 
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Removes the erroneous transformation from screen space in `MagnitudeAxisFullPlotAreaRenderer.Render` performed before computing sweep angles

As far as I can tell, the transformation didn't make any sense, and uses a method that is explicitly marked as only for use by non-Polar plots. This was passing negative and otherwise incorrect values to `atan2` messing up the sweep angles. The additional checks added in #1370 remain necessary to deal with zero-values passed to `atan2`.

@oxyplot/admins 
