### PR TITLE
remove SkiaSharp.PdfExporter.Dpi (#1591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 - Remove exporter Background properties (#1409)
 - Remove OxyThickness Width and Height properties (#1429)
 - RenderingExtensions.DrawRectangleAsPolygon(...) extension methods. IRenderContext.DrawRectangle(...) with an appropriate EdgeRenderingMode can be used instead.
+- SkiaSharp.PdfExporter.Dpi property (#1591)
 
 ### Fixed
 - Legend font size is not affected by DefaultFontSize (#1396)

--- a/Source/OxyPlot.SkiaSharp/PdfExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/PdfExporter.cs
@@ -15,17 +15,12 @@ namespace OxyPlot.SkiaSharp
     public class PdfExporter : IExporter
     {
         /// <summary>
-        /// Gets or sets the DPI.
-        /// </summary>
-        public float Dpi { get; set; } = 72;
-
-        /// <summary>
-        /// Gets or sets the export height (in points, as defined by <see cref="Dpi"/>).
+        /// Gets or sets the export height (in points, where 1 point equals 1/72 inch).
         /// </summary>
         public float Height { get; set; }
 
         /// <summary>
-        /// Gets or sets the export width (in points, as defined by <see cref="Dpi"/>).
+        /// Gets or sets the export width (in points, where 1 point equals 1/72 inch).
         /// </summary>
         public float Width { get; set; }
 
@@ -63,10 +58,10 @@ namespace OxyPlot.SkiaSharp
         /// <inheritdoc/>
         public void Export(IPlotModel model, Stream stream)
         {
-            using var document = SKDocument.CreatePdf(stream, this.Dpi);
+            using var document = SKDocument.CreatePdf(stream);
             using var pdfCanvas = document.BeginPage(this.Width, this.Height);
             using var context = new SkiaRenderContext { RenderTarget = RenderTarget.VectorGraphic, SkCanvas = pdfCanvas, UseTextShaping = this.UseTextShaping };
-            var dpiScale = this.Dpi / 96;
+            const float dpiScale = 72f / 96;
             context.DpiScale = dpiScale;
             model.Update(true);
             pdfCanvas.Clear(model.Background.ToSKColor());


### PR DESCRIPTION
Fixes #1591.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove `Dpi` property from `SkiaSharp.PdfExporter`, as this is not really needed

@oxyplot/admins
