### PR TITLE
Add Read-only Collection Interfaces for .NET 4.0 (#1600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Example for Issue #1481 showing text rendering with emoji
 - Native Clipping for OxyPlot.SvgRenderContext (#1564)
 - Examples of full plot area polar plots with non-zero minimums (#1586)
+- Read-Only collection interfaces for .NET 4.0 (#1600)
 
 ### Changed
 - Legends model (#644)

--- a/Source/OxyPlot/Graphics/ElementCollection{T}.cs
+++ b/Source/OxyPlot/Graphics/ElementCollection{T}.cs
@@ -17,7 +17,7 @@ namespace OxyPlot
     /// Represents a collection of <see cref="Element" /> objects.
     /// </summary>
     /// <typeparam name="T">The type of the elements.</typeparam>
-    public class ElementCollection<T> : IList<T> where T : Element
+    public class ElementCollection<T> : IList<T>, IReadOnlyList<T> where T : Element
     {
         /// <summary>
         /// The parent <see cref="Model" />.

--- a/Source/OxyPlot/Net40Compatibility/CompatibilityExtensions.cs
+++ b/Source/OxyPlot/Net40Compatibility/CompatibilityExtensions.cs
@@ -1,0 +1,55 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CompatibilityExtensions.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot
+{
+#if NET40
+    using OxyPlot.Net40Compatibility;
+#endif
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides extension methods facilitating compatibility with .NET 4.0.
+    /// </summary>
+    public static class CompatibilityExtensions
+    {
+        /// <summary>
+        /// Returns a <see cref="IReadOnlyList{T}"/> corresponding to the specified <see cref="List{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the list.</typeparam>
+        /// <param name="list">The list.</param>
+        /// <returns>
+        /// On .NET4.0, this returns a wrapper around the <paramref name="list"/> which implements <see cref="IReadOnlyList{T}"/> and <see cref="IList{T}"/>.
+        /// On .NET4.5 and later, this directly returns the <paramref name="list"/>.
+        /// </returns>
+        public static IReadOnlyList<T> AsReadOnlyList<T>(this List<T> list)
+        {
+#if NET40
+            return new ReadOnlyListWrapper<T>(list);
+#else
+            return list;
+#endif
+        }
+        
+        /// <summary>
+        /// Returns a <see cref="IReadOnlyList{T}"/> corresponding to the specified array.
+        /// </summary>
+        /// <typeparam name="T">The type of the array.</typeparam>
+        /// <param name="array">The array.</param>
+        /// <returns>
+        /// On .NET4.0, this returns a wrapper around the <paramref name="array"/> which implements <see cref="IReadOnlyList{T}"/> and <see cref="IList{T}"/>.
+        /// On .NET4.5 and later, this directly returns the <paramref name="array"/>.
+        /// </returns>
+        public static IReadOnlyList<T> AsReadOnlyList<T>(this T[] array)
+        {
+#if NET40
+            return new ReadOnlyListWrapper<T>(array);
+#else
+            return array;
+#endif
+        }
+    }
+}

--- a/Source/OxyPlot/Net40Compatibility/Interfaces.cs
+++ b/Source/OxyPlot/Net40Compatibility/Interfaces.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Interfaces.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+#if NET40
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// Defines a read-only collection of elements.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    public interface IReadOnlyCollection<out T> : IEnumerable<T>
+    {
+        /// <summary>
+        /// The number of elements in the collection.
+        /// </summary>
+        int Count { get; }
+    }
+
+    /// <summary>
+    /// Defines a read-only list of elements.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    public interface IReadOnlyList<out T> : IReadOnlyCollection<T>
+    {
+        /// <summary>
+        /// Gets the element at the specified index in the list.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns>The element at the specified index in the list.</returns>
+        T this[int index] { get; }
+    }
+}
+#endif

--- a/Source/OxyPlot/Net40Compatibility/ReadOnlyListWrapper.cs
+++ b/Source/OxyPlot/Net40Compatibility/ReadOnlyListWrapper.cs
@@ -1,0 +1,104 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ReadOnlyListWrapper.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+#if NET40
+namespace OxyPlot.Net40Compatibility
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents a wrapper around a <see cref="List{T}"/> which implements <see cref="IReadOnlyList{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the list.</typeparam>
+    internal class ReadOnlyListWrapper<T> : IReadOnlyList<T>, IList<T>
+    {
+        private readonly IList<T> source;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyListWrapper{T}"/> class.
+        /// </summary>
+        /// <param name="source">The source list.</param>
+        public ReadOnlyListWrapper(IList<T> source)
+        {
+            this.source = source;
+        }
+
+        /// <inheritdoc/>
+        public T this[int index] => this.source[index];
+
+        /// <inheritdoc/>
+        T IList<T>.this[int index] { get => this[index]; set => throw new InvalidOperationException(); }
+
+        /// <inheritdoc/>
+        public int Count => this.source.Count;
+
+        /// <inheritdoc/>
+        public bool IsReadOnly => true;
+
+        /// <inheritdoc/>
+        public void Add(T item)
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <inheritdoc/>
+        public void Clear()
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <inheritdoc/>
+        public bool Contains(T item)
+        {
+            return this.source.Contains(item);
+        }
+
+        /// <inheritdoc/>
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            this.source.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.source.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        public int IndexOf(T item)
+        {
+            return this.source.IndexOf(item);
+        }
+
+        /// <inheritdoc/>
+        public void Insert(int index, T item)
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <inheritdoc/>
+        public bool Remove(T item)
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <inheritdoc/>
+        public void RemoveAt(int index)
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.source.GetEnumerator();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #1600.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add read-only collection interfaces (conditionally compiled only for .NET 4.0)
- Add wrapper class implementing `IReadOnlyList<T>` and `IList<T>`

@oxyplot/admins
