### PR TITLE
Advance System.Drawing.Common to version 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 - Replace Axis.DesiredSize by Axis.DesiredMargin, change signature of Axis.Measure(...) (#453)
 - Axis renderers now render all ticks they are provided (#1580)
 - Auto margins don't reserve space for axis labels if axis range is fixed (#1577)
+- System.Drawing.Common references updated to 4.7.0 (#1608)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/OxyPlot.Core.Drawing/OxyPlot.Core.Drawing.csproj
+++ b/Source/OxyPlot.Core.Drawing/OxyPlot.Core.Drawing.csproj
@@ -25,7 +25,7 @@
         <Compile Include="..\OxyPlot.WindowsForms\GraphicsRenderContext.cs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
+        <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />


### PR DESCRIPTION
Fixes #1605 .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Advance the dependency on System.Drawing.Common to 4.7.0. This shouldn't lose backwards compatability, and seems to fix text rendering under Linux. with .NET Core 3.1

@oxyplot/admins
