### PR TITLE
Wpf Speed Up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Native Clipping for OxyPlot.SvgRenderContext (#1564)
 - Examples of full plot area polar plots with non-zero minimums (#1586)
 - Read-Only collection interfaces for .NET 4.0 (#1600)
+- Add a PlotView.TextMeasurementMethod property to allow using the much faster GlyphTypeface based measurement at runtime
 
 ### Changed
 - Legends model (#644)
@@ -55,6 +56,8 @@ All notable changes to this project will be documented in this file.
 - Axis renderers now render all ticks they are provided (#1580)
 - Auto margins don't reserve space for axis labels if axis range is fixed (#1577)
 - System.Drawing.Common references updated to 4.7.0 (#1608)
+- Refactor DrawLineSegmentsByStreamGeometry() to draw much faster
+- Implement StreamGeometry-based implementations of DrawEllipses, DrawLine, and DrawRectangle(s) which improves the rendering speed.
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -98,6 +98,7 @@ Peter-B-
 Philippe AURIOU <p.auriou@live.fr>
 Piotr Warzocha <pw@piootr.pl>
 Poul Erik Venø <poulerikvenoehansen@gmail.com>
+Régis Boudin <regis@boudin.name>
 Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
 Sarah Müller <sy-mueller@gmx-topmail.de>

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -225,9 +225,48 @@ namespace OxyPlot.Wpf
                 return;
             }
 
+            if (this.UseStreamGeometry)
+            {
+                this.DrawLineByStreamGeometry(points, stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
+                return;
+            }
+
             var e = this.CreateAndAdd<Polyline>();
             this.SetStroke(e, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
             e.Points = this.ToPointCollection(points, e.StrokeThickness, edgeRenderingMode);
+        }
+
+        /// <summary>
+        /// Draws a polyline using a StreamGeometry.
+        /// </summary>
+        /// <param name="points">The points defining the polyline. The polyline is drawn from point 0, to point 1, to point 2 and so on.</param>
+        /// <param name="stroke">The stroke color.</param>
+        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <param name="dashArray">The dash array (in device independent units, 1/96 inch). Use <c>null</c> to get a solid line.</param>
+        /// <param name="lineJoin">The line join type.</param>
+        public void DrawLineByStreamGeometry(
+            IList<ScreenPoint> points,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray,
+            LineJoin lineJoin)
+        {
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray);
+
+            var actualStrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
+            var actualPoints = this.GetActualPointsForStreamGeometry(points, actualStrokeThickness, edgeRenderingMode);
+
+            var streamGeometry = new StreamGeometry();
+            using (var streamGeometryContext = streamGeometry.Open())
+            {
+                streamGeometryContext.BeginFigure(actualPoints.Item1, false, false);
+                streamGeometryContext.PolyLineTo(actualPoints.Item2, !stroke.IsUndefined(), true);
+            }
+
+            path.Data = streamGeometry;
         }
 
         ///<inheritdoc/>
@@ -924,15 +963,15 @@ namespace OxyPlot.Wpf
             this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
 
             var actualStrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
-            var actualPoints = this.GetActualPoints(points, actualStrokeThickness, edgeRenderingMode).ToList();
+            var actualPoints = this.GetActualPointsForStreamGeometry(points, actualStrokeThickness, edgeRenderingMode);
 
             var streamGeometry = new StreamGeometry();
             using (var streamGeometryContext = streamGeometry.Open())
             {
-                streamGeometryContext.BeginFigure(actualPoints[0], false, false);
-                for (int i = 1; i < actualPoints.Count; i++)
+                streamGeometryContext.BeginFigure(actualPoints.Item1, false, false);
+                for (int i = 0; i < actualPoints.Item2.Count; i++)
                 {
-                    streamGeometryContext.LineTo(actualPoints[i], (i & 0x1) != 0, false);
+                    streamGeometryContext.LineTo(actualPoints.Item2[i], (i & 0x1) == 0, false);
                 }
             }
             path.Data = streamGeometry;
@@ -1168,6 +1207,39 @@ namespace OxyPlot.Wpf
                     return points.Select(p => PixelLayout.Snap(p.X, p.Y, strokeThickness, this.VisualOffset, this.DpiScale));
                 default:
                     return points.Select(p => new Point(p.X, p.Y));
+            }
+        }
+
+        /// <summary>
+        /// Snaps points to pixels if required by the edge rendering mode.
+        /// </summary>
+        /// <param name="points">The points.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The processed points.</returns>
+        private Tuple<Point, IList<Point>> GetActualPointsForStreamGeometry(IList<ScreenPoint> points, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (points.Count < 1)
+            {
+                return Tuple.Create(new Point(), (IList<Point>)new Point[0]);
+            }
+            var pointsList = new Point[points.Count - 1];
+            switch (edgeRenderingMode)
+            {
+                case EdgeRenderingMode.Adaptive when RenderContextBase.IsStraightLine(points):
+                case EdgeRenderingMode.Automatic when RenderContextBase.IsStraightLine(points):
+                case EdgeRenderingMode.PreferSharpness:
+                    for (int i = 0; i < pointsList.Length; i++)
+                    {
+                        pointsList[i] = PixelLayout.Snap(points[i + 1].X, points[i + 1].Y, strokeThickness, this.VisualOffset, this.DpiScale);
+                    }
+                    return Tuple.Create(PixelLayout.Snap(points[0].X, points[0].Y, strokeThickness, this.VisualOffset, this.DpiScale), (IList<Point>)pointsList);
+                default:
+                    for (int i = 0; i < pointsList.Length; i++)
+                    {
+                        pointsList[i] = new Point(points[i + 1].X, points[i + 1].Y);
+                    }
+                    return Tuple.Create(new Point(points[0].X, points[0].Y), (IList<Point>)pointsList);
             }
         }
 

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -363,6 +363,12 @@ namespace OxyPlot.Wpf
         ///<inheritdoc/>
         public void DrawRectangle(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
+            if (this.UseStreamGeometry)
+            {
+                this.DrawRectangleByStreamGeometry(rect, fill, stroke, thickness, edgeRenderingMode);
+                return;
+            }
+
             var e = this.CreateAndAdd<Path>();
             this.SetStroke(e, stroke, thickness, edgeRenderingMode);
 
@@ -379,6 +385,12 @@ namespace OxyPlot.Wpf
         ///<inheritdoc/>
         public void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
+            if (this.UseStreamGeometry)
+            {
+                this.DrawRectanglesByStreamGeometry(rectangles, fill, stroke, thickness, edgeRenderingMode);
+                return;
+            }
+
             var path = this.CreateAndAdd<Path>();
             this.SetStroke(path, stroke, thickness, edgeRenderingMode);
             if (!fill.IsUndefined())
@@ -393,6 +405,70 @@ namespace OxyPlot.Wpf
             }
 
             path.Data = gg;
+        }
+
+        /// <summary>
+        /// Draws a collection of rectangles, where all have the same stroke and fill.
+        /// This performs better than calling DrawRectangle multiple times.
+        /// </summary>
+        /// <param name="rectangle">The rectangle.</param>
+        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be filled.</param>
+        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be stroked.</param>
+        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        private void DrawRectangleByStreamGeometry(OxyRect rectangle, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
+            if (!fill.IsUndefined())
+            {
+                path.Fill = this.GetCachedBrush(fill);
+            }
+
+            var sg = new StreamGeometry { FillRule = FillRule.Nonzero };
+            using (var context = sg.Open())
+            {
+                this.DrawRectangleInContext(context, rectangle, !fill.IsUndefined(), !stroke.IsUndefined(), path.StrokeThickness, edgeRenderingMode);
+            }
+
+            path.Data = sg;
+        }
+
+        /// <summary>
+        /// Draws a collection of rectangles, where all have the same stroke and fill.
+        /// This performs better than calling DrawRectangle multiple times.
+        /// </summary>
+        /// <param name="rectangles">The rectangles.</param>
+        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be filled.</param>
+        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be stroked.</param>
+        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        private void DrawRectanglesByStreamGeometry(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
+            if (!fill.IsUndefined())
+            {
+                path.Fill = this.GetCachedBrush(fill);
+            }
+
+            var sg = new StreamGeometry { FillRule = FillRule.Nonzero };
+            using (var context = sg.Open())
+            {
+                foreach (var rect in rectangles)
+                {
+                    this.DrawRectangleInContext(context, rect, !fill.IsUndefined(), !stroke.IsUndefined(), path.StrokeThickness, edgeRenderingMode);
+                }
+            }
+
+            path.Data = sg;
+        }
+
+        private void DrawRectangleInContext(StreamGeometryContext context, OxyRect rect, bool isFilled, bool isStroked, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            var r = this.GetActualRect(rect, strokeThickness, edgeRenderingMode);
+            context.BeginFigure(r.TopLeft, isFilled, true);
+            context.PolyLineTo(new[] { r.TopRight, r.BottomRight, r.BottomLeft}, isStroked, true);
         }
 
         /// <summary>

--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -82,6 +82,7 @@ namespace OxyPlot.Wpf
         /// <inheritdoc/>
         protected override void RenderOverride()
         {
+            RenderContext.TextMeasurementMethod = TextMeasurementMethod;
             if (this.DisconnectCanvasWhileUpdating)
             {
                 // TODO: profile... not sure if this makes any difference
@@ -124,6 +125,23 @@ namespace OxyPlot.Wpf
             var exporter = new PngExporter() { Width = (int)this.ActualWidth, Height = (int)this.ActualHeight };
             var bitmap = exporter.ExportToBitmap(this.ActualModel);
             Clipboard.SetImage(bitmap);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="TextMeasurementMethod"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty TextMeasurementMethodProperty =
+            DependencyProperty.Register(
+                nameof(TextMeasurementMethod), typeof(TextMeasurementMethod), typeof(PlotViewBase), new PropertyMetadata(TextMeasurementMethod.TextBlock));
+
+        /// <summary>
+        /// Gets or sets the vertical zoom cursor.
+        /// </summary>
+        /// <value>The zoom vertical cursor.</value>
+        public TextMeasurementMethod TextMeasurementMethod
+        {
+            get => (TextMeasurementMethod)this.GetValue(TextMeasurementMethodProperty);
+            set => this.SetValue(TextMeasurementMethodProperty, value);
         }
     }
 }


### PR DESCRIPTION
### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)
I have kept the history as separate commits to try and make the review easier.

### Changes proposed in this pull request:

- Refactor the implementation of DrawLineSegmentsByStreamGeometry() by making a single figure, and applying the stroke to only every other segment. This removes many expensive calls to BeginFigure(), and speeds up the rendering of axes ticks, grids, and some of the markers.
- Add implementations of DrawRectangle(), DrawRectangles(), and DrawEllipses() using a StreamGeometry. This speeds up the rendering significantly when using Square or Circle markers.
- Add a property to allow changing the TextMeasurementMethod at runtime. This can help reduce the rendering time.
- Implement a DrawLineUsingStreamGeometry. The code itself is not really faster than using a Polyline, but again the rendering time is shorter. There is also a new GetActualPointsForStreamGeometry() to create an IList<Point> ready to be used by StreamGeometryContext.PloyLineTo(). The alternatives are to either call LineTo multiple times, or 2 calls to the Linq ToList() extension.
- I am still trying to assess what DrawLineBalanced actually does differently; but it has a really significant impact on speed as well (5.6 times for the C#, plus the rendering time). Incidentally I am wondering whether the MaxFiguresPerGeometry is still relevant. Removing these could allow further speed improvements.

@oxyplot/admins
