### PR TITLE
SkiaSharp SvgExporter supports PlotModel.Background (#1619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ All notable changes to this project will be documented in this file.
 - Auto margins are set incorrectly if Axis.TitleFontSize is set to non-default value (related to #1577)
 - Incomplete rendering of AreaSeries in some situations (#1512)
 - ColumnSeries / BarSeries not working with more than one value-axis (#729)
+- OxyPlot.SkiaSharp.SvgExporter plot background color (#1619)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
@@ -40,5 +40,16 @@ namespace OxyPlot.SkiaSharp.Tests
             this.outputDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, SVG_FOLDER);
             Directory.CreateDirectory(this.outputDirectory);
         }
+
+        [Test]
+        public void BackgroundColor()
+        {
+            var model = ShowCases.CreateNormalDistributionModel();
+            model.Background = OxyColors.AliceBlue;
+            var exporter = new SvgExporter { Width = 1000, Height = 750 };
+            using var stream = File.Create(Path.Combine(this.outputDirectory, "Background.svg"));
+            exporter.Export(model, stream);
+        }
+
     }
 }

--- a/Source/OxyPlot.SkiaSharp/SvgExporter.cs
+++ b/Source/OxyPlot.SkiaSharp/SvgExporter.cs
@@ -30,6 +30,12 @@ namespace OxyPlot.SkiaSharp
             using var skStream = new SKManagedWStream(stream);
             using var writer = new SKXmlStreamWriter(skStream);
             using var canvas = SKSvgCanvas.Create(new SKRect(0, 0, this.Width, this.Height), writer);
+
+            if (!model.Background.IsInvisible())
+            {
+                canvas.Clear(model.Background.ToSKColor());
+            }
+
             // SVG export does not work with UseTextShaping=true. However SVG does text shaping by itself anyway, so we can just disable it
             using var context = new SkiaRenderContext { RenderTarget = RenderTarget.VectorGraphic, SkCanvas = canvas, UseTextShaping = false };
             model.Update(true);


### PR DESCRIPTION
Fixes #1619 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add support for the plot model background in OxyPlot.SkiaSharp.SvgExporter by clearing the render canvas with the plot model background if it is not invisible.
    The `Clear` command adds a full-extent rectangle to the XML
- Adds a corresponding test

@oxyplot/admins
