### PR TITLE
Don't clip zero-crossing axis lines within plot bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ All notable changes to this project will be documented in this file.
 - Incomplete rendering of AreaSeries in some situations (#1512)
 - ColumnSeries / BarSeries not working with more than one value-axis (#729)
 - OxyPlot.SkiaSharp.SvgExporter plot background color (#1619)
+- Don't clip zerocrossing axis lines within plot bounds (#1441)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -2097,7 +2097,7 @@ namespace ExampleLibrary
             return plot;
         }
 
-        [Example("#1441: Zero crossing quadrant axes disappear on zoom and pan")]
+        [Example("#1441: Zero crossing quadrant axes disappear on zoom and pan (Closed)")]
         public static PlotModel ZeroCrossingQuadrantAxes()
         {
             var plot = new PlotModel() { Title = "Zoom or Pan axes to make them disappear" };
@@ -2283,6 +2283,7 @@ namespace ExampleLibrary
 
             return plot;
         }
+
         [Example("#1512: FindWindowStartIndex.")]
         public static PlotModel FindWindowsStartIndex()
         {
@@ -2312,6 +2313,48 @@ namespace ExampleLibrary
             
             plotModel1.Series.Add(areaSeries);
           
+
+            return plotModel1;
+        }
+
+        [Example("#1441: Near-border axis line clipping (Closed)")]
+        public static PlotModel ZeroCrossingWithInsertHorizontalAxisAndTransparentBorder()
+        {
+            var plotModel1 = new PlotModel
+            {
+                Title = "PositionAtZeroCrossing = true",
+                Subtitle = "Horizontal axis StartPosition = 0.1 End Position = 0.9",
+                PlotAreaBorderThickness = new OxyThickness(5),
+                PlotAreaBorderColor = OxyColor.FromArgb(127, 127, 127, 127),
+                PlotMargins = new OxyThickness(10, 10, 10, 10)
+            };
+            plotModel1.Axes.Add(new LinearAxis
+            {
+                Minimum = -100,
+                Maximum = 100,
+                PositionAtZeroCrossing = true,
+                AxislineStyle = LineStyle.Solid,
+                TickStyle = TickStyle.Crossing
+            });
+            plotModel1.Axes.Add(new LinearAxis
+            {
+                Minimum = -100,
+                Maximum = 100,
+                Position = AxisPosition.Bottom,
+                PositionAtZeroCrossing = true,
+                AxislineStyle = LineStyle.Solid,
+                TickStyle = TickStyle.Crossing,
+                StartPosition = 0.9,
+                EndPosition = 0.1
+            });
+
+            var scatter = new ScatterSeries();
+            var rnd = new Random(0);
+            for (int i = 0; i < 100; i++)
+            {
+                scatter.Points.Add(new ScatterPoint(rnd.NextDouble() * 100 - 50, rnd.NextDouble() * 100 - 50));
+            }
+            plotModel1.Series.Add(scatter);
 
             return plotModel1;
         }

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -75,8 +75,12 @@ namespace OxyPlot.Axes
                 // the axis should be positioned at the origin of the perpendicular axis
                 axisPosition = perpendicularAxis.Transform(0);
 
-                var p0 = perpendicularAxis.Transform(perpendicularAxis.ActualMinimum);
-                var p1 = perpendicularAxis.Transform(perpendicularAxis.ActualMaximum);
+                var p0 = axis.IsHorizontal()
+                    ? perpendicularAxis.ScreenMin.X
+                    : perpendicularAxis.ScreenMin.Y;
+                var p1 = axis.IsHorizontal()
+                    ? perpendicularAxis.ScreenMax.X
+                    : perpendicularAxis.ScreenMax.Y;
 
                 // find the min/max positions
                 var min = Math.Min(p0, p1);
@@ -98,8 +102,7 @@ namespace OxyPlot.Axes
                     var borderPosition = axis.IsHorizontal()
                         ? this.Plot.PlotArea.Top
                         : this.Plot.PlotArea.Left;
-                    // small 0.00001 term compensates for floating point inaccuracies in computing axis' bounds
-                    if (axisPosition <= borderPosition + 0.00001 && borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
+                    if (axisPosition <= borderPosition && borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
                     {
                         // there is already a line here...
                         drawAxisLine = false;
@@ -116,8 +119,7 @@ namespace OxyPlot.Axes
                     var borderPosition = axis.IsHorizontal()
                         ? this.Plot.PlotArea.Bottom
                         : this.Plot.PlotArea.Right;
-                    // small 0.00001 term compensates for floating point inaccuracies in computing axis' bounds
-                    if (axisPosition >= borderPosition - 0.00001 && borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
+                    if (axisPosition >= borderPosition && borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
                     {
                         // there is already a line here...
                         drawAxisLine = false;

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -95,7 +95,11 @@ namespace OxyPlot.Axes
                     var borderThickness = axis.IsHorizontal()
                         ? this.Plot.PlotAreaBorderThickness.Top
                         : this.Plot.PlotAreaBorderThickness.Left;
-                    if (borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
+                    var borderPosition = axis.IsHorizontal()
+                        ? this.Plot.PlotArea.Top
+                        : this.Plot.PlotArea.Left;
+                    // small 0.00001 term compensates for floating point inaccuracies in computing axis' bounds
+                    if (axisPosition <= borderPosition + 0.00001 && borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
                     {
                         // there is already a line here...
                         drawAxisLine = false;
@@ -109,7 +113,11 @@ namespace OxyPlot.Axes
                     var borderThickness = axis.IsHorizontal()
                         ? this.Plot.PlotAreaBorderThickness.Bottom
                         : this.Plot.PlotAreaBorderThickness.Right;
-                    if (borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
+                    var borderPosition = axis.IsHorizontal()
+                        ? this.Plot.PlotArea.Bottom
+                        : this.Plot.PlotArea.Right;
+                    // small 0.00001 term compensates for floating point inaccuracies in computing axis' bounds
+                    if (axisPosition >= borderPosition - 0.00001 && borderThickness > 0 && this.Plot.PlotAreaBorderColor.IsVisible())
                     {
                         // there is already a line here...
                         drawAxisLine = false;


### PR DESCRIPTION
Fixes #1441 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Only clips zero-crossing axes which are on the plot bounds, fixing an issue where the ticks would be repositioned to the axis minimum, but the line would be removed, when the minimum was not on the plot bounds
- Swaps the minimum computation to a lookup of `ScreenMin/Max`, reducing issues with inaccuracies
- Adds an additional example to the existing example for #1441 showing the boundary behaviour on a single pair of axes

@aliridha1510
@oxyplot/admins
