### PR TITLE
Assign colors to invisible series (#1599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Native Clipping for OxyPlot.SvgRenderContext (#1564)
 - Examples of full plot area polar plots with non-zero minimums (#1586)
 - Read-Only collection interfaces for .NET 4.0 (#1600)
+- Add PlotModel.AssignColorsToInvisibleSeries property to control whether invisible series are included or skipped when assigning automatic colors (#1599)
 
 ### Changed
 - Legends model (#644)
@@ -57,6 +58,7 @@ All notable changes to this project will be documented in this file.
 - CategoryAxis should not contain rendering information about BarSeries (#741)
 - CategorizedSeries changed to BarSeriesBase<T> (#741)
 - System.Drawing.Common references updated to 4.7.0 (#1608)
+- Invisible series are assigned automatic colors by default, configurable with PlotModel.AssignColorsToInvisibleSeries property that defaults to true (#1599)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -128,6 +128,7 @@ namespace OxyPlot
             this.PlotAreaBorderThickness = new OxyThickness(1);
             this.EdgeRenderingMode = EdgeRenderingMode.Automatic;
 
+            this.AssignColorsToInvisibleSeries = true;
             this.IsLegendVisible = true;
 
             this.DefaultColors = new List<OxyColor>
@@ -251,6 +252,11 @@ namespace OxyPlot
         /// </summary>
         /// <value>The edge rendering mode. The default is <see cref="EdgeRenderingMode.Automatic"/>.</value>
         public EdgeRenderingMode EdgeRenderingMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether invisible series should be assigned automatic colors.
+        /// </summary>
+        public bool AssignColorsToInvisibleSeries { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the legend is visible. The titles of the series must be set to use the legend.
@@ -795,8 +801,12 @@ namespace OxyPlot
                     this.UpdateMaxMin(updateData);
 
                     // Update undefined colors
+                    var automaticColorSeries = this.AssignColorsToInvisibleSeries
+                        ? (IEnumerable<Series.Series>)this.Series
+                        : visibleSeries;
+
                     this.ResetDefaultColor();
-                    foreach (var s in visibleSeries)
+                    foreach (var s in automaticColorSeries)
                     {
                         s.SetDefaultValues();
                     }


### PR DESCRIPTION
Fixes #1599 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds a `bool AssignColorsToInvisibleSeries` property to `PlotModel` to determine whether invisible series should be assigned automatic colors
- Default for `AssignColorsToInvisibleSeries` is true, which is a breaking change, but I believe provides a significantly better experience when checking series on and off via the legend

Good existing examples are Bar Series > All in one, and Function Series > Lamé Curves.

@oxyplot/admins
