### PR TITLE
Account for MaximumPadding when computing ActualMinimum (#1625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ All notable changes to this project will be documented in this file.
 - Incomplete rendering of AreaSeries in some situations (#1512)
 - ColumnSeries / BarSeries not working with more than one value-axis (#729)
 - OxyPlot.SkiaSharp.SvgExporter plot background color (#1619)
+- MinimumPadding incorrect when MaximumPadding is non-zero (#1625)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1616,6 +1616,9 @@ namespace OxyPlot.Axes
         /// Calculates the actual maximum value of the axis, including the <see cref="MaximumPadding" />.
         /// </summary>
         /// <returns>The new actual maximum value of the axis.</returns>
+        /// <remarks>
+        /// Must be called before <see cref="CalculateActualMinimum" />
+        /// </remarks>
         protected virtual double CalculateActualMaximum()
         {
             var actualMaximum = this.DataMaximum;
@@ -1642,6 +1645,9 @@ namespace OxyPlot.Axes
         /// Calculates the actual minimum value of the axis, including the <see cref="MinimumPadding" />.
         /// </summary>
         /// <returns>The new actual minimum value of the axis.</returns>
+        /// <remarks>
+        /// Must be called after <see cref="CalculateActualMaximum" />
+        /// </remarks>
         protected virtual double CalculateActualMinimum()
         {
             var actualMinimum = this.DataMinimum;
@@ -1657,7 +1663,8 @@ namespace OxyPlot.Axes
             {
                 double x1 = this.PreTransform(this.ActualMaximum);
                 double x0 = this.PreTransform(actualMinimum);
-                double dx = this.MinimumPadding * (x1 - x0);
+                double existingPadding = this.MaximumPadding;
+                double dx = this.MinimumPadding * ((x1 - x0) / (1.0 + existingPadding));
                 return this.PostInverseTransform(x0 - dx);
             }
 


### PR DESCRIPTION
Fixes #1625 .

### Checklist

- [ ] I have included examples or tests (Axis example > Padding 10%)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix `CalculateActualMinimum` and add remarks about the order in which `CalculateActualMinimum` and `CalculateActualMaximum` should be called.

@oxyplot/admins
