### PR TITLE
Overlapping bar series (#1265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Native Clipping for OxyPlot.SvgRenderContext (#1564)
 - Examples of full plot area polar plots with non-zero minimums (#1586)
 - Read-Only collection interfaces for .NET 4.0 (#1600)
+- Overlapping bar series (#1265)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -909,6 +909,29 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("BaseValue (overlaping)")]
+        public static PlotModel BaseValueOverlaping()
+        {
+            var model = new PlotModel { Title = "BaseValue (overlaping)", Subtitle = "BaseValue = -1" };
+            var series1 = new BarSeries { Title = "Series 1", IsStacked = true, OverlapsStack = true, BaseValue = -1 };
+            series1.Items.Add(new BarItem { Value = 1 });
+            series1.Items.Add(new BarItem { Value = 2 });
+            model.Series.Add(series1);
+            var series2 = new BarSeries { Title = "Series 2", IsStacked = true, OverlapsStack = true, BaseValue = -1, BarWidth = 0.5 };
+            series2.Items.Add(new BarItem { Value = 4 });
+            series2.Items.Add(new BarItem { Value = 7 });
+            model.Series.Add(series2);
+
+            var categoryAxis = new CategoryAxis
+            {
+                Title = "Category",
+                Position = AxisPosition.Left
+            };
+            categoryAxis.Labels.AddRange(new[] { "A", "B" });
+            model.Axes.Add(categoryAxis);
+            return model;
+        }
+
         [Example("GapWidth 0%")]
         public static PlotModel GapWidth0()
         {
@@ -1015,12 +1038,18 @@ namespace ExampleLibrary
             s6.Items.Add(new BarItem { Value = 68 });
             s6.Items.Add(new BarItem { Value = 12 });
 
+            var s7 = new BarSeries { Title = "Series 7", IsStacked = true, OverlapsStack = true, StrokeColor = OxyColors.Black, StrokeThickness = 1, LabelFormatString = "{0:0}", LabelPlacement = LabelPlacement.Base, StackGroup = "3", BarWidth = 0.5 };
+            s7.Items.Add(new BarItem { Value = 10 });
+            s7.Items.Add(new BarItem { Value = 80 });
+            s7.Items.Add(new BarItem { Value = 100, CategoryIndex = categoryD });
+
             model.Series.Add(s1);
             model.Series.Add(s2);
             model.Series.Add(s3);
             model.Series.Add(s4);
             model.Series.Add(s5);
             model.Series.Add(s6);
+            model.Series.Add(s7);
             model.Axes.Add(categoryAxis);
             model.Axes.Add(valueAxis);
             return model;

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -67,6 +67,9 @@ namespace OxyPlot.Series
         /// <inheritdoc/>
         public bool IsStacked { get; set; }
 
+        /// <inheritdoc/>
+        public bool OverlapsStack { get; set; }
+
         /// <summary>
         /// Gets or sets the label format string.
         /// </summary>
@@ -198,7 +201,7 @@ namespace OxyPlot.Series
                     this.Manager.SetCurrentMinValue(stackIndex, i, minTemp);
 
                     var stackedMaxValue = this.Manager.GetCurrentMaxValue(stackIndex, i);
-                    if (!double.IsNaN(stackedMaxValue))
+                    if (!this.OverlapsStack && !double.IsNaN(stackedMaxValue))
                     {
                         maxTemp += stackedMaxValue;
                     }
@@ -380,7 +383,7 @@ namespace OxyPlot.Series
 
                 // Get base- and topValue
                 var baseValue = double.NaN;
-                if (this.IsStacked)
+                if (this.IsStacked && !this.OverlapsStack)
                 {
                     baseValue = this.Manager.GetCurrentBaseValue(stackIndex, categoryIndex, value < 0);
                 }

--- a/Source/OxyPlot/Series/BarSeries/ErrorBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/ErrorBarSeries.cs
@@ -82,7 +82,7 @@ namespace OxyPlot.Series
                     this.Manager.SetCurrentMinValue(stackIndex, i, minTemp);
 
                     var stackedMaxValue = this.Manager.GetCurrentMaxValue(stackIndex, i);
-                    if (!double.IsNaN(stackedMaxValue))
+                    if (!this.OverlapsStack && !double.IsNaN(stackedMaxValue))
                     {
                         maxTemp += stackedMaxValue;
                     }

--- a/Source/OxyPlot/Series/BarSeries/IStackableSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/IStackableSeries.cs
@@ -20,6 +20,11 @@ namespace OxyPlot.Series
         bool IsStacked { get; }
 
         /// <summary>
+        /// Gets a value indicating whether this series should overlap its stack when <see cref="IsStacked"/> is true.
+        /// </summary>
+        bool OverlapsStack { get; }
+
+        /// <summary>
         /// Gets the stack group.
         /// </summary>
         /// <value>The stack group.</value>

--- a/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
@@ -67,6 +67,9 @@ namespace OxyPlot.Series
         /// <inheritdoc/>
         public bool IsStacked => true;
 
+        /// <inheritdoc/>
+        public bool OverlapsStack => true;
+
         /// <summary>
         /// Gets or sets the label color.
         /// </summary>


### PR DESCRIPTION
Fixes #1265 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds an `OverlapsStack` property to `IStackableSeries` which determines whether a stacked series should overlaps its stack, with the effect that it is not integrating in the stack base position
- Adds a dedicated example, and an additional series to the 'All in one' example

I'm not convinced by the name `OverlapsStack`, but this is a simple way of implementing this.

### Outstanding concerns

 - Do we want this feature at all? It seemed like a good idea when I was implementing it, but I'm not sure it is now.

@oxyplot/admins
