### PR TITLE
Allows one-cell grid.

### DIFF
--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -173,9 +173,9 @@ namespace OxyPlot.Series
             {
                 double max = this.Data[0, 0];
                 double min = this.Data[0, 0];
-                for (int i = 0; i < this.Data.GetUpperBound(0); i++)
+                for (int i = 0; i =< this.Data.GetUpperBound(0); i++)
                 {
-                    for (int j = 0; j < this.Data.GetUpperBound(1); j++)
+                    for (int j = 0; j =< this.Data.GetUpperBound(1); j++)
                     {
                         max = Math.Max(max, this.Data[i, j]);
                         min = Math.Min(min, this.Data[i, j]);

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -173,9 +173,9 @@ namespace OxyPlot.Series
             {
                 double max = this.Data[0, 0];
                 double min = this.Data[0, 0];
-                for (int i = 0; i =< this.Data.GetUpperBound(0); i++)
+                for (int i = 0; i <= this.Data.GetUpperBound(0); i++)
                 {
-                    for (int j = 0; j =< this.Data.GetUpperBound(1); j++)
+                    for (int j = 0; j <= this.Data.GetUpperBound(1); j++)
                     {
                         max = Math.Max(max, this.Data[i, j]);
                         min = Math.Min(min, this.Data[i, j]);


### PR DESCRIPTION
Fixes a counting issue with a grid consisting of only one cell.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

An error is generated when the grid is completely horizontal. This is as expected, as no unique contours are then possible.

In a one-cell grid with a non-horizontal layout, the height is computed in only one corner of the cell, triggering above error because only a null height computation is then possible. With the proposed change, all corners of the cell are considered. So, if the cell is not horizontal, no error is generated.

In a normal, multicell application, the proposed change correctly calculates the total height, not discarding the last row nor the last column.   

See corresponding bug report #1634 and more examples with wrong and correct behavior in the file [png.zip](https://github.com/oxyplot/oxyplot/files/5019281/png.zip).


@oxyplot/admins
