### PR TITLE
LineSeries derivatives use ActualMarkerColor (#1630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - CategorizedSeries changed to BarSeriesBase<T> (#741)
 - System.Drawing.Common references updated to 4.7.0 (#1608)
 - Invisible series are assigned automatic colors by default, configurable with PlotModel.AssignColorsToInvisibleSeries property that defaults to true (#1599)
+- StemSeries, AreaSeries, TwoColorAreaSeries, and StairStepSeries use `ActualMarkerColor` (#1630)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/Examples/ExampleLibrary/Series/StemSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/StemSeriesExamples.cs
@@ -31,7 +31,6 @@ namespace ExampleLibrary
                              MarkerType = MarkerType.Circle,
                              MarkerSize = 6,
                              MarkerStroke = OxyColors.White,
-                             MarkerFill = OxyColors.SkyBlue,
                              MarkerStrokeThickness = 1.5
                          });
         }

--- a/Source/OxyPlot/Series/AreaSeries.cs
+++ b/Source/OxyPlot/Series/AreaSeries.cs
@@ -300,7 +300,7 @@ namespace OxyPlot.Series
                     this.MarkerType,
                     null,
                     markerSizes,
-                    this.MarkerFill,
+                    this.ActualMarkerFill,
                     this.MarkerStroke,
                     this.MarkerStrokeThickness,
                     this.EdgeRenderingMode,

--- a/Source/OxyPlot/Series/StairStepSeries.cs
+++ b/Source/OxyPlot/Series/StairStepSeries.cs
@@ -215,7 +215,7 @@ namespace OxyPlot.Series
                             this.MarkerType,
                             this.MarkerOutline,
                             new[] { this.MarkerSize },
-                            this.MarkerFill,
+                            this.ActualMarkerFill,
                             this.MarkerStroke,
                             this.MarkerStrokeThickness,
                             this.EdgeRenderingMode);

--- a/Source/OxyPlot/Series/StemSeries.cs
+++ b/Source/OxyPlot/Series/StemSeries.cs
@@ -164,7 +164,7 @@ namespace OxyPlot.Series
                     this.MarkerType,
                     this.MarkerOutline,
                     new[] { this.MarkerSize },
-                    this.MarkerFill,
+                    this.ActualMarkerFill,
                     this.MarkerStroke,
                     this.MarkerStrokeThickness,
                     this.EdgeRenderingMode);

--- a/Source/OxyPlot/Series/TwoColorAreaSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorAreaSeries.cs
@@ -195,7 +195,7 @@ namespace OxyPlot.Series
                 Reverse = false,
                 Color = this.ActualColor,
                 Fill = this.ActualFill,
-                MarkerFill = this.MarkerFill,
+                MarkerFill = this.ActualMarkerFill,
                 MarkerStroke = this.MarkerStroke,
                 DashArray = this.ActualDashArray,
                 Baseline = this.Limit
@@ -245,7 +245,7 @@ namespace OxyPlot.Series
                     this.MarkerType,
                     null,
                     markerSizes, 
-                    this.MarkerFill, 
+                    this.ActualMarkerFill, 
                     this.MarkerStroke,
                     this.MarkerStrokeThickness,
                     this.EdgeRenderingMode,


### PR DESCRIPTION
Fixes #1630

### Checklist

- [ ] I have included examples or tests (I've removed the redundant explicit marker color from the StemSeries example as an example)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change 4 derivatives of `LineSeries` to use the `LineSeries.ActualMarkerColor` when rendering markers

This improves consistency, makes it possible to use automatic colors for markers with these series, and makes it easier to use markers, as only the marker style needs to be specified for something to appear (all other `Marker*` properties have sane defaults).

@oxyplot/admins
