### PR TITLE
Add additional parameters for HistogramSeries LabelFormatString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Overlapping bar series (#1265)
 - `AxisPosition.All` for axes which need a margin on all sides of the plot area (#1574)
 - IRenderContext.ClipCount property (#1593)
+- Additional parameters for HistogramSeries LabelFormatString
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -62,6 +62,16 @@ namespace ExampleLibrary
             return HistogramLabelPlacement().ReverseYAxis();
         }
 
+        [Example("Label Format String")]
+        public static PlotModel LabelFormatString()
+        {
+            var model = CreateDisconnectedBins();
+            var hs = model.Series[0] as HistogramSeries;
+            hs.LabelFormatString = "Start: {1:0.00}\nEnd: {2:0.00}\nValue: {0:0.00}\nArea: {3:0.00}\nCount: {4}";
+            hs.LabelPlacement = LabelPlacement.Inside;
+            return model;
+        }
+
         [Example("Custom Bins")]
         public static PlotModel CustomBins()
         {

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -340,7 +340,7 @@ namespace OxyPlot.Series
         /// <param name="item">The item.</param>
         protected void RenderLabel(IRenderContext rc, OxyRect rect, HistogramItem item)
         {
-            var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, item.Value);
+            var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, item.Value, item.RangeStart, item.RangeEnd, item.Area, item.Count);
             DataPoint dp;
             VerticalAlignment va;
             var ha = HorizontalAlignment.Center;


### PR DESCRIPTION
 Adds additional parameters for `HistogramSeries.LabelFormatString`, so that e.g. the count can be displayed on the bar (per comment in #1644)

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add the Start, End, Area, and Count as parameters for `HistogramSeries.LabelFormatString`

When this goes through, I'll put a PR together to update the documentation.

@oxyplot/admins
