### PR TITLE
Optimize clipping calls #1661

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to this project will be documented in this file.
 - `AngleAxis` has position `AxisPosition.All` by default (#1574)
 - Clipping API changed from SetClip(...) and ResetClip() to PushClip(...) and PopClip() (#1593)
 - Remove TileMapAnnotation examples from automated testing (#1667)
+- Optimize clipping calls (#1661)
 
 ### Removed
 - Remove PlotModel.Legends (#644)
@@ -80,6 +81,8 @@ All notable changes to this project will be documented in this file.
 - Axis.UpdateFromSeries(...) and Series.UpdateValidData() (#741)
 - Support for IRenderContext implementations without native clipping (#1593)
 - CohenSutherlandClipping and SutherlandHodgmanClipping (#1593)
+- DrawClippedXxx(...) extensions in RenderingExtensions (#1661)
+- PathAnnotation.ClipText property - text is now always clipped (#1661)
 
 ### Fixed
 - Legend font size is not affected by DefaultFontSize (#1396)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to this project will be documented in this file.
 - Clipping API changed from SetClip(...) and ResetClip() to PushClip(...) and PopClip() (#1593)
 - Remove TileMapAnnotation examples from automated testing (#1667)
 - Optimize clipping calls (#1661)
+- Mark CandleStickAndVolumeSeries as obsolete (#1661)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotation.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotation.cs
@@ -105,8 +105,6 @@ namespace ExampleLibrary
         /// <param name="rc">The render context.</param>
         public override void Render(IRenderContext rc)
         {
-            base.Render(rc);
-
             var lon0 = this.XAxis.ActualMinimum;
             var lon1 = this.XAxis.ActualMaximum;
             var lat0 = this.YAxis.ActualMinimum;
@@ -166,7 +164,7 @@ namespace ExampleLibrary
                     var r = OxyRect.Create(s00.X, s00.Y, s11.X, s11.Y);
 
                     // draw the image
-                    rc.DrawClippedImage(clippingRectangle, img, r.Left, r.Top, r.Width, r.Height, this.Opacity, true);
+                    rc.DrawImage(img, r.Left, r.Top, r.Width, r.Height, this.Opacity, true);
                 }
             }
 

--- a/Source/Examples/ExampleLibrary/CustomSeries/ErrorSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/ErrorSeries.cs
@@ -72,8 +72,6 @@ namespace ExampleLibrary
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
-
             int n = points.Count;
 
             // Transform all points to screen coordinates
@@ -114,8 +112,7 @@ namespace ExampleLibrary
             // clip the line segments with the clipping rectangle
             for (int i = 0; i + 1 < segments.Count; i += 2)
             {
-                rc.DrawClippedLine(
-                    clippingRect,
+                rc.DrawReducedLine(
                     new[] { segments[i], segments[i + 1] },
                     2,
                     this.GetSelectableColor(this.Color),

--- a/Source/Examples/ExampleLibrary/CustomSeries/LineSegmentSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/LineSegmentSeries.cs
@@ -62,8 +62,6 @@ namespace ExampleLibrary
                 throw new InvalidOperationException("Axis has not been defined.");
             }
 
-            var clippingRect = this.GetClippingRect();
-
             var screenPoints = Points.Select(this.Transform).ToList();
             var verticalLines = new List<ScreenPoint>();
 
@@ -86,13 +84,13 @@ namespace ExampleLibrary
             {
                 if (this.LineStyle != LineStyle.None)
                 {
-                    rc.DrawClippedLineSegments(clippingRect, screenPoints, this.ActualColor, this.StrokeThickness, this.EdgeRenderingMode, this.LineStyle.GetDashArray(), this.LineJoin);
+                    rc.DrawLineSegments(screenPoints, this.ActualColor, this.StrokeThickness, this.EdgeRenderingMode, this.LineStyle.GetDashArray(), this.LineJoin);
                 }
 
-                rc.DrawClippedLineSegments(clippingRect, verticalLines, this.ActualColor, this.StrokeThickness / 3, this.EdgeRenderingMode, LineStyle.Dash.GetDashArray(), this.LineJoin);
+                rc.DrawLineSegments(verticalLines, this.ActualColor, this.StrokeThickness / 3, this.EdgeRenderingMode, LineStyle.Dash.GetDashArray(), this.LineJoin);
             }
 
-            rc.DrawMarkers(screenPoints, clippingRect, this.MarkerType, null, this.MarkerSize, this.MarkerFill, this.MarkerStroke, this.MarkerStrokeThickness, this.EdgeRenderingMode);
+            rc.DrawMarkers(screenPoints, this.MarkerType, null, this.MarkerSize, this.MarkerFill, this.MarkerStroke, this.MarkerStrokeThickness, this.EdgeRenderingMode);
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/CustomSeries/MatrixSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/MatrixSeries.cs
@@ -161,12 +161,11 @@ namespace ExampleLibrary
                 this.image = OxyImage.Create(pixels, ImageFormat.Png);
             }
 
-            var clip = this.GetClippingRect();
             var x0 = Math.Min(p0.X, p1.X);
             var y0 = Math.Min(p0.Y, p1.Y);
             var w = Math.Abs(p0.X - p1.X);
             var h = Math.Abs(p0.Y - p1.Y);
-            rc.DrawClippedImage(clip, this.image, x0, y0, w, h, 1, false);
+            rc.DrawImage(this.image, x0, y0, w, h, 1, false);
 
             var points = new List<ScreenPoint>();
             if (this.GridInterval > 0)
@@ -197,7 +196,7 @@ namespace ExampleLibrary
                 points.Add(this.Transform(n, m));
             }
 
-            rc.DrawClippedLineSegments(clip, points, this.GridColor, 1, this.EdgeRenderingMode, null, LineJoin.Miter);
+            rc.DrawLineSegments(points, this.GridColor, 1, this.EdgeRenderingMode, null, LineJoin.Miter);
 
             if (this.BorderColor.IsVisible())
             {
@@ -213,7 +212,7 @@ namespace ExampleLibrary
                         this.Transform(m, n)
                     };
 
-                rc.DrawClippedLineSegments(clip, borderPoints, this.BorderColor, 1, this.EdgeRenderingMode, null, LineJoin.Miter);
+                rc.DrawLineSegments(borderPoints, this.BorderColor, 1, this.EdgeRenderingMode, null, LineJoin.Miter);
             }
         }
 

--- a/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/PolarHeatMapSeries.cs
@@ -196,8 +196,7 @@ namespace OxyPlot.Series
             this.image = OxyImage.Create(p, ImageFormat.Png);
 
             // Render the image
-            var clip = this.GetClippingRect();
-            rc.DrawClippedImage(clip, this.image, dest.Left, dest.Top, dest.Width, dest.Height, 1, false);
+            rc.DrawImage(this.image, dest.Left, dest.Top, dest.Width, dest.Height, 1, false);
         }
 
         /// <summary>
@@ -287,8 +286,7 @@ namespace OxyPlot.Series
             }
 
             // Render the image
-            var clip = this.GetClippingRect();
-            rc.DrawClippedImage(clip, this.image, dest.Left, dest.Top, dest.Width, dest.Height, 1, false);
+            rc.DrawImage(this.image, dest.Left, dest.Top, dest.Width, dest.Height, 1, false);
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -807,7 +807,7 @@ namespace ExampleLibrary
 
             public override OxyRect GetClippingRect()
             {
-                return new OxyRect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
+                return OxyRect.Everything;
             }
         }
     }

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -804,7 +804,6 @@ namespace ExampleLibrary
             }
 
             /// <inheritdoc/>
-
             public override OxyRect GetClippingRect()
             {
                 return OxyRect.Everything;

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -802,6 +802,13 @@ namespace ExampleLibrary
                 base.Render(rc);
                 this.Rendering(rc);
             }
+
+            /// <inheritdoc/>
+
+            public override OxyRect GetClippingRect()
+            {
+                return new OxyRect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
+            }
         }
     }
 }

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -243,7 +243,6 @@ namespace ExampleLibrary
                 PlotAreaBorderColor = OxyColors.LightGray,
             };
 
-
             var distanceAxis = new LinearAxis
             {
                 Position = AxisPosition.Left,

--- a/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/MiscExamples.cs
@@ -23,6 +23,7 @@ namespace ExampleLibrary
     using OxyPlot.Axes;
     using OxyPlot.Series;
     using OxyPlot.Legends;
+    using System.Linq;
 
     [Examples("Misc")]
     public static class MiscExamples
@@ -239,19 +240,42 @@ namespace ExampleLibrary
                 Title = "Train schedule",
                 Subtitle = "Bergensbanen (Oslo-Bergen, Norway)",
                 IsLegendVisible = false,
-                PlotAreaBorderThickness = new OxyThickness(0),
-                PlotMargins = new OxyThickness(60, 4, 60, 40)
+                PlotAreaBorderColor = OxyColors.LightGray,
             };
-            model.Axes.Add(
-                new LinearAxis
-                {
-                    Position = AxisPosition.Left,
-                    Minimum = -20,
-                    Maximum = 540,
-                    Title = "Distance from Oslo S",
-                    IsAxisVisible = true,
-                    StringFormat = "0"
-                });
+
+
+            var distanceAxis = new LinearAxis
+            {
+                Position = AxisPosition.Left,
+                Minimum = -20,
+                Maximum = 540,
+                Title = "Distance from Oslo S",
+                IsAxisVisible = true,
+                StringFormat = "0",
+            };
+
+            model.Axes.Add(distanceAxis);
+
+            var stationAxis = new CustomAxis
+            {
+                MajorGridlineStyle = LineStyle.Solid,
+                MajorGridlineColor = OxyColors.LightGray,
+                Minimum = distanceAxis.Minimum,
+                Maximum = distanceAxis.Maximum,
+                Position = AxisPosition.Right,
+                IsPanEnabled = false,
+                IsZoomEnabled = false,
+                MajorTickSize = 0,
+            };
+
+            distanceAxis.AxisChanged += (sender, e) =>
+            {
+                stationAxis.Minimum = distanceAxis.ActualMinimum;
+                stationAxis.Maximum = distanceAxis.ActualMaximum;
+            };
+
+            model.Axes.Add(stationAxis);
+
             model.Axes.Add(
                 new TimeSpanAxis
                 {
@@ -315,23 +339,8 @@ namespace ExampleLibrary
                     double x = double.Parse(fields[1], CultureInfo.InvariantCulture);
                     if (!string.IsNullOrEmpty(fields[0]))
                     {
-                        // Add a horizontal annotation line for the station
-                        model.Annotations.Add(
-                            new LineAnnotation
-                            {
-                                Type = LineAnnotationType.Horizontal,
-                                Y = x,
-                                Layer = AnnotationLayer.BelowSeries,
-                                LineStyle = LineStyle.Solid,
-                                Color = OxyColors.LightGray,
-                                Text = fields[0] + "  ",
-                                TextVerticalAlignment = VerticalAlignment.Middle,
-                                TextLinePosition = 1,
-                                TextMargin = 0,
-                                TextPadding = 4,
-                                ClipText = false,
-                                TextHorizontalAlignment = HorizontalAlignment.Left
-                            });
+                        stationAxis.MajorTicks.Add(x);
+                        stationAxis.Labels.Add(fields[0]);
                     }
 
                     for (int i = 0; i < series.Length; i++)
@@ -388,23 +397,6 @@ namespace ExampleLibrary
 
             return model;
         }
-
-        /*        [Example("World population")]
-                public static PlotModel WorldPopulation()
-                {
-                    WorldPopulationDataSet dataSet;
-                    using (var stream = GetResourceStream("WorldPopulation.xml"))
-                    {
-                        var serializer = new XmlSerializer(typeof(WorldPopulationDataSet));
-                        dataSet = (WorldPopulationDataSet)serializer.Deserialize(stream);
-                    }
-
-                    var model = new PlotModel { Title = "World population" };
-                    model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "millions" });
-                    var series1 = new LineSeries { ItemsSource = dataSet.Items, DataFieldX = "Year", DataFieldY = "Population", StrokeThickness = 3, MarkerType = MarkerType.Circle };
-                    model.Series.Add(series1);
-                    return model;
-                }*/
 
         [Example("La Linea (AreaSeries)")]
         public static PlotModel LaLineaAreaSeries()
@@ -2382,21 +2374,23 @@ namespace ExampleLibrary
             }
         }
 
-        /*        [XmlRoot("DataSet")]
-                [XmlInclude(typeof(Data))]
-                public class WorldPopulationDataSet
-                {
-                    [XmlElement("Data")]
-                    public List<Data> Items { get; set; }
+        private class CustomAxis : LinearAxis
+        {
+            public IList<double> MajorTicks { get; } = new List<double>();
+            public IList<double> MinorTicks { get; } = new List<double>();
+            public IList<string> Labels { get; } = new List<string>();
 
-                    public class Data
-                    {
-                        [XmlAttribute("Year")]
-                        public int Year { get; set; }
+            public override void GetTickValues(out IList<double> majorLabelValues, out IList<double> majorTickValues, out IList<double> minorTickValues)
+            {
+                majorTickValues = majorLabelValues = this.MajorTicks.Where(d => d >= this.ActualMinimum && d <= this.ActualMaximum).ToList();
+                minorTickValues = this.MinorTicks.Where(d => d >= this.ActualMinimum && d <= this.ActualMaximum).ToList();
+            }
 
-                        [XmlAttribute("Population")]
-                        public double Population { get; set; }
-                    }
-                }*/
+            protected override string FormatValueOverride(double x)
+            {
+                return this.Labels[this.MajorTicks.IndexOf(x)];
+            }
+        }
+
     }
 }

--- a/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
+++ b/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
@@ -55,7 +55,6 @@ namespace ExampleLibrary.Utilities
         /// </summary>
         private static readonly HashSet<Type> NonTransposableDataSpaceAnnotationTypes = new HashSet<Type>
         {
-            typeof(TileMapAnnotation),
         };
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
+++ b/Source/Examples/ExampleLibrary/Utilities/PlotModelUtilities.cs
@@ -89,18 +89,8 @@ namespace ExampleLibrary.Utilities
         {
             return (model.Axes.Count > 0 || model.Series.Count > 0)
                 && model.Axes.All(a => a.Position != AxisPosition.None)
-                && model.Series.All(s =>
-                {
-                    var type = s.GetType();
-                    return s is XYAxisSeries
-                           && type.GetTypeInfo().Assembly == typeof(PlotModel).GetTypeInfo().Assembly
-                           && !NonTransposableSeriesTypes.Contains(type);
-                })
-                && model.Annotations.All(a =>
-                {
-                    var type = a.GetType();
-                    return !NonTransposableDataSpaceAnnotationTypes.Contains(type);
-                });
+                && model.Series.All(s => s is ITransposablePlotElement && !NonTransposableSeriesTypes.Contains(s.GetType()))
+                && model.Annotations.All(a => a is ITransposablePlotElement && !NonTransposableDataSpaceAnnotationTypes.Contains(a.GetType()));
         }
 
         /// <summary>

--- a/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
+++ b/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
@@ -93,43 +93,5 @@ namespace OxyPlot.Tests
                 }
             }
         }
-
-        [Test]
-        public void Export_BoundedTest()
-        {
-            const string DestinationDirectory = "SvgExporterTests_Meh";
-            if (!Directory.Exists(DestinationDirectory))
-            {
-                Directory.CreateDirectory(DestinationDirectory);
-            }
-
-            var fileName = "BoundedTest";
-            var path = Path.Combine(DestinationDirectory, FileNameUtilities.CreateValidFileName(fileName, ".svg"));
-
-            var width = 550;
-            var height = 550;
-            var whole = new OxyRect(0, 0, width, height);
-
-            var rect = new OxyRect(50, 50, 400, 400);
-            //var model = ExampleLibrary.PolarPlotExamples.ArchimedeanSpiral();
-            var model = ExampleLibrary.AxisExamples.PositionTier();
-            model.Title = "Title";
-            model.Subtitle = "SubTitle";
-            model.PlotAreaBorderColor = OxyColors.Black;
-            model.PlotAreaBorderThickness = new OxyThickness(1.0);
-            var textMeasurer = new PdfRenderContext(width, height, model.Background);
-            
-            using (var stream = new FileStream(path, FileMode.Create))
-            using (var rc = new SvgRenderContext(stream, width, height, false, textMeasurer, model.Background, true))
-            {
-                ((IPlotModel)model).Update(true);
-                ((IPlotModel)model).Render(rc, rect);
-                rc.DrawClippedRectangle(whole, rect.Inflate(2.0, 2.0), OxyColors.Transparent, OxyColors.Blue, 1.0, EdgeRenderingMode.Adaptive);
-                rc.DrawClippedRectangle(whole, model.PlotBounds, OxyColors.Transparent, OxyColors.Black, 1.0, EdgeRenderingMode.Adaptive);
-                rc.DrawClippedRectangle(whole, whole, OxyColors.Transparent, OxyColors.Black, 1.0, EdgeRenderingMode.Adaptive);
-                rc.Complete();
-                rc.Flush();
-            }
-        }
     }
 }

--- a/Source/OxyPlot/Annotations/Annotation.cs
+++ b/Source/OxyPlot/Annotations/Annotation.cs
@@ -14,7 +14,7 @@ namespace OxyPlot.Annotations
     /// <summary>
     /// Provides an abstract base class for annotations.
     /// </summary>
-    public abstract class Annotation : PlotElement, ITransposablePlotElement
+    public abstract class Annotation : PlotElement, IXyAxisPlotElement
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Annotation" /> class.
@@ -84,39 +84,46 @@ namespace OxyPlot.Annotations
         {
         }
 
-        /// <summary>
-        /// Gets the clipping rectangle.
-        /// </summary>
-        /// <returns>
-        /// The clipping rectangle.
-        /// </returns>
-        public virtual OxyRect GetClippingRect()
+        /// <inheritdoc/>
+        public override OxyRect GetClippingRect()
         {
             var rect = this.PlotModel.PlotArea;
-            var axisRect = this.GetAxisClippingRect();
+            var axisRect = PlotElementUtilities.GetClippingRect(this);
 
-            var minX = double.NegativeInfinity;
+            var minX = 0d;
             var maxX = double.PositiveInfinity;
-            var minY = double.NegativeInfinity;
+            var minY = 0d;
             var maxY = double.PositiveInfinity;
 
             if (this.ClipByXAxis)
             {
-                minX = this.Orientate(axisRect.TopLeft).X;
-                maxX = this.Orientate(axisRect.BottomRight).X;
+                minX = axisRect.TopLeft.X;
+                maxX = axisRect.BottomRight.X;
             }
 
             if (this.ClipByYAxis)
             {
-                minY = this.Orientate(axisRect.TopLeft).Y;
-                maxY = this.Orientate(axisRect.BottomRight).Y;
+                minY = axisRect.TopLeft.Y;
+                maxY = axisRect.BottomRight.Y;
             }
 
-            var minPoint = this.Orientate(new ScreenPoint(minX, minY));
-            var maxPoint = this.Orientate(new ScreenPoint(maxX, maxY));
+            var minPoint = new ScreenPoint(minX, minY);
+            var maxPoint = new ScreenPoint(maxX, maxY);
 
             var axisClipRect = new OxyRect(minPoint, maxPoint);
             return rect.Clip(axisClipRect);
+        }
+
+        /// <inheritdoc/>
+        public virtual ScreenPoint Transform(DataPoint p)
+        {
+            return PlotElementUtilities.Transform(this, p);
+        }
+
+        /// <inheritdoc/>
+        public virtual DataPoint InverseTransform(ScreenPoint p)
+        {
+            return PlotElementUtilities.InverseTransform(this, p);
         }
     }
 }

--- a/Source/OxyPlot/Annotations/Annotation.cs
+++ b/Source/OxyPlot/Annotations/Annotation.cs
@@ -90,10 +90,10 @@ namespace OxyPlot.Annotations
         /// <returns>
         /// The clipping rectangle.
         /// </returns>
-        protected OxyRect GetClippingRect()
+        public virtual OxyRect GetClippingRect()
         {
             var rect = this.PlotModel.PlotArea;
-            var axisRect = TransposablePlotElementExtensions.GetClippingRect(this);
+            var axisRect = this.GetAxisClippingRect();
 
             var minX = double.NegativeInfinity;
             var maxX = double.PositiveInfinity;

--- a/Source/OxyPlot/Annotations/ArrowAnnotation.cs
+++ b/Source/OxyPlot/Annotations/ArrowAnnotation.cs
@@ -97,10 +97,7 @@ namespace OxyPlot.Annotations
         /// <value>The 'veeness'.</value>
         public double Veeness { get; set; }
 
-        /// <summary>
-        /// Renders the arrow annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
@@ -125,15 +122,13 @@ namespace OxyPlot.Annotations
             var p3 = p1 - (n * this.HeadWidth * this.StrokeThickness);
             var p4 = p1 + (d * this.Veeness * this.StrokeThickness);
 
-            var clippingRectangle = this.GetClippingRect();
             const double MinimumSegmentLength = 4;
 
             var dashArray = this.LineStyle.GetDashArray();
 
             if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
             {
-                rc.DrawClippedLine(
-                    clippingRectangle,
+                rc.DrawReducedLine(
                     new[] { this.screenStartPoint, p4 },
                     MinimumSegmentLength * MinimumSegmentLength,
                     this.GetSelectableColor(this.Color),
@@ -142,8 +137,7 @@ namespace OxyPlot.Annotations
                     dashArray,
                     this.LineJoin);
 
-                rc.DrawClippedPolygon(
-                    clippingRectangle,
+                rc.DrawReducedPolygon(
                     new[] { p3, this.screenEndPoint, p2, p4 },
                     MinimumSegmentLength * MinimumSegmentLength,
                     this.GetSelectableColor(this.Color),
@@ -196,8 +190,7 @@ namespace OxyPlot.Annotations
             }
 
             var textPoint = this.GetActualTextPosition(() => this.screenStartPoint);
-            rc.DrawClippedText(
-                clippingRectangle,
+            rc.DrawText(
                 textPoint,
                 this.Text,
                 this.ActualTextColor,

--- a/Source/OxyPlot/Annotations/EllipseAnnotation.cs
+++ b/Source/OxyPlot/Annotations/EllipseAnnotation.cs
@@ -48,21 +48,14 @@ namespace OxyPlot.Annotations
         /// </summary>
         public double Height { get; set; }
 
-        /// <summary>
-        /// Renders the polygon annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
 
             this.screenRectangle = new OxyRect(this.Transform(this.X - (this.Width / 2), this.Y - (this.Height / 2)), this.Transform(this.X + (this.Width / 2), this.Y + (this.Height / 2)));
 
-            // clip to the area defined by the axes
-            var clippingRectangle = this.GetClippingRect();
-
-            rc.DrawClippedEllipse(
-                clippingRectangle,
+            rc.DrawEllipse(
                 this.screenRectangle,
                 this.GetSelectableFillColor(this.Fill),
                 this.GetSelectableColor(this.Stroke),
@@ -73,8 +66,7 @@ namespace OxyPlot.Annotations
             {
                 var textPosition = this.GetActualTextPosition(() => this.screenRectangle.Center);
                 this.GetActualTextAlignment(out var ha, out var va);
-                rc.DrawClippedText(
-                    clippingRectangle,
+                rc.DrawText(
                     textPosition,
                     this.Text,
                     this.ActualTextColor,

--- a/Source/OxyPlot/Annotations/ImageAnnotation.cs
+++ b/Source/OxyPlot/Annotations/ImageAnnotation.cs
@@ -104,10 +104,7 @@ namespace OxyPlot.Annotations
         /// <value>The vertical alignment.</value>
         public VerticalAlignment VerticalAlignment { get; set; }
 
-        /// <summary>
-        /// Renders the image annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
@@ -115,8 +112,6 @@ namespace OxyPlot.Annotations
             var p = this.GetPoint(this.X, this.Y, this.PlotModel);
             var o = this.GetVector(this.OffsetX, this.OffsetY, this.PlotModel);
             var position = p + o;
-
-            var clippingRectangle = this.GetClippingRect();
 
             var s = this.GetVector(this.Width, this.Height, this.PlotModel);
 
@@ -168,14 +163,7 @@ namespace OxyPlot.Annotations
 
             this.actualBounds = new OxyRect(x, y, width, height);
 
-            if (this.X.Unit == PlotLengthUnit.Data || this.Y.Unit == PlotLengthUnit.Data)
-            {
-                rc.DrawClippedImage(clippingRectangle, this.ImageSource, x, y, width, height, this.Opacity, this.Interpolate);
-            }
-            else
-            {
-                rc.DrawImage(this.ImageSource, x, y, width, height, this.Opacity, this.Interpolate);
-            }
+            rc.DrawImage(this.ImageSource, x, y, width, height, this.Opacity, this.Interpolate);
         }
 
         /// <summary>
@@ -309,6 +297,17 @@ namespace OxyPlot.Annotations
             }
 
             return new ScreenVector(xd, yd);
+        }
+
+        /// <inheritdoc/>
+        public override OxyRect GetClippingRect()
+        {
+            if (this.X.Unit == PlotLengthUnit.Data || this.Y.Unit == PlotLengthUnit.Data)
+            {
+                return base.GetClippingRect();
+            }
+
+            return new OxyRect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
         }
     }
 }

--- a/Source/OxyPlot/Annotations/ImageAnnotation.cs
+++ b/Source/OxyPlot/Annotations/ImageAnnotation.cs
@@ -14,7 +14,7 @@ namespace OxyPlot.Annotations
     /// <summary>
     /// Represents an annotation that shows an image.
     /// </summary>
-    public class ImageAnnotation : Annotation
+    public class ImageAnnotation : TransposableAnnotation
     {
         /// <summary>
         /// The actual bounds of the rendered image.
@@ -307,7 +307,7 @@ namespace OxyPlot.Annotations
                 return base.GetClippingRect();
             }
 
-            return new OxyRect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
+            return OxyRect.Everything;
         }
     }
 }

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -40,7 +40,6 @@ namespace OxyPlot.Annotations
             this.TextLinePosition = 1;
             this.TextOrientation = AnnotationTextOrientation.AlongLine;
             this.TextMargin = 12;
-            this.ClipText = true;
             this.TextHorizontalAlignment = HorizontalAlignment.Right;
             this.TextVerticalAlignment = VerticalAlignment.Top;
         }
@@ -116,12 +115,6 @@ namespace OxyPlot.Annotations
         public double TextLinePosition { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to clip the text within the plot area.
-        /// </summary>
-        /// <value><c>true</c> if text should be clipped within the plot area; otherwise, <c>false</c>.</value>
-        public bool ClipText { get; set; }
-
-        /// <summary>
         /// Gets or sets the actual minimum value on the x axis.
         /// </summary>
         /// <value>The actual minimum value on the x axis.</value>
@@ -145,10 +138,7 @@ namespace OxyPlot.Annotations
         /// <value>The actual maximum value on the y axis.</value>
         protected double ActualMaximumY { get; set; }
 
-        /// <summary>
-        /// Renders the annotation on the specified context.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
@@ -157,8 +147,6 @@ namespace OxyPlot.Annotations
 
             this.screenPoints = this.GetScreenPoints();
 
-            var clippingRectangle = this.GetClippingRect();
-
             const double MinimumSegmentLength = 4;
 
             var clippedPoints = new List<ScreenPoint>();
@@ -166,8 +154,7 @@ namespace OxyPlot.Annotations
 
             if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
             {
-                rc.DrawClippedLine(
-                   clippingRectangle,
+                rc.DrawReducedLine(
                    this.screenPoints,
                    MinimumSegmentLength * MinimumSegmentLength,
                    this.GetSelectableColor(this.Color),
@@ -239,33 +226,16 @@ namespace OxyPlot.Annotations
                         angle = this.TextRotation;
                     }
 
-                    if (this.ClipText)
-                    {
-                        rc.DrawClippedText(
-                            clippingRectangle,
-                            textPosition,
-                            this.Text,
-                            this.ActualTextColor,
-                            this.ActualFont,
-                            this.ActualFontSize,
-                            this.ActualFontWeight,
-                            angle,
-                            ha,
-                            va);
-                    }
-                    else
-                    {
-                        rc.DrawText(
-                           textPosition,
-                           this.Text,
-                           this.ActualTextColor,
-                           this.ActualFont,
-                           this.ActualFontSize,
-                           this.ActualFontWeight,
-                           angle,
-                           ha,
-                           va);
-                    }
+                    rc.DrawText(
+                        textPosition,
+                        this.Text,
+                        this.ActualTextColor,
+                        this.ActualFont,
+                        this.ActualFontSize,
+                        this.ActualFontWeight,
+                        angle,
+                        ha,
+                        va);
                 }
             }
         }

--- a/Source/OxyPlot/Annotations/PointAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PointAnnotation.cs
@@ -62,20 +62,14 @@ namespace OxyPlot.Annotations
         /// <value>A polyline. The default is <c>null</c>.</value>
         public ScreenPoint[] CustomOutline { get; set; }
 
-        /// <summary>
-        /// Renders the polygon annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
 
             this.screenPosition = this.Transform(this.X, this.Y);
 
-            // clip to the area defined by the axes
-            var clippingRectangle = this.GetClippingRect();
-
-            rc.DrawMarker(clippingRectangle, this.screenPosition, this.Shape, this.CustomOutline, this.Size, this.Fill, this.Stroke, this.StrokeThickness, this.EdgeRenderingMode);
+            rc.DrawMarker(this.screenPosition, this.Shape, this.CustomOutline, this.Size, this.Fill, this.Stroke, this.StrokeThickness, this.EdgeRenderingMode);
 
             if (!string.IsNullOrEmpty(this.Text))
             {
@@ -83,8 +77,7 @@ namespace OxyPlot.Annotations
                 var dx = -(int)ha * (this.Size + this.TextMargin);
                 var dy = -(int)va * (this.Size + this.TextMargin);
                 var textPosition = this.screenPosition + new ScreenVector(dx, dy);
-                rc.DrawClippedText(
-                    clippingRectangle,
+                rc.DrawText(
                     textPosition,
                     this.Text,
                     this.ActualTextColor,

--- a/Source/OxyPlot/Annotations/PolygonAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PolygonAnnotation.cs
@@ -51,10 +51,7 @@ namespace OxyPlot.Annotations
         /// <value>The points.</value>
         public List<DataPoint> Points { get; private set; }
 
-        /// <summary>
-        /// Renders the polygon annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
@@ -70,13 +67,9 @@ namespace OxyPlot.Annotations
                 return;
             }
 
-            // clip to the area defined by the axes
-            var clippingRectangle = this.GetClippingRect();
-
             const double MinimumSegmentLength = 4;
 
-            rc.DrawClippedPolygon(
-                clippingRectangle,
+            rc.DrawReducedPolygon(
                 this.screenPoints,
                 MinimumSegmentLength * MinimumSegmentLength,
                 this.GetSelectableFillColor(this.Fill),
@@ -91,8 +84,7 @@ namespace OxyPlot.Annotations
                 this.GetActualTextAlignment(out var ha, out var va);
                 var textPosition = this.GetActualTextPosition(() => ScreenPointHelper.GetCentroid(this.screenPoints));
 
-                rc.DrawClippedText(
-                    clippingRectangle,
+                rc.DrawText(
                     textPosition,
                     this.Text,
                     this.ActualTextColor,

--- a/Source/OxyPlot/Annotations/RectangleAnnotation.cs
+++ b/Source/OxyPlot/Annotations/RectangleAnnotation.cs
@@ -59,10 +59,7 @@ namespace OxyPlot.Annotations
         /// <value>The maximum Y.</value>
         public double MaximumY { get; set; }
 
-        /// <summary>
-        /// Renders the rectangle annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
@@ -79,8 +76,7 @@ namespace OxyPlot.Annotations
 
             this.screenRectangle = new OxyRect(this.Transform(x1, y1), this.Transform(x2, y2));
             
-            rc.DrawClippedRectangle(
-                clippingRectangle,
+            rc.DrawRectangle(
                 this.screenRectangle,
                 this.GetSelectableFillColor(this.Fill),
                 this.GetSelectableColor(this.Stroke),
@@ -94,8 +90,7 @@ namespace OxyPlot.Annotations
 
             this.GetActualTextAlignment(out var ha, out var va);
             var textPosition = this.GetActualTextPosition(() => this.screenRectangle.Center);
-            rc.DrawClippedText(
-                clippingRectangle,
+            rc.DrawText(
                 textPosition,
                 this.Text,
                 this.ActualTextColor,

--- a/Source/OxyPlot/Annotations/TextAnnotation.cs
+++ b/Source/OxyPlot/Annotations/TextAnnotation.cs
@@ -64,20 +64,16 @@ namespace OxyPlot.Annotations
         /// <value>The stroke thickness.</value>
         public double StrokeThickness { get; set; }
 
-        /// <summary>
-        /// Renders the text annotation.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             base.Render(rc);
 
             var position = this.Transform(this.TextPosition) + this.Orientate(this.Offset);
-            var clippingRectangle = this.GetClippingRect();
+
             var textSize = rc.MeasureText(this.Text, this.ActualFont, this.ActualFontSize, this.ActualFontWeight);
             this.GetActualTextAlignment(out var ha, out var va);
 
-            using var _ = rc.AutoResetClip(clippingRectangle);
             this.actualBounds = GetTextBounds(position, textSize, this.Padding, this.TextRotation, ha, va);
 
             if ((this.TextRotation % 90).Equals(0))
@@ -89,7 +85,6 @@ namespace OxyPlot.Annotations
             {
                 rc.DrawPolygon(this.actualBounds, this.Background, this.Stroke, this.StrokeThickness, this.EdgeRenderingMode);
             }
-
 
             rc.DrawMathText(
                 position,

--- a/Source/OxyPlot/Annotations/TextualAnnotation.cs
+++ b/Source/OxyPlot/Annotations/TextualAnnotation.cs
@@ -14,7 +14,7 @@ namespace OxyPlot.Annotations
     /// <summary>
     /// Provides an abstract base class for annotations that contains text.
     /// </summary>
-    public abstract class TextualAnnotation : Annotation
+    public abstract class TextualAnnotation : TransposableAnnotation
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TextualAnnotation"/> class.

--- a/Source/OxyPlot/Annotations/TransposableAnnotation.cs
+++ b/Source/OxyPlot/Annotations/TransposableAnnotation.cs
@@ -1,0 +1,56 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TransposableAnnotation.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Annotations
+{
+    /// <summary>
+    /// Provides an abstract base class for transposable annotations.
+    /// </summary>
+    public abstract class TransposableAnnotation : Annotation, ITransposablePlotElement
+    {
+        /// <inheritdoc/>
+        public override OxyRect GetClippingRect()
+        {
+            var rect = this.PlotModel.PlotArea;
+            var axisRect = PlotElementUtilities.GetOrientatedClippingRect(this);
+
+            var minX = 0d;
+            var maxX = double.PositiveInfinity;
+            var minY = 0d;
+            var maxY = double.PositiveInfinity;
+
+            if (this.ClipByXAxis)
+            {
+                minX = this.Orientate(axisRect.TopLeft).X;
+                maxX = this.Orientate(axisRect.BottomRight).X;
+            }
+
+            if (this.ClipByYAxis)
+            {
+                minY = this.Orientate(axisRect.TopLeft).Y;
+                maxY = this.Orientate(axisRect.BottomRight).Y;
+            }
+
+            var minPoint = this.Orientate(new ScreenPoint(minX, minY));
+            var maxPoint = this.Orientate(new ScreenPoint(maxX, maxY));
+
+            var axisClipRect = new OxyRect(minPoint, maxPoint);
+            return rect.Clip(axisClipRect);
+        }
+
+        /// <inheritdoc/>
+        public override ScreenPoint Transform(DataPoint p)
+        {
+            return PlotElementUtilities.TransformOrientated(this, p);
+        }
+
+        /// <inheritdoc/>
+        public override DataPoint InverseTransform(ScreenPoint p)
+        {
+            return PlotElementUtilities.InverseTransformOrientated(this, p);
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
@@ -261,6 +261,7 @@ namespace OxyPlot.Axes
 
             if (pass == 1)
             {
+                using var _ = this.RenderContext.AutoResetClip(new OxyRect(axis.ScreenMin, axis.ScreenMax));
                 foreach (var tickValue in this.MajorLabelValues)
                 {
                     this.RenderTickText(axis, tickValue, angleAxis);
@@ -383,8 +384,7 @@ namespace OxyPlot.Axes
 
 
             string text = axis.FormatValue(x);
-            this.RenderContext.DrawClippedMathText(
-                new OxyRect(axis.ScreenMin, axis.ScreenMax),
+            this.RenderContext.DrawMathText(
                 pt,
                 text,
                 axis.ActualTextColor,

--- a/Source/OxyPlot/Legends/Legend.Rendering.cs
+++ b/Source/OxyPlot/Legends/Legend.Rendering.cs
@@ -436,6 +436,11 @@ namespace OxyPlot.Legends
                 seriesToRender.Clear();
             };
 
+            if (!measureOnly)
+            {
+                rc.PushClip(rect);
+            }
+
             foreach (var g in itemGroupNames)
             {
                 var itemGroup = items.Where(i => i.SeriesGroupName == g);
@@ -524,6 +529,11 @@ namespace OxyPlot.Legends
                 }
 
                 renderItems();
+            }
+
+            if (!measureOnly)
+            {
+                rc.PopClip();
             }
 
             if (size.Width > 0)

--- a/Source/OxyPlot/PlotModel/IPlotElement.cs
+++ b/Source/OxyPlot/PlotModel/IPlotElement.cs
@@ -20,5 +20,11 @@ namespace OxyPlot
         /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
         /// <remarks>This method creates the hash code by reflecting the value of all public properties.</remarks>
         int GetElementHashCode();
+
+        /// <summary>
+        /// Gets the clipping rectangle.
+        /// </summary>
+        /// <returns>The clipping rectangle.</returns>
+        OxyRect GetClippingRect();
     }
 }

--- a/Source/OxyPlot/PlotModel/ITransposablePlotElement.cs
+++ b/Source/OxyPlot/PlotModel/ITransposablePlotElement.cs
@@ -9,27 +9,10 @@
 
 namespace OxyPlot
 {
-    using OxyPlot.Axes;
-
     /// <summary>
     /// The TransposablePlotElement interface.
     /// </summary>
-    public interface ITransposablePlotElement : IPlotElement
+    public interface ITransposablePlotElement : IXyAxisPlotElement
     {
-        /// <summary>
-        /// Gets the X axis.
-        /// </summary>
-        Axis XAxis { get; }
-
-        /// <summary>
-        /// Gets the Y axis.
-        /// </summary>
-        Axis YAxis { get; }
-
-        /// <summary>
-        /// Gets the clipping rectangle.
-        /// </summary>
-        /// <returns>The clipping rectangle.</returns>
-        OxyRect GetClippingRect();
     }
 }

--- a/Source/OxyPlot/PlotModel/ITransposablePlotElement.cs
+++ b/Source/OxyPlot/PlotModel/ITransposablePlotElement.cs
@@ -25,5 +25,11 @@ namespace OxyPlot
         /// Gets the Y axis.
         /// </summary>
         Axis YAxis { get; }
+
+        /// <summary>
+        /// Gets the clipping rectangle.
+        /// </summary>
+        /// <returns>The clipping rectangle.</returns>
+        OxyRect GetClippingRect();
     }
 }

--- a/Source/OxyPlot/PlotModel/IXyAxisPlotElement.cs
+++ b/Source/OxyPlot/PlotModel/IXyAxisPlotElement.cs
@@ -1,0 +1,40 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IXyAxisPlotElement.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot
+{
+    using OxyPlot.Axes;
+
+    /// <summary>
+    /// Defines a plot element that uses an X and a Y axis.
+    /// </summary>
+    public interface IXyAxisPlotElement : IPlotElement
+    {
+        /// <summary>
+        /// Gets the X axis.
+        /// </summary>
+        Axis XAxis { get; }
+
+        /// <summary>
+        /// Gets the Y axis.
+        /// </summary>
+        Axis YAxis { get; }
+
+        /// <summary>
+        /// Transforms the specified data point to a screen point by the axes of the plot element.
+        /// </summary>
+        /// <param name="p">The data point.</param>
+        /// <returns>A screen point.</returns>
+        ScreenPoint Transform(DataPoint p);
+
+        /// <summary>
+        /// Transforms from a screen point to a data point by the axes of this series.
+        /// </summary>
+        /// <param name="p">The screen point.</param>
+        /// <returns>A data point.</returns>
+        DataPoint InverseTransform(ScreenPoint p);
+    }
+}

--- a/Source/OxyPlot/PlotModel/PlotElement.cs
+++ b/Source/OxyPlot/PlotModel/PlotElement.cs
@@ -147,6 +147,12 @@ namespace OxyPlot
             }
         }
 
+        /// <inheritdoc/>
+        public virtual OxyRect GetClippingRect()
+        {
+            return OxyRect.Everything;
+        }
+
         /// <summary>
         /// Returns a hash code for this element.
         /// </summary>

--- a/Source/OxyPlot/PlotModel/PlotElementExtensions.cs
+++ b/Source/OxyPlot/PlotModel/PlotElementExtensions.cs
@@ -1,10 +1,7 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="TransposablePlotElementExtensions.cs" company="OxyPlot">
+// <copyright file="PlotElementExtensions.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
-// <summary>
-//   Defines the TransposablePlotElementExtensions type.
-// </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace OxyPlot
@@ -12,30 +9,18 @@ namespace OxyPlot
     /// <summary>
     /// The transposable plot element extensions.
     /// </summary>
-    public static class TransposablePlotElementExtensions
+    public static class PlotElementExtensions
     {
-        /// <summary>
-        /// Gets the clipping rectangle defined by the Axis the <see cref="ITransposablePlotElement"/> uses.
-        /// </summary>
-        /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
-        /// <returns>The clipping rectangle.</returns>
-        public static OxyRect GetAxisClippingRect(this ITransposablePlotElement element)
-        {
-            var p1 = new ScreenPoint(element.XAxis.ScreenMin.X, element.YAxis.ScreenMin.Y);
-            var p2 = new ScreenPoint(element.XAxis.ScreenMax.X, element.YAxis.ScreenMax.Y);
-            return new OxyRect(element.Orientate(p1), element.Orientate(p2));
-        }
-        
         /// <summary>
         /// Transforms from a screen point to a data point by the axes of this series.
         /// </summary>
         /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
-        /// <param name="p">The screen point.</param>
+        /// <param name="x">The x coordinate of the screen point.</param>
+        /// <param name="y">The y coordinate of the screen point.</param>
         /// <returns>A data point.</returns>
-        public static DataPoint InverseTransform(this ITransposablePlotElement element, ScreenPoint p)
+        public static DataPoint InverseTransform(this IXyAxisPlotElement element, double x, double y)
         {
-            p = element.Orientate(p);
-            return element.XAxis.InverseTransform(p.X, p.Y, element.YAxis);
+            return element.InverseTransform(new ScreenPoint(x, y));
         }
 
         /// <summary>
@@ -79,10 +64,7 @@ namespace OxyPlot
         /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
         /// <param name="ha">The <see cref="HorizontalAlignment" /> to orientate.</param>
         /// <param name="va">The <see cref="VerticalAlignment" /> to orientate.</param>
-        public static void Orientate(
-            this ITransposablePlotElement element,
-            ref HorizontalAlignment ha,
-            ref VerticalAlignment va)
+        public static void Orientate(this ITransposablePlotElement element, ref HorizontalAlignment ha, ref VerticalAlignment va)
         {
             if (element.XAxis.IsReversed)
             {
@@ -103,26 +85,15 @@ namespace OxyPlot
         }
 
         /// <summary>
-        /// Transforms the specified coordinates to a screen point by the axes of this series.
-        /// </summary>
-        /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
-        /// <param name="x">The x coordinate.</param>
-        /// <param name="y">The y coordinate.</param>
-        /// <returns>A screen point.</returns>
-        public static ScreenPoint Transform(this ITransposablePlotElement element, double x, double y)
-        {
-            return element.Orientate(element.XAxis.Transform(x, y, element.YAxis));
-        }
-
-        /// <summary>
         /// Transforms the specified data point to a screen point by the axes of this series.
         /// </summary>
         /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
-        /// <param name="p">The point.</param>
+        /// <param name="x">The x coordinate of the data point.</param>
+        /// <param name="y">The y coordinate of the data point.</param>
         /// <returns>A screen point.</returns>
-        public static ScreenPoint Transform(this ITransposablePlotElement element, DataPoint p)
+        public static ScreenPoint Transform(this IXyAxisPlotElement element, double x, double y)
         {
-            return element.Transform(p.X, p.Y);
+            return element.Transform(new DataPoint(x, y));
         }
     }
 }

--- a/Source/OxyPlot/PlotModel/PlotElementUtilities.cs
+++ b/Source/OxyPlot/PlotModel/PlotElementUtilities.cs
@@ -1,0 +1,82 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PlotModelUtilities.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot
+{
+    /// <summary>
+    /// Provides utility functions for plot elements.
+    /// </summary>
+    public static class PlotElementUtilities
+    {
+        /// <summary>
+        /// Gets the clipping rectangle defined by the Axis the <see cref="IXyAxisPlotElement"/> uses.
+        /// </summary>
+        /// <param name="element">The <see cref="IXyAxisPlotElement" />.</param>
+        /// <returns>The clipping rectangle.</returns>
+        public static OxyRect GetClippingRect(IXyAxisPlotElement element)
+        {
+            var p1 = new ScreenPoint(element.XAxis.ScreenMin.X, element.YAxis.ScreenMin.Y);
+            var p2 = new ScreenPoint(element.XAxis.ScreenMax.X, element.YAxis.ScreenMax.Y);
+            return new OxyRect(p1, p2);
+        }
+
+        /// <summary>
+        /// Gets the clipping rectangle defined by the Axis the <see cref="ITransposablePlotElement"/> uses while being aware of the orientation.
+        /// </summary>
+        /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
+        /// <returns>The clipping rectangle.</returns>
+        public static OxyRect GetOrientatedClippingRect(ITransposablePlotElement element)
+        {
+            var p1 = new ScreenPoint(element.XAxis.ScreenMin.X, element.YAxis.ScreenMin.Y);
+            var p2 = new ScreenPoint(element.XAxis.ScreenMax.X, element.YAxis.ScreenMax.Y);
+            return new OxyRect(element.Orientate(p1), element.Orientate(p2));
+        }
+
+        /// <summary>
+        /// Transforms from a screen point to a data point by the axes of this series.
+        /// </summary>
+        /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
+        /// <param name="p">The screen point.</param>
+        /// <returns>A data point.</returns>
+        public static DataPoint InverseTransform(IXyAxisPlotElement element, ScreenPoint p)
+        {
+            return element.XAxis.InverseTransform(p.X, p.Y, element.YAxis);
+        }
+
+        /// <summary>
+        /// Transforms from a screen point to a data point by the axes of this series while being aware of the orientation.
+        /// </summary>
+        /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
+        /// <param name="p">The screen point.</param>
+        /// <returns>A data point.</returns>
+        public static DataPoint InverseTransformOrientated(ITransposablePlotElement element, ScreenPoint p)
+        {
+            return InverseTransform(element, element.Orientate(p));
+        }
+
+        /// <summary>
+        /// Transforms the specified coordinates to a screen point by the axes of the plot element.
+        /// </summary>
+        /// <param name="element">The plot element.</param>
+        /// <param name="p">The data point.</param>
+        /// <returns>A screen point.</returns>
+        public static ScreenPoint Transform(IXyAxisPlotElement element, DataPoint p)
+        {
+            return element.XAxis.Transform(p.X, p.Y, element.YAxis);
+        }
+
+        /// <summary>
+        /// Transforms the specified coordinates to a screen point by the axes of the plot element while being aware of the orientation.
+        /// </summary>
+        /// <param name="element">The plot element.</param>
+        /// <param name="p">The data point.</param>
+        /// <returns>A screen point.</returns>
+        public static ScreenPoint TransformOrientated(ITransposablePlotElement element, DataPoint p)
+        {
+            return element.Orientate(Transform(element, p));
+        }
+    }
+}

--- a/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
@@ -46,6 +46,7 @@ namespace OxyPlot
 
                 try
                 {
+                    using var _ = rc.AutoResetClip(rect);
                     if (this.lastPlotException != null)
                     {
                         // There was an exception during plot model update. 
@@ -112,7 +113,7 @@ namespace OxyPlot
                         this.RenderLegends(rc);
                     }
 
-                    if (rc.ClipCount != initialClipCount)
+                    if (rc.ClipCount != initialClipCount + 1)
                     {
                         throw new InvalidOperationException("Unbalanced calls to IRenderContext.PushClip were made during rendering.");
                     }
@@ -278,13 +279,7 @@ namespace OxyPlot
         /// <param name="layer">The layer.</param>
         private void RenderAnnotations(IRenderContext rc, AnnotationLayer layer)
         {
-            foreach (var a in this.Annotations.Where(a => a.Layer == layer))
-            {
-                rc.SetToolTip(a.ToolTip);
-                a.Render(rc);
-            }
-
-            rc.SetToolTip(null);
+            this.RenderPlotElements(this.Annotations.Where(a => a.Layer == layer), rc, annotation => annotation.Render(rc));
         }
 
         /// <summary>
@@ -365,10 +360,38 @@ namespace OxyPlot
                 barSeriesManager.InitializeRender();
             }
 
-            foreach (var s in this.Series.Where(s => s.IsVisible))
+            this.RenderPlotElements(this.Series.Where(s => s.IsVisible), rc, series => series.Render(rc));
+        }
+
+        private void RenderPlotElements<T>(IEnumerable<T> plotElements, IRenderContext rc, Action<T> renderAction) where T: PlotElement
+        {
+            OxyRect? previousClippingRect = null;
+
+            foreach (var plotElement in plotElements)
             {
-                rc.SetToolTip(s.ToolTip);
-                s.Render(rc);
+                var currentClippingRect = (plotElement as ITransposablePlotElement)?.GetClippingRect();
+                if (!currentClippingRect.Equals(previousClippingRect))
+                {
+                    if (previousClippingRect != null)
+                    {
+                        rc.PopClip();
+                        previousClippingRect = null;
+                    }
+
+                    if (currentClippingRect != null)
+                    {
+                        rc.PushClip(currentClippingRect.Value);
+                        previousClippingRect = currentClippingRect;
+                    }
+                }
+
+                rc.SetToolTip(plotElement.ToolTip);
+                renderAction(plotElement);
+            }
+
+            if (previousClippingRect != null)
+            {
+                rc.PopClip();
             }
 
             rc.SetToolTip(null);

--- a/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
@@ -365,22 +365,22 @@ namespace OxyPlot
 
         private void RenderPlotElements<T>(IEnumerable<T> plotElements, IRenderContext rc, Action<T> renderAction) where T: PlotElement
         {
-            OxyRect? previousClippingRect = null;
+            var previousClippingRect = OxyRect.Everything;
 
             foreach (var plotElement in plotElements)
             {
-                var currentClippingRect = (plotElement as ITransposablePlotElement)?.GetClippingRect();
+                var currentClippingRect = plotElement.GetClippingRect();
                 if (!currentClippingRect.Equals(previousClippingRect))
                 {
-                    if (previousClippingRect != null)
+                    if (!previousClippingRect.Equals(OxyRect.Everything))
                     {
                         rc.PopClip();
-                        previousClippingRect = null;
+                        previousClippingRect = OxyRect.Everything;
                     }
 
-                    if (currentClippingRect != null)
+                    if (!currentClippingRect.Equals(OxyRect.Everything))
                     {
-                        rc.PushClip(currentClippingRect.Value);
+                        rc.PushClip(currentClippingRect);
                         previousClippingRect = currentClippingRect;
                     }
                 }
@@ -389,7 +389,7 @@ namespace OxyPlot
                 renderAction(plotElement);
             }
 
-            if (previousClippingRect != null)
+            if (!previousClippingRect.Equals(OxyRect.Everything))
             {
                 rc.PopClip();
             }

--- a/Source/OxyPlot/PlotModel/TransposablePlotElementExtensions.cs
+++ b/Source/OxyPlot/PlotModel/TransposablePlotElementExtensions.cs
@@ -15,17 +15,17 @@ namespace OxyPlot
     public static class TransposablePlotElementExtensions
     {
         /// <summary>
-        /// Gets the clipping rectangle.
+        /// Gets the clipping rectangle defined by the Axis the <see cref="ITransposablePlotElement"/> uses.
         /// </summary>
         /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
         /// <returns>The clipping rectangle.</returns>
-        public static OxyRect GetClippingRect(this ITransposablePlotElement element)
+        public static OxyRect GetAxisClippingRect(this ITransposablePlotElement element)
         {
             var p1 = new ScreenPoint(element.XAxis.ScreenMin.X, element.YAxis.ScreenMin.Y);
             var p2 = new ScreenPoint(element.XAxis.ScreenMax.X, element.YAxis.ScreenMax.Y);
             return new OxyRect(element.Orientate(p1), element.Orientate(p2));
         }
-
+        
         /// <summary>
         /// Transforms from a screen point to a data point by the axes of this series.
         /// </summary>

--- a/Source/OxyPlot/Rendering/OxyRect.cs
+++ b/Source/OxyPlot/Rendering/OxyRect.cs
@@ -19,6 +19,11 @@ namespace OxyPlot
     public struct OxyRect : IFormattable, IEquatable<OxyRect>
     {
         /// <summary>
+        /// Gets an infinitely large <see cref="OxyRect"/> starting at (0,0).
+        /// </summary>
+        public static readonly OxyRect Everything = new OxyRect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
+
+        /// <summary>
         /// The height of the rectangle.
         /// </summary>
         private readonly double height;

--- a/Source/OxyPlot/Series/AreaSeries.cs
+++ b/Source/OxyPlot/Series/AreaSeries.cs
@@ -239,16 +239,12 @@ namespace OxyPlot.Series
 
             double minDistSquared = this.MinimumSegmentLength * this.MinimumSegmentLength;
 
-            var clippingRect = this.GetClippingRect();
-            using var _ = rc.AutoResetClip(clippingRect);
-
             var areaContext = new AreaRenderContext
             {
                 Points = actualPoints,
                 WindowStartIndex = startIdx,
                 XMax = xmax,
                 RenderContext = rc,
-                ClippingRect = clippingRect,
                 MinDistSquared = minDistSquared,
                 Reverse = false,
                 Color = this.ActualColor,
@@ -275,14 +271,11 @@ namespace OxyPlot.Series
                 var pts = chunksOfPoints[chunkIndex];
                 var pts2 = chunksOfPoints2[chunkIndex];
 
-                // pts = SutherlandHodgmanClipping.ClipPolygon(clippingRect, pts);
-
                 // combine the two lines and draw the clipped area
                 var allPts = new List<ScreenPoint>();
                 allPts.AddRange(pts2);
                 allPts.AddRange(pts);
-                rc.DrawClippedPolygon(
-                    clippingRect,
+                rc.DrawReducedPolygon(
                     allPts,
                     minDistSquared,
                     this.GetSelectableFillColor(this.ActualFill),
@@ -294,7 +287,6 @@ namespace OxyPlot.Series
 
                 // draw the markers on top
                 rc.DrawMarkers(
-                    clippingRect,
                     pts,
                     this.MarkerType,
                     null,
@@ -305,7 +297,6 @@ namespace OxyPlot.Series
                     this.EdgeRenderingMode,
                     1);
                 rc.DrawMarkers(
-                    clippingRect,
                     pts2,
                     this.MarkerType,
                     null,
@@ -464,8 +455,7 @@ namespace OxyPlot.Series
                 final = this.InterpolationAlgorithm.CreateSpline(resampled, false, 0.25);
             }
 
-            context.RenderContext.DrawClippedLine(
-                context.ClippingRect,
+            context.RenderContext.DrawReducedLine(
                 final,
                 context.MinDistSquared,
                 this.GetSelectableColor(context.Color),
@@ -528,11 +518,6 @@ namespace OxyPlot.Series
             /// Gets or sets render context.
             /// </summary>
             public IRenderContext RenderContext { get; set; }
-
-            /// <summary>
-            /// Gets or sets clipping rectangle.
-            /// </summary>
-            public OxyRect ClippingRect { get; set; }
 
             /// <summary>
             /// Gets or sets minimum squared distance between points.

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -257,7 +257,6 @@ namespace OxyPlot.Series
         /// Renders the bar/column item.
         /// </summary>
         /// <param name="rc">The render context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="barValue">The end value of the bar.</param>
         /// <param name="categoryValue">The category value.</param>
         /// <param name="actualBarWidth">The actual width of the bar.</param>
@@ -265,7 +264,6 @@ namespace OxyPlot.Series
         /// <param name="rect">The rectangle of the bar.</param>
         protected virtual void RenderItem(
             IRenderContext rc,
-            OxyRect clippingRect,
             double barValue,
             double categoryValue,
             double actualBarWidth,
@@ -283,8 +281,7 @@ namespace OxyPlot.Series
                 }
             }
 
-            rc.DrawClippedRectangle(
-                clippingRect,
+            rc.DrawRectangle(
                 rect,
                 this.GetSelectableFillColor(actualFillColor),
                 this.StrokeColor,
@@ -296,7 +293,6 @@ namespace OxyPlot.Series
         /// Renders the item label.
         /// </summary>
         /// <param name="rc">The render context</param>
-        /// <param name="clippingRect">The clipping rectangle</param>
         /// <param name="item">The item.</param>
         /// <param name="baseValue">The bar item base value.</param>
         /// <param name="topValue">The bar item top value.</param>
@@ -304,7 +300,6 @@ namespace OxyPlot.Series
         /// <param name="categoryEndValue">The bar item category end value.</param>
         protected void RenderLabel(
             IRenderContext rc,
-            OxyRect clippingRect,
             BarItem item,
             double baseValue,
             double topValue,
@@ -347,8 +342,7 @@ namespace OxyPlot.Series
 
             pt += this.Orientate(marginVector);
 
-            rc.DrawClippedText(
-                clippingRect,
+            rc.DrawText(
                 pt,
                 s,
                 this.ActualTextColor,
@@ -369,8 +363,6 @@ namespace OxyPlot.Series
             {
                 return;
             }
-
-            var clippingRect = this.GetClippingRect();
 
             var actualBarWidth = this.GetActualBarWidth();
             var stackIndex = this.IsStacked ? this.Manager.GetStackIndex(this.StackGroup) : 0;
@@ -415,13 +407,12 @@ namespace OxyPlot.Series
 
                 this.ActualBarRectangles.Add(rect);
 
-                this.RenderItem(rc, clippingRect, topValue, categoryValue, actualBarWidth, item, rect);
+                this.RenderItem(rc, topValue, categoryValue, actualBarWidth, item, rect);
 
                 if (this.LabelFormatString != null)
                 {
                     this.RenderLabel(
                         rc,
-                        clippingRect,
                         item,
                         baseValue,
                         topValue,

--- a/Source/OxyPlot/Series/BarSeries/ErrorBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/ErrorBarSeries.cs
@@ -114,26 +114,16 @@ namespace OxyPlot.Series
             this.MaxX = maxValue;
         }
 
-        /// <summary>
-        /// Renders the bar/column item.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
-        /// <param name="barValue">The end value of the bar.</param>
-        /// <param name="categoryValue">The category value.</param>
-        /// <param name="actualBarWidth">The actual width of the bar.</param>
-        /// <param name="item">The item.</param>
-        /// <param name="rect">The rectangle of the bar.</param>
+        /// <inheritdoc/>
         protected override void RenderItem(
             IRenderContext rc,
-            OxyRect clippingRect,
             double barValue,
             double categoryValue,
             double actualBarWidth,
             BarItem item,
             OxyRect rect)
         {
-            base.RenderItem(rc, clippingRect, barValue, categoryValue, actualBarWidth, item, rect);
+            base.RenderItem(rc, barValue, categoryValue, actualBarWidth, item, rect);
 
             if (!(item is ErrorBarItem errorItem))
             {
@@ -152,10 +142,8 @@ namespace OxyPlot.Series
             var lowerErrorPoint = this.Transform(errorStart, categoryMiddle);
             var upperErrorPoint = this.Transform(errorEnd, categoryMiddle);
 
-            rc.DrawClippedLine(
-                clippingRect,
+            rc.DrawLine(
                 new List<ScreenPoint> { lowerErrorPoint, upperErrorPoint },
-                0,
                 this.StrokeColor,
                 this.ErrorStrokeThickness,
                 this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -166,10 +154,8 @@ namespace OxyPlot.Series
             {
                 var lowerLeftErrorPoint = this.Transform(errorStart, categoryStart);
                 var lowerRightErrorPoint = this.Transform(errorStart, categoryEnd);
-                rc.DrawClippedLine(
-                    clippingRect,
+                rc.DrawLine(
                     new List<ScreenPoint> { lowerLeftErrorPoint, lowerRightErrorPoint },
-                    0,
                     this.StrokeColor,
                     this.ErrorStrokeThickness,
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -178,10 +164,8 @@ namespace OxyPlot.Series
 
                 var upperLeftErrorPoint = this.Transform(errorEnd, categoryStart);
                 var upperRightErrorPoint = this.Transform(errorEnd, categoryEnd);
-                rc.DrawClippedLine(
-                    clippingRect,
+                rc.DrawLine(
                     new List<ScreenPoint> { upperLeftErrorPoint, upperRightErrorPoint },
-                    0,
                     this.StrokeColor,
                     this.ErrorStrokeThickness,
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),

--- a/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
@@ -202,8 +202,6 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var clippingRect = this.GetClippingRect();
-
             var actualBarWidth = this.GetActualBarWidth();
             var stackIndex = this.Manager.GetStackIndex(this.StackGroup);
 
@@ -221,8 +219,7 @@ namespace OxyPlot.Series
 
                 this.ActualBarRectangles.Add(rectangle);
 
-                rc.DrawClippedRectangle(
-                    clippingRect,
+                rc.DrawRectangle(
                     rectangle,
                     this.GetSelectableFillColor(item.Color.GetActualColor(this.ActualFillColor)),
                     this.StrokeColor,
@@ -236,8 +233,7 @@ namespace OxyPlot.Series
                     var pt = new ScreenPoint(
                         (rectangle.Left + rectangle.Right) / 2, (rectangle.Top + rectangle.Bottom) / 2);
 
-                    rc.DrawClippedText(
-                        clippingRect,
+                    rc.DrawText(
                         pt,
                         s,
                         this.ActualTextColor,

--- a/Source/OxyPlot/Series/BarSeries/LinearBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/LinearBarSeries.cs
@@ -140,10 +140,7 @@ namespace OxyPlot.Series
             };
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             this.rectangles.Clear();
@@ -157,9 +154,6 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
-
-            using var _ = rc.AutoResetClip(clippingRect);
             this.RenderBars(rc, actualPoints);
         }
 

--- a/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
@@ -146,18 +146,13 @@ namespace OxyPlot.Series
             return null;
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             if (this.Items.Count == 0)
             {
                 return;
             }
-
-            var clippingRect = this.GetClippingRect();
 
             int startIdx = 0;
             double xmax = double.MaxValue;
@@ -191,8 +186,7 @@ namespace OxyPlot.Series
                 this.ActualBarRectangles.Add(rectangle);
                 this.ActualItems.Add(item);
 
-                rc.DrawClippedRectangle(
-                    clippingRect,
+                rc.DrawRectangle(
                     rectangle,
                     this.GetSelectableFillColor(item.Color.GetActualColor(this.ActualFillColor)),
                     this.StrokeColor,
@@ -214,8 +208,7 @@ namespace OxyPlot.Series
                     var pt = new ScreenPoint(
                         (rectangle.Left + rectangle.Right) / 2, (rectangle.Top + rectangle.Bottom) / 2);
 
-                    rc.DrawClippedText(
-                        clippingRect,
+                    rc.DrawText(
                         pt,
                         s,
                         this.ActualTextColor,

--- a/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
@@ -186,7 +186,6 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var clippingRect = this.GetClippingRect();
             var actualBarWidth = this.GetActualBarWidth();
 
             for (var i = 0; i < this.ValidItems.Count; i++)
@@ -211,15 +210,13 @@ namespace OxyPlot.Series
                 this.ActualMinimumBarRectangles.Add(minimumRectangle);
                 this.ActualMaximumBarRectangles.Add(maximumRectangle);
 
-                rc.DrawClippedRectangle(
-                    clippingRect,
+                rc.DrawRectangle(
                     minimumRectangle,
                     item.MinimumColor.GetActualColor(this.ActualMinimumFillColor),
                     this.StrokeColor,
                     this.StrokeThickness,
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
-                rc.DrawClippedRectangle(
-                    clippingRect,
+                rc.DrawRectangle(
                     maximumRectangle,
                     item.MaximumColor.GetActualColor(this.ActualMaximumFillColor),
                     this.StrokeColor,
@@ -241,8 +238,7 @@ namespace OxyPlot.Series
                     var va = VerticalAlignment.Middle;
                     this.Orientate(ref ha, ref va);
 
-                    rc.DrawClippedText(
-                        clippingRect,
+                    rc.DrawText(
                         pt,
                         s,
                         this.ActualTextColor,
@@ -267,8 +263,7 @@ namespace OxyPlot.Series
                     var va = VerticalAlignment.Middle;
                     this.Orientate(ref ha, ref va);
 
-                    rc.DrawClippedText(
-                        clippingRect,
+                    rc.DrawText(
                         pt,
                         s,
                         this.ActualTextColor,

--- a/Source/OxyPlot/Series/BoxPlotSeries.cs
+++ b/Source/OxyPlot/Series/BoxPlotSeries.cs
@@ -326,19 +326,15 @@ namespace OxyPlot.Series
 
                 if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
                 {
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { topWhiskerTop, topWhiskerBottom },
-                        0,
                         strokeColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
                         dashArray,
                         LineJoin.Miter);
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { bottomWhiskerTop, bottomWhiskerBottom },
-                        0,
                         strokeColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -354,19 +350,15 @@ namespace OxyPlot.Series
                     var bottomWhiskerLine1 = this.Transform(item.X - halfWhiskerWidth, item.LowerWhisker);
                     var bottomWhiskerLine2 = this.Transform(item.X + halfWhiskerWidth, item.LowerWhisker);
 
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { topWhiskerLine1, topWhiskerLine2 },
-                        0,
                         strokeColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
                         null,
                         LineJoin.Miter);
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { bottomWhiskerLine1, bottomWhiskerLine2 },
-                        0,
                         strokeColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -378,9 +370,9 @@ namespace OxyPlot.Series
                 {
                     // Draw the box
                     var rect = this.GetBoxRect(item);
-                    rc.DrawClippedRectangle(
-                        clippingRect, 
-                        rect, fillColor, 
+                    rc.DrawRectangle(
+                        rect, 
+                        fillColor, 
                         strokeColor, 
                         this.StrokeThickness, 
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
@@ -391,10 +383,8 @@ namespace OxyPlot.Series
                     // Draw the median line
                     var medianLeft = this.Transform(item.X - halfBoxWidth, item.Median);
                     var medianRight = this.Transform(item.X + halfBoxWidth, item.Median);
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { medianLeft, medianRight },
-                        0,
                         strokeColor,
                         this.StrokeThickness * this.MedianThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -420,10 +410,8 @@ namespace OxyPlot.Series
                     // Draw the median line
                     var meanLeft = this.Transform(item.X - halfBoxWidth, item.Mean);
                     var meanRight = this.Transform(item.X + halfBoxWidth, item.Mean);
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { meanLeft, meanRight },
-                        0,
                         strokeColor,
                         this.StrokeThickness * this.MeanThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -450,7 +438,6 @@ namespace OxyPlot.Series
                 // Draw the outlier(s)
                 var markerSizes = outlierScreenPoints.Select(o => this.OutlierSize).ToList();
                 rc.DrawMarkers(
-                    clippingRect,
                     outlierScreenPoints,
                     this.OutlierType,
                     this.OutlierOutline,

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -276,9 +276,6 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
-            using var _ = rc.AutoResetClip(clippingRect);
-
             var contourLabels = new List<ContourLabel>();
             var dashArray = this.LineStyle.GetDashArray();
 
@@ -293,8 +290,7 @@ namespace OxyPlot.Series
 
                 var strokeColor = contour.Color.GetActualColor(this.ActualColor);
 
-                rc.DrawClippedLine(
-                    clippingRect,
+                rc.DrawReducedLine(
                     transformedPoints,
                     4,
                     this.GetSelectableColor(strokeColor),
@@ -318,7 +314,7 @@ namespace OxyPlot.Series
 
                 if (!this.MultiLabel)
                 {
-                    this.AddContourLabels(contour, transformedPoints, clippingRect, contourLabels, (transformedPoints.Length - 1) * 0.5);
+                    this.AddContourLabels(contour, transformedPoints, contourLabels, (transformedPoints.Length - 1) * 0.5);
                     continue;
                 }
 
@@ -326,7 +322,7 @@ namespace OxyPlot.Series
                 var labelsCount = (int)(contourLength / this.LabelSpacing);
                 if (labelsCount == 0)
                 {
-                    this.AddContourLabels(contour, transformedPoints, clippingRect, contourLabels, (transformedPoints.Length - 1) * 0.5);
+                    this.AddContourLabels(contour, transformedPoints, contourLabels, (transformedPoints.Length - 1) * 0.5);
                     continue;
                 }
 
@@ -363,7 +359,7 @@ namespace OxyPlot.Series
                         contourPartLengthOld = contourPartLength;
                     }
 
-                    this.AddContourLabels(contour, transformedPoints, clippingRect, contourLabels, labelIndex);
+                    this.AddContourLabels(contour, transformedPoints, contourLabels, labelIndex);
                 }
             }
 
@@ -456,10 +452,9 @@ namespace OxyPlot.Series
         /// </summary>
         /// <param name="contour">The contour.</param>
         /// <param name="pts">The points of the contour.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="contourLabels">The contour labels.</param>
         /// <param name="labelIndex">The index of the point in the list of points, where the label should get added.</param>
-        private void AddContourLabels(Contour contour, ScreenPoint[] pts, OxyRect clippingRect, ICollection<ContourLabel> contourLabels, double labelIndex)
+        private void AddContourLabels(Contour contour, ScreenPoint[] pts, ICollection<ContourLabel> contourLabels, double labelIndex)
         {
             if (pts.Length < 2)
             {
@@ -473,10 +468,6 @@ namespace OxyPlot.Series
             var dy = pts[i1].Y - pts[i0].Y;
             var x = pts[i0].X + (dx * (labelIndex - i0));
             var y = pts[i0].Y + (dy * (labelIndex - i0));
-            if (!clippingRect.Contains(x, y))
-            {
-                return;
-            }
 
             var pos = new ScreenPoint(x, y);
             var angle = Math.Atan2(dy, dx) * 180 / Math.PI;

--- a/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/CandleStickSeries.cs
@@ -73,10 +73,7 @@ namespace OxyPlot.Series
             return this.FindWindowStartIndex(this.Items, item => item.X, x, startIndex);
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             var nitems = this.Items.Count;
@@ -89,7 +86,6 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
             var dashArray = this.LineStyle.GetDashArray();
 
             var dataCandlewidth = (this.CandleWidth > 0) ? this.CandleWidth : this.minDx * 0.80;
@@ -133,10 +129,8 @@ namespace OxyPlot.Series
                 if (this.StrokeThickness > 0 && this.LineStyle != LineStyle.None)
                 {
                     // Upper extent
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { high, max },
-                        0,
                         lineColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode,
@@ -144,10 +138,8 @@ namespace OxyPlot.Series
                         this.LineJoin);
 
                     // Lower extent
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { min, low },
-                        0,
                         lineColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode,
@@ -158,7 +150,7 @@ namespace OxyPlot.Series
                 var p1 = this.Transform(bar.X - halfDataCandlewidth, bar.Open);
                 var p2 = this.Transform(bar.X + halfDataCandlewidth, bar.Close);
                 var rect = new OxyRect(p1, p2);
-                rc.DrawClippedRectangle(clippingRect, rect, fillColor, lineColor, this.StrokeThickness, this.EdgeRenderingMode);
+                rc.DrawRectangle(rect, fillColor, lineColor, this.StrokeThickness, this.EdgeRenderingMode);
             }
         }
 

--- a/Source/OxyPlot/Series/FinancialSeries/HighLowSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/HighLowSeries.cs
@@ -220,10 +220,7 @@ namespace OxyPlot.Series
                    && !double.IsInfinity(pt.High) && !double.IsNaN(pt.Low) && !double.IsInfinity(pt.Low);
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             if (this.items.Count == 0)
@@ -233,7 +230,6 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
             var dashArray = this.LineStyle.GetDashArray();
             var actualColor = this.GetSelectableColor(this.ActualColor);
             foreach (var v in this.items)
@@ -248,10 +244,8 @@ namespace OxyPlot.Series
                     var high = this.Transform(v.X, v.High);
                     var low = this.Transform(v.X, v.Low);
 
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawLine(
                         new[] { low, high },
-                        0,
                         actualColor,
                         this.StrokeThickness,
                         this.EdgeRenderingMode,
@@ -263,10 +257,8 @@ namespace OxyPlot.Series
                     {
                         var open = this.Transform(v.X, v.Open);
                         var openTick = open - tickVector;
-                        rc.DrawClippedLine(
-                            clippingRect,
+                        rc.DrawLine(
                             new[] { open, openTick },
-                            0,
                             actualColor,
                             this.StrokeThickness,
                             this.EdgeRenderingMode,
@@ -278,10 +270,8 @@ namespace OxyPlot.Series
                     {
                         var close = this.Transform(v.X, v.Close);
                         var closeTick = close + tickVector;
-                        rc.DrawClippedLine(
-                            clippingRect,
+                        rc.DrawLine(
                             new[] { close, closeTick },
-                            0,
                             actualColor,
                             this.StrokeThickness,
                             this.EdgeRenderingMode,

--- a/Source/OxyPlot/Series/FinancialSeries/OldCandleStickSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/OldCandleStickSeries.cs
@@ -69,10 +69,7 @@ namespace OxyPlot.Series
             }
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             if (this.IsTransposed())
@@ -87,7 +84,6 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
             var dashArray = this.LineStyle.GetDashArray();
             var actualColor = this.GetSelectableColor(this.ActualColor);
             var shadowEndColor = this.GetSelectableColor(this.ShadowEndColor);
@@ -111,10 +107,8 @@ namespace OxyPlot.Series
 
                     if (double.IsNaN(v.Open) || double.IsNaN(v.Close))
                     {
-                        rc.DrawClippedLine(
-                            clippingRect,
+                        rc.DrawLine(
                             new[] { low, high },
-                            0,
                             actualColor,
                             this.StrokeThickness,
                             this.EdgeRenderingMode,
@@ -129,10 +123,8 @@ namespace OxyPlot.Series
                         var min = new ScreenPoint(open.X, Math.Min(open.Y, close.Y));
 
                         // Upper shadow
-                        rc.DrawClippedLine(
-                            clippingRect,
+                        rc.DrawLine(
                             new[] { high, min },
-                            0,
                             actualColor,
                             this.StrokeThickness,
                             this.EdgeRenderingMode,
@@ -140,10 +132,8 @@ namespace OxyPlot.Series
                             this.LineJoin);
 
                         // Lower shadow
-                        rc.DrawClippedLine(
-                            clippingRect,
+                        rc.DrawLine(
                             new[] { max, low },
-                            0,
                             actualColor,
                             this.StrokeThickness,
                             this.EdgeRenderingMode,
@@ -155,10 +145,8 @@ namespace OxyPlot.Series
                         {
                             var highLeft = new ScreenPoint(high.X - (this.CandleWidth * 0.5 * this.ShadowEndLength) - 1, high.Y);
                             var highRight = new ScreenPoint(high.X + (this.CandleWidth * 0.5 * this.ShadowEndLength), high.Y);
-                            rc.DrawClippedLine(
-                                 clippingRect,
+                            rc.DrawLine(
                                  new[] { highLeft, highRight },
-                                 0,
                                  shadowEndColor,
                                  this.StrokeThickness,
                                  this.EdgeRenderingMode,
@@ -167,10 +155,8 @@ namespace OxyPlot.Series
 
                             var lowLeft = new ScreenPoint(low.X - (this.CandleWidth * 0.5 * this.ShadowEndLength) - 1, low.Y);
                             var lowRight = new ScreenPoint(low.X + (this.CandleWidth * 0.5 * this.ShadowEndLength), low.Y);
-                            rc.DrawClippedLine(
-                                clippingRect,
+                            rc.DrawLine(
                                 new[] { lowLeft, lowRight },
-                                0,
                                 shadowEndColor,
                                 this.StrokeThickness,
                                 this.EdgeRenderingMode,
@@ -184,7 +170,7 @@ namespace OxyPlot.Series
                         var fillColor = v.Close > v.Open
                                             ? this.GetSelectableFillColor(this.ActualIncreasingFill)
                                             : this.GetSelectableFillColor(this.DecreasingFill);
-                        rc.DrawClippedRectangle(clippingRect, rect, fillColor, actualColor, this.StrokeThickness, this.EdgeRenderingMode);
+                        rc.DrawRectangle(rect, fillColor, actualColor, this.StrokeThickness, this.EdgeRenderingMode);
                     }
                 }
             }

--- a/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/VolumeSeries.cs
@@ -189,10 +189,7 @@ namespace OxyPlot.Series
             return OhlcvItem.FindIndex(this.data, x, startingIndex);
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             if (this.data == null || this.data.Count == 0)
@@ -251,7 +248,7 @@ namespace OxyPlot.Series
                             var fillcolor = (bar.BuyVolume > bar.SellVolume) ? barfillUp : barfillDown;
                             var linecolor = (bar.BuyVolume > bar.SellVolume) ? lineUp : lineDown;
                             var rect1 = new OxyRect(p1, p2);
-                            rc.DrawClippedRectangle(clippingRect, rect1, fillcolor, linecolor, this.StrokeThickness, this.EdgeRenderingMode);
+                            rc.DrawRectangle(rect1, fillcolor, linecolor, this.StrokeThickness, this.EdgeRenderingMode);
                         }
 
                         break;
@@ -264,8 +261,8 @@ namespace OxyPlot.Series
                             var rectBuy = new OxyRect(p1, p2Buy);
                             var rectSell = new OxyRect(p1, p2Bell);
 
-                            rc.DrawClippedRectangle(clippingRect, rectBuy, fillUp, lineUp, this.StrokeThickness, this.EdgeRenderingMode);
-                            rc.DrawClippedRectangle(clippingRect, rectSell, fillDown, lineDown, this.StrokeThickness, this.EdgeRenderingMode);
+                            rc.DrawRectangle(rectBuy, fillUp, lineUp, this.StrokeThickness, this.EdgeRenderingMode);
+                            rc.DrawRectangle(rectSell, fillDown, lineDown, this.StrokeThickness, this.EdgeRenderingMode);
                         }
 
                         break;
@@ -290,8 +287,8 @@ namespace OxyPlot.Series
                                 rectSell = new OxyRect(p2Buy, pBoth);
                             }
 
-                            rc.DrawClippedRectangle(clippingRect, rectBuy, fillUp, lineUp, this.StrokeThickness, this.EdgeRenderingMode);
-                            rc.DrawClippedRectangle(clippingRect, rectSell, fillDown, lineDown, this.StrokeThickness, this.EdgeRenderingMode);
+                            rc.DrawRectangle(rectBuy, fillUp, lineUp, this.StrokeThickness, this.EdgeRenderingMode);
+                            rc.DrawRectangle(rectSell, fillDown, lineDown, this.StrokeThickness, this.EdgeRenderingMode);
 
                             break;
                         }
@@ -310,10 +307,8 @@ namespace OxyPlot.Series
                 var lineA = this.Transform(p1.X, 0);
                 var lineB = this.Transform(p2.X, 0);
 
-                rc.DrawClippedLine(
-                    clippingRect,
+                rc.DrawLine(
                     new[] { lineA, lineB },
-                    0,
                     this.InterceptColor,
                     this.InterceptStrokeThickness,
                     this.EdgeRenderingMode,

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -266,12 +266,11 @@ namespace OxyPlot.Series
                 this.colorAxisHash = currentColorAxisHash;
             }
 
-            var clip = this.GetClippingRect();
             if (needImage)
             {
                 if (this.image != null)
                 {
-                    rc.DrawClippedImage(clip, this.image, rect.Left, rect.Top, rect.Width, rect.Height, 1, this.Interpolate);
+                    rc.DrawImage(this.image, rect.Left, rect.Top, rect.Width, rect.Height, 1, this.Interpolate);
                 }
             }
             else
@@ -293,7 +292,7 @@ namespace OxyPlot.Series
                         var pointb = this.Orientate(new ScreenPoint(s00.X + ((i + 1) * sdx), s00.Y + ((j + 1) * sdy))); // re-orientate
                         var rectrect = new OxyRect(pointa, pointb);
 
-                        rc.DrawClippedRectangle(clip, rectrect, rectcolor, OxyColors.Undefined, 0, this.EdgeRenderingMode);
+                        rc.DrawRectangle(rectrect, rectcolor, OxyColors.Undefined, 0, this.EdgeRenderingMode);
                     }
                 }
             }
@@ -505,7 +504,6 @@ namespace OxyPlot.Series
         /// <param name="rect">The bounding rectangle for the data.</param>
         protected virtual void RenderLabels(IRenderContext rc, OxyRect rect)
         {
-            var clip = this.GetClippingRect();
             int m = this.Data.GetLength(0);
             int n = this.Data.GetLength(1);
             double fontSize = (rect.Height / n) * this.LabelFontSize;
@@ -531,8 +529,7 @@ namespace OxyPlot.Series
                     var hsv = color.ToHsv();
                     var textColor = hsv[2] > 0.6 ? OxyColors.Black : OxyColors.White;
                     var label = this.GetLabel(v, i, j);
-                    rc.DrawClippedText(
-                        clip,
+                    rc.DrawText(
                         point,
                         label,
                         textColor,

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -132,13 +132,8 @@ namespace OxyPlot.Series
         /// <param name="rc">The rendering context.</param>
         public override void Render(IRenderContext rc)
         {
-            var actualBins = this.ActualItems;
-
             this.VerifyAxes();
-
-            var clippingRect = this.GetClippingRect();
-            using var _ = rc.AutoResetClip(clippingRect);
-            this.RenderBins(rc, actualBins);
+            this.RenderBins(rc, this.ActualItems);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -331,21 +331,18 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
-            using var _ = rc.AutoResetClip(clippingRect);
-
-            this.RenderPoints(rc, clippingRect, actualPoints);
+            this.RenderPoints(rc, actualPoints);
 
             if (this.LabelFormatString != null)
             {
                 // render point labels (not optimized for performance)
-                this.RenderPointLabels(rc, clippingRect);
+                this.RenderPointLabels(rc);
             }
 
             if (this.LineLegendPosition != LineLegendPosition.None && !string.IsNullOrEmpty(this.Title))
             {
                 // renders a legend on the line
-                this.RenderLegendOnLine(rc, clippingRect);
+                this.RenderLegendOnLine(rc);
             }
         }
 
@@ -368,7 +365,6 @@ namespace OxyPlot.Series
                 this.ActualDashArray);
             var midpt = new ScreenPoint(xmid, ymid);
             rc.DrawMarker(
-                legendBox,
                 midpt,
                 this.MarkerType,
                 this.MarkerOutline,
@@ -435,9 +431,8 @@ namespace OxyPlot.Series
         /// Renders the points as line, broken line and markers.
         /// </summary>
         /// <param name="rc">The rendering context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="points">The points to render.</param>
-        protected void RenderPoints(IRenderContext rc, OxyRect clippingRect, IList<DataPoint> points)
+        protected void RenderPoints(IRenderContext rc, IList<DataPoint> points)
         {
             var lastValidPoint = new ScreenPoint?();
             var areBrokenLinesRendered = this.BrokenLineThickness > 0 && this.BrokenLineStyle != LineStyle.None;
@@ -458,7 +453,7 @@ namespace OxyPlot.Series
 				var xmin = this.XAxis.ActualMinimum;
 				xmax = this.XAxis.ActualMaximum;
 				this.WindowStartIndex = this.UpdateWindowStartIndex(points, point => point.X, xmin, this.WindowStartIndex);
-				
+
 				startIdx = this.WindowStartIndex;
 			}
 
@@ -477,8 +472,7 @@ namespace OxyPlot.Series
 														? this.ActualColor
 														: this.BrokenLineColor;
 
-						rc.DrawClippedLineSegments(
-							clippingRect,
+						rc.DrawLineSegments(
 							broken,
 							actualBrokenLineColor,
 							this.BrokenLineThickness,
@@ -505,11 +499,11 @@ namespace OxyPlot.Series
 					}
 
 					this.Decimator(this.contiguousScreenPointsBuffer, this.decimatorBuffer);
-					this.RenderLineAndMarkers(rc, clippingRect, this.decimatorBuffer);
+					this.RenderLineAndMarkers(rc, this.decimatorBuffer);
 				}
 				else
 				{
-					this.RenderLineAndMarkers(rc, clippingRect, this.contiguousScreenPointsBuffer);
+					this.RenderLineAndMarkers(rc, this.contiguousScreenPointsBuffer);
 				}
 
 				this.contiguousScreenPointsBuffer.Clear();
@@ -604,8 +598,7 @@ namespace OxyPlot.Series
         /// Renders the point labels.
         /// </summary>
         /// <param name="rc">The render context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
-        protected void RenderPointLabels(IRenderContext rc, OxyRect clippingRect)
+        protected void RenderPointLabels(IRenderContext rc)
         {
             int index = -1;
             foreach (var point in this.ActualPoints)
@@ -618,11 +611,6 @@ namespace OxyPlot.Series
                 }
 
                 var pt = this.Transform(point) + new ScreenVector(0, -this.LabelMargin);
-
-                if (!clippingRect.Contains(pt))
-                {
-                    continue;
-                }
 
                 var item = this.GetItem(index);
                 var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, point.X, point.Y);
@@ -649,8 +637,7 @@ namespace OxyPlot.Series
                     }
 #endif
 
-                rc.DrawClippedText(
-                    clippingRect,
+                rc.DrawText(
                     pt,
                     s,
                     this.ActualTextColor,
@@ -667,8 +654,7 @@ namespace OxyPlot.Series
         /// Renders a legend on the line.
         /// </summary>
         /// <param name="rc">The render context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
-        protected void RenderLegendOnLine(IRenderContext rc, OxyRect clippingRect)
+        protected void RenderLegendOnLine(IRenderContext rc)
         {
             // Find the position
             DataPoint point;
@@ -697,8 +683,7 @@ namespace OxyPlot.Series
             var pt = this.Transform(point) + this.Orientate(new ScreenVector(dx, 0));
 
             // Render the legend
-            rc.DrawClippedText(
-                clippingRect,
+            rc.DrawText(
                 pt,
                 this.Title,
                 this.ActualTextColor,
@@ -714,9 +699,8 @@ namespace OxyPlot.Series
         /// Renders the transformed points as a line (smoothed if <see cref="InterpolationAlgorithm"/> isn’t <c>null</c>) and markers (if <see cref="MarkerType"/> is not <c>None</c>).
         /// </summary>
         /// <param name="rc">The render context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="pointsToRender">The points to render.</param>
-        protected virtual void RenderLineAndMarkers(IRenderContext rc, OxyRect clippingRect, IList<ScreenPoint> pointsToRender)
+        protected virtual void RenderLineAndMarkers(IRenderContext rc, IList<ScreenPoint> pointsToRender)
         {
             var screenPoints = pointsToRender;
             if (this.InterpolationAlgorithm != null)
@@ -729,7 +713,7 @@ namespace OxyPlot.Series
             // clip the line segments with the clipping rectangle
             if (this.StrokeThickness > 0 && this.ActualLineStyle != LineStyle.None)
             {
-                this.RenderLine(rc, clippingRect, screenPoints);
+                this.RenderLine(rc, screenPoints);
             }
 
             if (this.MarkerType != MarkerType.None)
@@ -737,7 +721,6 @@ namespace OxyPlot.Series
                 var markerBinOffset = this.MarkerResolution > 0 ? this.Transform(this.MinX, this.MinY) : default(ScreenPoint);
 
                 rc.DrawMarkers(
-                    clippingRect, 
                     pointsToRender, 
                     this.MarkerType, 
                     this.MarkerOutline, 
@@ -755,9 +738,8 @@ namespace OxyPlot.Series
         /// Renders a continuous line.
         /// </summary>
         /// <param name="rc">The render context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="pointsToRender">The points to render.</param>
-        protected virtual void RenderLine(IRenderContext rc, OxyRect clippingRect, IList<ScreenPoint> pointsToRender)
+        protected virtual void RenderLine(IRenderContext rc, IList<ScreenPoint> pointsToRender)
         {
             var dashArray = this.ActualDashArray;
 
@@ -766,8 +748,7 @@ namespace OxyPlot.Series
                 this.outputBuffer = new List<ScreenPoint>(pointsToRender.Count);
             }
 
-            rc.DrawClippedLine(
-                clippingRect, 
+            rc.DrawReducedLine(
                 pointsToRender, 
                 this.MinimumSegmentLength * this.MinimumSegmentLength, 
                 this.GetSelectableColor(this.ActualColor), 

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -106,12 +106,8 @@
         /// <param name="rc">The rendering context.</param>
         public override void Render(IRenderContext rc)
         {
-            var actualRects = this.ActualItems;
-
             this.VerifyAxes();
-
-            var clippingRect = this.GetClippingRect();
-            this.RenderRectangles(rc, clippingRect, actualRects);
+            this.RenderRectangles(rc, this.ActualItems);
         }
 
         /// <summary>
@@ -198,9 +194,8 @@
         /// Renders the points as line, broken line and markers.
         /// </summary>
         /// <param name="rc">The rendering context.</param>
-        /// <param name="clippingRect">The clipping rectangle.</param>
         /// <param name="items">The Items to render.</param>
-        protected void RenderRectangles(IRenderContext rc, OxyRect clippingRect, ICollection<RectangleItem> items)
+        protected void RenderRectangles(IRenderContext rc, ICollection<RectangleItem> items)
         {
             foreach (var item in items)
             {
@@ -212,8 +207,7 @@
 
                 var rectrect = new OxyRect(p1, p2);
 
-                rc.DrawClippedRectangle(
-                    clippingRect, 
+                rc.DrawRectangle(
                     rectrect, 
                     rectcolor, 
                     OxyColors.Undefined,
@@ -222,8 +216,7 @@
 
                 if (this.LabelFontSize > 0)
                 {
-                    rc.DrawClippedText(
-                        clippingRect, 
+                    rc.DrawText(
                         rectrect.Center, 
                         item.Value.ToString(this.LabelFormatString), 
                         this.ActualTextColor, 

--- a/Source/OxyPlot/Series/ScatterErrorSeries.cs
+++ b/Source/OxyPlot/Series/ScatterErrorSeries.cs
@@ -93,8 +93,6 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var clippingRectangle = this.GetClippingRect();
-
             var segments = new List<ScreenPoint>();
             foreach (var point in actualPoints)
             {
@@ -139,8 +137,7 @@ namespace OxyPlot.Series
                 }
             }
 
-            rc.DrawClippedLineSegments(
-                clippingRectangle, 
+            rc.DrawLineSegments(
                 segments, 
                 this.GetSelectableColor(this.ErrorBarColor), 
                 this.ErrorBarStrokeThickness, 

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -314,10 +314,7 @@ namespace OxyPlot.Series
             return result;
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             var actualPoints = this.ActualPointsList;
@@ -404,8 +401,6 @@ namespace OxyPlot.Series
             // Offset of the bins
             var binOffset = this.Transform(this.MinX, this.MaxY);
 
-            using var _ = rc.AutoResetClip(clippingRect);
-
             if (this.ColorAxis != null)
             {
                 // Draw the grouped (by color defined in ColorAxis) markers
@@ -414,7 +409,6 @@ namespace OxyPlot.Series
                 {
                     var color = this.ColorAxis.GetColor(group.Key);
                     rc.DrawMarkers(
-                        clippingRect,
                         group.Value,
                         this.MarkerType,
                         this.MarkerOutline,
@@ -430,7 +424,6 @@ namespace OxyPlot.Series
 
             // Draw unselected markers
             rc.DrawMarkers(
-                clippingRect,
                 allPoints,
                 this.MarkerType,
                 this.MarkerOutline,
@@ -444,7 +437,6 @@ namespace OxyPlot.Series
 
             // Draw the selected markers
             rc.DrawMarkers(
-                clippingRect,
                 selectedPoints,
                 this.MarkerType,
                 this.MarkerOutline,
@@ -476,7 +468,6 @@ namespace OxyPlot.Series
             var midpt = new ScreenPoint(xmid, ymid);
 
             rc.DrawMarker(
-                legendBox,
                 midpt,
                 this.MarkerType,
                 this.MarkerOutline,
@@ -588,8 +579,7 @@ namespace OxyPlot.Series
                     }
 #endif
 
-                rc.DrawClippedText(
-                    clippingRect,
+                rc.DrawText(
                     pt,
                     s,
                     this.ActualTextColor,

--- a/Source/OxyPlot/Series/StairStepSeries.cs
+++ b/Source/OxyPlot/Series/StairStepSeries.cs
@@ -148,7 +148,6 @@ namespace OxyPlot.Series
 
             this.VerifyAxes();
 
-            var clippingRect = this.GetClippingRect();
             var dashArray = this.ActualDashArray;
             var verticalLineDashArray = this.VerticalLineStyle.GetDashArray();
             var lineStyle = this.ActualLineStyle;
@@ -176,16 +175,14 @@ namespace OxyPlot.Series
                                 vlpts.Add(lpts[i + 2]);
                             }
 
-                            rc.DrawClippedLineSegments(
-                                clippingRect,
+                            rc.DrawLineSegments(
                                 hlpts,
                                 actualColor,
                                 this.StrokeThickness,
                                 this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
                                 dashArray,
                                 this.LineJoin);
-                            rc.DrawClippedLineSegments(
-                                clippingRect,
+                            rc.DrawLineSegments(
                                 vlpts,
                                 actualColor,
                                 verticalStrokeThickness,
@@ -195,10 +192,8 @@ namespace OxyPlot.Series
                         }
                         else
                         {
-                            rc.DrawClippedLine(
-                                clippingRect,
+                            rc.DrawLine(
                                 lpts,
-                                0,
                                 actualColor,
                                 this.StrokeThickness,
                                 this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
@@ -210,7 +205,6 @@ namespace OxyPlot.Series
                     if (this.MarkerType != MarkerType.None)
                     {
                         rc.DrawMarkers(
-                            clippingRect,
                             mpts,
                             this.MarkerType,
                             this.MarkerOutline,
@@ -255,7 +249,7 @@ namespace OxyPlot.Series
             if (this.LabelFormatString != null)
             {
                 // render point labels (not optimized for performance)
-                this.RenderPointLabels(rc, clippingRect);
+                this.RenderPointLabels(rc);
             }
         }
     }

--- a/Source/OxyPlot/Series/StemSeries.cs
+++ b/Source/OxyPlot/Series/StemSeries.cs
@@ -119,8 +119,6 @@ namespace OxyPlot.Series
 
             double minDistSquared = this.MinimumSegmentLength * this.MinimumSegmentLength;
 
-            var clippingRect = this.GetClippingRect();
-
             // Transform all points to screen coordinates
             // Render the line when invalid points occur
             var dashArray = this.ActualDashArray;
@@ -139,8 +137,7 @@ namespace OxyPlot.Series
 
                 if (this.StrokeThickness > 0 && this.ActualLineStyle != LineStyle.None)
                 {
-                    rc.DrawClippedLine(
-                        clippingRect,
+                    rc.DrawReducedLine(
                         points,
                         minDistSquared,
                         actualColor,
@@ -159,7 +156,6 @@ namespace OxyPlot.Series
             if (this.MarkerType != MarkerType.None)
             {
                 rc.DrawMarkers(
-                    clippingRect,
                     markerPoints,
                     this.MarkerType,
                     this.MarkerOutline,

--- a/Source/OxyPlot/Series/TwoColorAreaSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorAreaSeries.cs
@@ -167,10 +167,7 @@ namespace OxyPlot.Series
             return result;
         }
 
-        /// <summary>
-        /// Renders the series on the specified rendering context.
-        /// </summary>
-        /// <param name="rc">The rendering context.</param>
+        /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
             // determine render range
@@ -181,16 +178,12 @@ namespace OxyPlot.Series
 
             double minDistSquared = this.MinimumSegmentLength * this.MinimumSegmentLength;
 
-            var clippingRect = this.GetClippingRect();
-            using var _ = rc.AutoResetClip(clippingRect);
-
             var areaContext = new TwoColorAreaRenderContext
             {
                 Points = this.abovePoints,
                 WindowStartIndex = this.WindowStartIndex,
                 XMax = xmax,
                 RenderContext = rc,
-                ClippingRect = clippingRect,
                 MinDistSquared = minDistSquared,
                 Reverse = false,
                 Color = this.ActualColor,
@@ -240,7 +233,6 @@ namespace OxyPlot.Series
                 }
 
                 rc.DrawMarkers(
-                    clippingRect,
                     aboveMarkers,
                     this.MarkerType,
                     null,
@@ -251,7 +243,6 @@ namespace OxyPlot.Series
                     this.EdgeRenderingMode,
                     1);
                 rc.DrawMarkers(
-                    clippingRect,
                     belowMarkers,
                     this.MarkerType,
                     null,
@@ -315,8 +306,7 @@ namespace OxyPlot.Series
             var poligon = new List<ScreenPoint>(baseline);
             poligon.AddRange(result);
 
-            context.RenderContext.DrawClippedPolygon(
-                context.ClippingRect,
+            context.RenderContext.DrawReducedPolygon(
                 poligon,
                 context.MinDistSquared,
                 this.GetSelectableFillColor(twoColorContext.Fill),
@@ -330,7 +320,6 @@ namespace OxyPlot.Series
 
                 // draw the markers on top
                 context.RenderContext.DrawMarkers(
-                    context.ClippingRect,
                     result,
                     this.MarkerType,
                     null,

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -101,6 +101,12 @@ namespace OxyPlot.Series
         /// </summary>
         protected int WindowStartIndex { get; set; }
 
+        /// <inheritdoc/>
+        public OxyRect GetClippingRect()
+        {
+            return this.GetAxisClippingRect();
+        }
+
         /// <summary>
         /// Gets the rectangle the series uses on the screen (screen coordinates).
         /// </summary>

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -102,9 +102,9 @@ namespace OxyPlot.Series
         protected int WindowStartIndex { get; set; }
 
         /// <inheritdoc/>
-        public OxyRect GetClippingRect()
+        public override OxyRect GetClippingRect()
         {
-            return this.GetAxisClippingRect();
+            return PlotElementUtilities.GetOrientatedClippingRect(this);
         }
 
         /// <summary>
@@ -116,6 +116,12 @@ namespace OxyPlot.Series
             return this.GetClippingRect();
         }
 
+        /// <inheritdoc/>
+        public DataPoint InverseTransform(ScreenPoint p)
+        {
+            return PlotElementUtilities.InverseTransformOrientated(this, p);
+        }
+
         /// <summary>
         /// Renders the legend symbol on the specified rendering context.
         /// </summary>
@@ -123,6 +129,12 @@ namespace OxyPlot.Series
         /// <param name="legendBox">The legend rectangle.</param>
         public override void RenderLegend(IRenderContext rc, OxyRect legendBox)
         {
+        }
+
+        /// <inheritdoc/>
+        public ScreenPoint Transform(DataPoint p)
+        {
+            return PlotElementUtilities.TransformOrientated(this, p);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1661.

### Checklist

- [ ] I have included examples or tests (there are enough examples demonstration clipping I think)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Move responsibility for clipping out of the `Render` methods of `Series` and `Annotation`s
- Remove `DrawClippedXxx()` extensions
- Avoid unnecessary clipping calls

### Remarks

- The `PathAnnotation.ClipText` property for obvious reasons was broken by these changes. As it didn't quite seem to fit the overall design anyway and appears not to be very widely used, I decided to remove it. The only place that actually used this property was the Train Schedule example. As I quite liked this example I fixed it using an `Axis` for the station labels, which seems more sensible to me anyway.
- The `CandleStickAndVolumeSeries` could only be fixed by a rather ugly hack. If anything, this indicates to me that this series violates some of the design principles the library is built around, so I applied the hack and marked it as obsolete with the recommendation to use separate `CandleStickSeries` and `VolumeSeries` instead.
- I noticed that `Annotation`s could return different clipping rectangles depending on whether you use `Annotation.GetClippingRect()` or the `ITransposablePlotElement.GetClippingRect()` extension. As this is not an ideal situation, I slightly changed the design here to make it more consistent.

@oxyplot/admins
