### PR TITLE
Fix OpenStreetMap example (#1642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file.
 - Axes with `AxisPosition.None` make no contribution to margins (#1574)
 - `AngleAxis` has position `AxisPosition.All` by default (#1574)
 - Clipping API changed from SetClip(...) and ResetClip() to PushClip(...) and PopClip() (#1593)
+- Remove TileMapAnnotation examples from automated testing (#1667)
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ All notable changes to this project will be documented in this file.
 - MinimumPadding incorrect when MaximumPadding is non-zero (#1625)
 - Don't clip zerocrossing axis lines within plot bounds (#1441)
 - Incorrect margins when using Color Axes with AxisPosition.None (#1574)
+- OpenStreetMap example (#1642)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotation.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotation.cs
@@ -49,6 +49,7 @@ namespace ExampleLibrary
             this.MaxZoomLevel = 20;
             this.Opacity = 1.0;
             this.MaxNumberOfDownloads = 8;
+            this.UserAgent = "OxyPlotExampleLibrary";
         }
 
         /// <summary>
@@ -92,6 +93,11 @@ namespace ExampleLibrary
         /// </summary>
         /// <value>The opacity.</value>
         public double Opacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user agent used for requests.
+        /// </summary>
+        public string UserAgent { get; set; }
 
         /// <summary>
         /// Renders the annotation on the specified context.
@@ -312,6 +318,15 @@ namespace ExampleLibrary
             string uri = this.queue.Dequeue();
             var request = (HttpWebRequest)WebRequest.Create(uri);
             request.Method = "GET";
+
+#if NET45
+            // unavailable in NET Standard 1.0
+            request.UserAgent = this.UserAgent;
+#else
+            // compiles but does not run under NET Framework
+            request.Headers["User-Agent"] = this.UserAgent;
+#endif
+
             Interlocked.Increment(ref this.numberOfDownloads);
             request.BeginGetResponse(
                 r =>

--- a/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotationExamples.cs
@@ -16,6 +16,8 @@ namespace ExampleLibrary
         [Example("TileMapAnnotation (openstreetmap.org)")]
         public static PlotModel TileMapAnnotation2()
         {
+            // See policy document: https://operations.osmfoundation.org/policies/tiles/
+
             var model = new PlotModel { Title = "TileMapAnnotation" };
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 10.4, Maximum = 10.6, Title = "Longitude" });
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = 59.88, Maximum = 59.96, Title = "Latitude" });
@@ -25,7 +27,8 @@ namespace ExampleLibrary
                 new TileMapAnnotation
                     {
                         Url = "http://tile.openstreetmap.org/{Z}/{X}/{Y}.png",
-                        CopyrightNotice = "OpenStreetMap"
+                        CopyrightNotice = "OpenStreetMap",
+                        MaxNumberOfDownloads = 2,
                     });
 
             return model;

--- a/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotationExamples.cs
@@ -13,7 +13,7 @@ namespace ExampleLibrary
     [Examples("TileMapAnnotation"), Tags("Annotations")]
     public static class TileMapAnnotationExamples
     {
-        [Example("TileMapAnnotation (openstreetmap.org)")]
+        [Example("TileMapAnnotation (openstreetmap.org)", true)]
         public static PlotModel TileMapAnnotation2()
         {
             // See policy document: https://operations.osmfoundation.org/policies/tiles/
@@ -34,7 +34,7 @@ namespace ExampleLibrary
             return model;
         }
 
-        [Example("TileMapAnnotation (statkart.no)")]
+        [Example("TileMapAnnotation (statkart.no)", true)]
         public static PlotModel TileMapAnnotation()
         {
             var model = new PlotModel { Title = "TileMapAnnotation" };

--- a/Source/Examples/ExampleLibrary/Attributes/ExampleAttribute.cs
+++ b/Source/Examples/ExampleLibrary/Attributes/ExampleAttribute.cs
@@ -18,9 +18,11 @@ namespace ExampleLibrary
         /// Initializes a new instance of the <see cref="ExampleAttribute"/> class.
         /// </summary>
         /// <param name="title">The title.</param>
-        public ExampleAttribute(string title = null)
+        /// <param name="excludeFromAutomatedTests">A value indiciating whether the example should be excluded from automated tests.</param>
+        public ExampleAttribute(string title = null, bool excludeFromAutomatedTests = false)
         {
             this.Title = title;
+            ExcludeFromAutomatedTests = excludeFromAutomatedTests;
         }
 
         /// <summary>
@@ -30,5 +32,13 @@ namespace ExampleLibrary
         /// The title.
         /// </value>
         public string Title { get; private set; }
+
+        /// <summary>
+        /// Gets a value indiciating whether this example should be excluded from automated tests.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the example should be excluded from automated tests, otherwise <c>false</c>.
+        /// </value>
+        public bool ExcludeFromAutomatedTests { get; }
     }
 }

--- a/Source/Examples/ExampleLibrary/Attributes/ExampleAttribute.cs
+++ b/Source/Examples/ExampleLibrary/Attributes/ExampleAttribute.cs
@@ -22,7 +22,7 @@ namespace ExampleLibrary
         public ExampleAttribute(string title = null, bool excludeFromAutomatedTests = false)
         {
             this.Title = title;
-            ExcludeFromAutomatedTests = excludeFromAutomatedTests;
+            this.ExcludeFromAutomatedTests = excludeFromAutomatedTests;
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/ExampleInfo.cs
+++ b/Source/Examples/ExampleLibrary/ExampleInfo.cs
@@ -51,6 +51,7 @@ namespace ExampleLibrary
         /// <param name="title">The title.</param>
         /// <param name="tags">The tags.</param>
         /// <param name="method">The method.</param>
+        /// <param name="excludeFromAutomatedTests">A value indiciating whether the example should be excluded from automated tests.</param>
         public ExampleInfo(string category, string title, string[] tags, MethodInfo method, bool excludeFromAutomatedTests)
         {
             this.Category = category;

--- a/Source/Examples/ExampleLibrary/ExampleInfo.cs
+++ b/Source/Examples/ExampleLibrary/ExampleInfo.cs
@@ -51,12 +51,13 @@ namespace ExampleLibrary
         /// <param name="title">The title.</param>
         /// <param name="tags">The tags.</param>
         /// <param name="method">The method.</param>
-        public ExampleInfo(string category, string title, string[] tags, MethodInfo method)
+        public ExampleInfo(string category, string title, string[] tags, MethodInfo method, bool excludeFromAutomatedTests)
         {
             this.Category = category;
             this.Title = title;
             this.Tags = tags;
             this.method = method;
+            this.ExcludeFromAutomatedTests = excludeFromAutomatedTests;
         }
 
         /// <summary>
@@ -202,6 +203,14 @@ namespace ExampleLibrary
         /// The tags.
         /// </value>
         public string[] Tags { get; }
+
+        /// <summary>
+        /// Gets a value indiciating whether this example should be excluded from automated tests.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the example should be excluded from automated tests, otherwise <c>false</c>.
+        /// </value>
+        public bool ExcludeFromAutomatedTests { get; }
 
         /// <summary>
         /// Gets the title.

--- a/Source/Examples/ExampleLibrary/Examples.cs
+++ b/Source/Examples/ExampleLibrary/Examples.cs
@@ -49,7 +49,8 @@ namespace ExampleLibrary
                                 examplesAttribute.Category,
                                 exampleAttribute.Title,
                                 tags.ToArray(),
-                                method);
+                                method,
+                                exampleAttribute.ExcludeFromAutomatedTests);
                     }
                 }
             }
@@ -75,21 +76,29 @@ namespace ExampleLibrary
         }
 
         /// <summary>
-        /// Gets the first example of each category.
+        /// Gets all examples suitable for automated test.
         /// </summary>
-        public static IEnumerable<ExampleInfo> GetFirstExampleOfEachCategory()
+        public static IEnumerable<ExampleInfo> GetListForAutomatedTest()
         {
-            return GetList()
+            return GetList().Where(ex => !ex.ExcludeFromAutomatedTests);
+        }
+
+        /// <summary>
+        /// Gets the first example of each category suitable for automated test.
+        /// </summary>
+        public static IEnumerable<ExampleInfo> GetFirstExampleOfEachCategoryForAutomatedTest()
+        {
+            return GetListForAutomatedTest()
                 .GroupBy(example => example.Category)
                 .Select(group => group.First());
         }
 
         /// <summary>
-        /// Gets the 'rendering capabilities' examples.
+        /// Gets the 'rendering capabilities' examples suitable for automated test.
         /// </summary>
-        public static IEnumerable<ExampleInfo> GetRenderingCapabilities()
+        public static IEnumerable<ExampleInfo> GetRenderingCapabilitiesForAutomatedTest()
         {
-            return GetCategory(typeof(RenderingCapabilities));
+            return GetCategory(typeof(RenderingCapabilities)).Where(ex => !ex.ExcludeFromAutomatedTests);
         }
     }
 }

--- a/Source/OxyPlot.ImageSharp.Tests/JpegExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/JpegExporterTests.cs
@@ -14,6 +14,7 @@ namespace OxyPlot.ImageSharp.Tests
     using OxyPlot.ImageSharp;
     using OxyPlot.Annotations;
     using ExampleLibrary;
+    using System.Linq;
 
     [TestFixture]
     public class JpegExporterTests
@@ -33,7 +34,7 @@ namespace OxyPlot.ImageSharp.Tests
         {
             var exporter = new JpegExporter(400, 300);
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".jpg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".jpg");
         }
 
         [Test]

--- a/Source/OxyPlot.ImageSharp.Tests/PngExporterTests.cs
+++ b/Source/OxyPlot.ImageSharp.Tests/PngExporterTests.cs
@@ -33,10 +33,10 @@ namespace OxyPlot.ImageSharp.Tests
         {
             var exporter = new PngExporter(400, 300);
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".png");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".png");
             exporter.Width = 800;
             exporter.Height = 600;
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilities(), exporter, directory, ".png");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilitiesForAutomatedTest(), exporter, directory, ".png");
         }
 
         [Test]

--- a/Source/OxyPlot.Pdf.Tests/PdfExporterTests.cs
+++ b/Source/OxyPlot.Pdf.Tests/PdfExporterTests.cs
@@ -33,7 +33,7 @@ namespace OxyPlot.Pdf.Tests
             const double Width = 297 / 25.4 * 72;
             const double Height = 210 / 25.4 * 72;
 
-            foreach (var example in Examples.GetList())
+            foreach (var example in Examples.GetListForAutomatedTest())
             {
                 void ExportModelAndCheckFileExists(PlotModel model, string fileName)
                 {

--- a/Source/OxyPlot.SkiaSharp.Tests/JpegExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/JpegExporterTests.cs
@@ -32,10 +32,10 @@ namespace OxyPlot.SkiaSharp.Tests
         {
             var exporter = new JpegExporter { Width = 400, Height = 300 };
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".jpg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".jpg");
             exporter.Width = 800;
             exporter.Height = 600;
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilities(), exporter, directory, ".jpg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilitiesForAutomatedTest(), exporter, directory, ".jpg");
         }
 
         [Test]

--- a/Source/OxyPlot.SkiaSharp.Tests/PdfExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/PdfExporterTests.cs
@@ -32,8 +32,8 @@ namespace OxyPlot.SkiaSharp.Tests
         {
             var exporter = new PdfExporter { Width = 297 / 25.4f * 72, Height = 210 / 25.4f * 72 };
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".pdf");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilities(), exporter, directory, ".pdf");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".pdf");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilitiesForAutomatedTest(), exporter, directory, ".pdf");
         }
 
         [Test]

--- a/Source/OxyPlot.SkiaSharp.Tests/PngExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/PngExporterTests.cs
@@ -32,10 +32,10 @@ namespace OxyPlot.SkiaSharp.Tests
         {
             var exporter = new PngExporter { Width = 400, Height = 300 };
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".png");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".png");
             exporter.Width = 800;
             exporter.Height = 600;
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilities(), exporter, directory, ".png");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilitiesForAutomatedTest(), exporter, directory, ".png");
         }
 
         [Test]

--- a/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
+++ b/Source/OxyPlot.SkiaSharp.Tests/SvgExporterTests.cs
@@ -22,8 +22,8 @@ namespace OxyPlot.SkiaSharp.Tests
         {
             var exporter = new SvgExporter { Width = 1000, Height = 750 };
             var directory = Path.Combine(this.outputDirectory, "ExampleLibrary");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategory(), exporter, directory, ".svg");
-            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilities(), exporter, directory, ".svg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetFirstExampleOfEachCategoryForAutomatedTest(), exporter, directory, ".svg");
+            ExportTest.ExportExamples_CheckThatAllFilesExist(Examples.GetRenderingCapabilitiesForAutomatedTest(), exporter, directory, ".svg");
         }
 
         [Test]

--- a/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
+++ b/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
@@ -23,7 +23,7 @@ namespace OxyPlot.Tests
         [Test]
         public void GenerateCodeForAllExamplesInExampleLibrary()
         {
-            foreach (var ei in ExampleLibrary.Examples.GetList())
+            foreach (var ei in ExampleLibrary.Examples.GetListForAutomatedTest())
             {
                 void CheckCode(PlotModel model)
                 {

--- a/Source/OxyPlot.Tests/Pdf/PdfExporterTests.cs
+++ b/Source/OxyPlot.Tests/Pdf/PdfExporterTests.cs
@@ -31,7 +31,7 @@ namespace OxyPlot.Tests
             const double Width = 297 / 25.4 * 72;
             const double Height = 210 / 25.4 * 72;
 
-            foreach (var example in Examples.GetList())
+            foreach (var example in Examples.GetListForAutomatedTest())
             {
                 void ExportModelAndCheckFileExists(PlotModel model, string fileName)
                 {

--- a/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
+++ b/Source/OxyPlot.Tests/PlotModel/PlotModelTests.cs
@@ -29,7 +29,7 @@ namespace OxyPlot.Tests
         [Test]
         public void Update_AllExamples_ThrowsNoExceptions()
         {
-            foreach (var example in Examples.GetList())
+            foreach (var example in Examples.GetListForAutomatedTest())
             {
                 ((IPlotModel)example.PlotModel)?.Update(true);
 

--- a/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
+++ b/Source/OxyPlot.Tests/Svg/SvgExporterTests.cs
@@ -62,7 +62,7 @@ namespace OxyPlot.Tests
                 Directory.CreateDirectory(DestinationDirectory);
             }
 
-            foreach (var example in Examples.GetList())
+            foreach (var example in Examples.GetListForAutomatedTest())
             {
                 void ExportModelAndCheckFileExists(PlotModel model, string fileName)
                 {

--- a/Source/OxyPlot.Wpf.Tests/ExampleLibraryTests.cs
+++ b/Source/OxyPlot.Wpf.Tests/ExampleLibraryTests.cs
@@ -11,7 +11,7 @@ namespace OxyPlot.Wpf.Tests
 {
     using System;
     using System.IO;
-
+    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>
@@ -45,7 +45,7 @@ namespace OxyPlot.Wpf.Tests
                 Directory.CreateDirectory(DiffDirectory);
             }
 
-            foreach (var example in ExampleLibrary.Examples.GetList())
+            foreach (var example in ExampleLibrary.Examples.GetListForAutomatedTest())
             {
                 void ExportAndCompareToBaseline(PlotModel model, string fileName)
                 {


### PR DESCRIPTION
Fixes #1642

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- As per the suggestions in #1642 and the OSM policy documentation (https://operations.osmfoundation.org/policies/tiles/)
  - Limits the number of download threads for OSM to 2
  - Adds a configurable UserAgent defaulting to "OxyPlotExampleLibrary"

Setting the user agent is a bit unpleasant, but has been tested with the NET Framework 4.6.1 and NET Core 3.1 WinForms example browser.

@oxyplot/admins
