### PR TITLE
Add netstandard2.0 target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - IRenderContext.ClipCount property (#1593)
 - Additional parameters for HistogramSeries LabelFormatString
 - Absolute screen-space axis margins (#1569)
+- netstandard2.0 TargetFramework (#1668)
 
 ### Changed
 - Legends model (#644)

--- a/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net45</TargetFrameworks>
     <PackageId>OxyPlot.ExampleLibrary</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Example models for OxyPlot.</Description>

--- a/Source/OxyPlot.ImageSharp/OxyPlot.ImageSharp.csproj
+++ b/Source/OxyPlot.ImageSharp/OxyPlot.ImageSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8</LangVersion>
-        <TargetFramework>netstandard1.3</TargetFramework>
+        <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
         <Description>OxyPlot is a plotting library for .NET. This is package is based on SixLabors.ImageSharp.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>8</LangVersion>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright (c) 2020 OxyPlot contributors</Copyright>
     <Authors>OxyPlot contributors</Authors>

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.0;net45;net40</TargetFrameworks>
+        <TargetFrameworks>netstandard1.0;netstandard2.0;net45;net40</TargetFrameworks>
         <PackageId>OxyPlot.Core</PackageId>
         <Description>OxyPlot is a plotting library for .NET. This is the core library including the foundation classes and plot model. To display the plots, you also need to add a platform-specific OxyPlot package that contains a PlotView component.</Description>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>


### PR DESCRIPTION
Fixes #1668 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add `netstandard2.0` target to `OxyPlot`, `OxyPlot.SkiaSharp`, `OxyPlot.ImageSharp` and `ExampleLibrary`

@oxyplot/admins
