### PR TITLE
Sign OxyPlot.Wpf (#1676)

### DIFF
--- a/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
+++ b/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>8</LangVersion>
+    <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Fixes #1676 .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Sign OxyPlot.Wpf, which is necessary for net framework applications to use it, and is blocking progress on OxyPlot.Contrib at the moment. Signing went missing with the split into Shared/WPF/Skia

@oxyplot/admins
