### PR TITLE
Fix incorrect clipping in TwoColorAreaSeries (#1678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to this project will be documented in this file.
 - Don't clip zerocrossing axis lines within plot bounds (#1441)
 - Incorrect margins when using Color Axes with AxisPosition.None (#1574)
 - OpenStreetMap example (#1642)
+- Incorrect clipping in TwoColorAreaSeries (#1678)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot/Series/TwoColorAreaSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorAreaSeries.cs
@@ -197,6 +197,7 @@ namespace OxyPlot.Series
             this.RenderChunkedPoints(areaContext);
 
             areaContext.Points = this.belowPoints;
+            areaContext.WindowStartIndex = this.WindowStartIndex2;
             areaContext.Reverse = this.Reverse2;
             areaContext.Color = this.ActualColor2;
             areaContext.Fill = this.ActualFill2;


### PR DESCRIPTION
Fixes #1678 .

### Checklist

- [ ] I have included examples or tests (existing example TwoColorAreaSeries, Temperature)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Set the WindowsStartIndex correctly for the below points

@oxyplot/admins
