### PR TITLE
Potential fix for ScreenMin and ScreenMax on Horizontal and Vertical Axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ All notable changes to this project will be documented in this file.
 - Incorrect margins when using Color Axes with AxisPosition.None (#1574)
 - OpenStreetMap example (#1642)
 - Incorrect clipping in TwoColorAreaSeries (#1678)
+- ScreenMin and ScreenMax on Horizontal and Vertical Axes depends on plot bounds (#1652)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1427,8 +1427,16 @@ namespace OxyPlot.Axes
                 a1 -= this.MaximumMargin * marginSign;
             }
 
-            this.ScreenMin = new ScreenPoint(a0, a1);
-            this.ScreenMax = new ScreenPoint(a1, a0);
+            if (this.IsHorizontal())
+            {
+                this.ScreenMin = new ScreenPoint(a0, y1);
+                this.ScreenMax = new ScreenPoint(a1, y0);
+            }
+            else if (this.IsVertical())
+            {
+                this.ScreenMin = new ScreenPoint(x0, a1);
+                this.ScreenMax = new ScreenPoint(x1, a0);
+            }
 
             if (this.MinimumDataMargin > 0)
             {


### PR DESCRIPTION
Addresses #1652 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Make the ScreenMin and ScreenMax of horizontal and vertical axes depend on their own clipping region and the plot bounds.

This makes much more sense than what they currently do, and the rendering code is already only using the 'correct' components of the two values. It may be possible to simplify some code (e.g. gridline cropping) as now the cropping region for the axis pair is just the intersection of the rectangles determined by ScreenMin/ScreenMax.

@oxyplot/admins
