### PR TITLE
Improve performance of CanvasRenderContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ All notable changes to this project will be documented in this file.
 - Additional parameters for HistogramSeries LabelFormatString
 - Absolute screen-space axis margins (#1569)
 - netstandard2.0 TargetFramework (#1668)
-- Add a PlotView.TextMeasurementMethod property to allow using the much faster GlyphTypeface based measurement at runtime
+- Add a PlotView.TextMeasurementMethod property to allow using the much faster GlyphTypeface based measurement at runtime (#1673)
+- OxyPlot.Wpf.XamlRenderContext - this doesn't use StreamGeometry and can be used for rendering to XAML (#1673)
 
 ### Changed
 - Legends model (#644)
@@ -73,8 +74,7 @@ All notable changes to this project will be documented in this file.
 - Remove TileMapAnnotation examples from automated testing (#1667)
 - Optimize clipping calls (#1661)
 - Mark CandleStickAndVolumeSeries as obsolete (#1661)
-- Refactor DrawLineSegmentsByStreamGeometry() to draw much faster
-- Implement StreamGeometry-based implementations of DrawEllipses, DrawLine, and DrawRectangle(s) which improves the rendering speed.
+- Implement StreamGeometry-based implementations of DrawEllipses, DrawLine, DrawLineSegments and DrawRectangle(s) which improves the rendering speed on WPF (#1673)
 
 ### Removed
 - Remove PlotModel.Legends (#644)
@@ -89,6 +89,7 @@ All notable changes to this project will be documented in this file.
 - CohenSutherlandClipping and SutherlandHodgmanClipping (#1593)
 - DrawClippedXxx(...) extensions in RenderingExtensions (#1661)
 - PathAnnotation.ClipText property - text is now always clipped (#1661)
+- CanvasRenderContext.UseStreamGeometry property - this functionality is replaced by the new XamlRenderContext (#1673)
 
 ### Fixed
 - Legend font size is not affected by DefaultFontSize (#1396)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Additional parameters for HistogramSeries LabelFormatString
 - Absolute screen-space axis margins (#1569)
 - netstandard2.0 TargetFramework (#1668)
+- Add a PlotView.TextMeasurementMethod property to allow using the much faster GlyphTypeface based measurement at runtime
 
 ### Changed
 - Legends model (#644)
@@ -72,6 +73,8 @@ All notable changes to this project will be documented in this file.
 - Remove TileMapAnnotation examples from automated testing (#1667)
 - Optimize clipping calls (#1661)
 - Mark CandleStickAndVolumeSeries as obsolete (#1661)
+- Refactor DrawLineSegmentsByStreamGeometry() to draw much faster
+- Implement StreamGeometry-based implementations of DrawEllipses, DrawLine, and DrawRectangle(s) which improves the rendering speed.
 
 ### Removed
 - Remove PlotModel.Legends (#644)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -98,6 +98,7 @@ Peter-B-
 Philippe AURIOU <p.auriou@live.fr>
 Piotr Warzocha <pw@piootr.pl>
 Poul Erik Venø <poulerikvenoehansen@gmail.com>
+Régis Boudin <regis@boudin.name>
 Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
 Sarah Müller <sy-mueller@gmx-topmail.de>

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -16,6 +16,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Annotations;
     using System.Linq;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Provides rendering capability examples.
@@ -822,6 +823,41 @@ namespace ExampleLibrary
                     rowCounter++;
                 }
 
+            }));
+            return model;
+        }
+
+        [Example("Ellipse Drawing")]
+        public static PlotModel EllipseDrawing()
+        {
+            const double RADIUS_X = 300;
+            const double RADIUS_Y = 100;
+            const double CENTER_X = RADIUS_X * 1.2;
+            const double CENTER_Y = RADIUS_Y * 1.2;
+
+            var radiusXSquare = RADIUS_X * RADIUS_X;
+            var radiusYSquare = RADIUS_Y * RADIUS_Y;
+            var n = 200;
+
+            var model = new PlotModel();
+            model.Annotations.Add(new DelegateAnnotation(rc =>
+            {
+                var rect = new OxyRect(CENTER_X - RADIUS_X, CENTER_Y - RADIUS_Y, RADIUS_X * 2, RADIUS_Y * 2);
+
+                var points = new ScreenPoint[n];
+                var cx = (rect.Left + rect.Right) / 2;
+                var cy = (rect.Top + rect.Bottom) / 2;
+                var rx = (rect.Right - rect.Left) / 2;
+                var ry = (rect.Bottom - rect.Top) / 2;
+                for (var i = 0; i < n; i++)
+                {
+                    var a = Math.PI * 2 * i / (n - 1);
+                    points[i] = new ScreenPoint(cx + (rx * Math.Cos(a)), cy + (ry * Math.Sin(a)));
+                }
+
+                rc.DrawPolygon(points, OxyColors.Undefined, OxyColors.Black, 4, EdgeRenderingMode.PreferGeometricAccuracy);
+                rc.DrawEllipse(rect, OxyColors.Undefined, OxyColors.White, 2, EdgeRenderingMode.PreferGeometricAccuracy);
+                rc.DrawText(new ScreenPoint(CENTER_X, CENTER_Y), "The white ellipse (drawn by Renderer) should match the black ellipse (drawn as Path).", OxyColors.Black, fontSize: 12, horizontalAlignment: HorizontalAlignment.Center, verticalAlignment: VerticalAlignment.Middle);
             }));
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -771,6 +771,61 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("LineJoin")]
+        public static PlotModel LineJoins()
+        {
+            const double STROKE_THICKNESS = 15;
+            const double LINE_LENGTH = 60;
+            var ANGLES = new[] { 135, 90, 45, 22.5 };
+            const double COL_WIDTH = 140;
+            const double ROW_HEIGHT = 90;
+            const double ROW_HEADER_WIDTH = 50;
+            const double COL_HEADER_HEIGHT = 50;
+
+
+            var model = new PlotModel();
+            model.Annotations.Add(new DelegateAnnotation(rc =>
+            {
+                var colCounter = 0;
+                var rowCounter = 0;
+                foreach (LineJoin lineJoin in Enum.GetValues(typeof(LineJoin)))
+                {
+                    var p = new ScreenPoint(COL_WIDTH * (colCounter + 0.5) + ROW_HEADER_WIDTH, COL_HEADER_HEIGHT / 2);
+                    rc.DrawText(p, lineJoin.ToString(), OxyColors.Black, fontSize: 12, horizontalAlignment: HorizontalAlignment.Center, verticalAlignment: VerticalAlignment.Middle);
+                    colCounter++;
+                }
+
+                foreach (var angle in ANGLES)
+                {
+                    colCounter = 0;
+                    var y = ROW_HEIGHT * rowCounter + COL_HEADER_HEIGHT;
+                    var halfAngle = angle / 2 / 360 * 2 * Math.PI;
+                    var dx = Math.Sin(halfAngle) * LINE_LENGTH;
+                    var dy = Math.Cos(halfAngle) * LINE_LENGTH;
+
+                    var textP = new ScreenPoint(15, y);
+                    rc.DrawText(textP, angle.ToString() + "°", OxyColors.Black, fontSize: 12);
+
+                    foreach (LineJoin lineJoin in Enum.GetValues(typeof(LineJoin)))
+                    {
+                        var x = COL_WIDTH * (colCounter + 0.5) + ROW_HEADER_WIDTH;
+
+                        var pMid = new ScreenPoint(x, y);
+                        var p1 = new ScreenPoint(x - dx, y + dy);
+                        var p2 = new ScreenPoint(x + dx, y + dy);
+
+                        rc.DrawLine(new[] { p1, pMid, p2 }, OxyColors.CornflowerBlue, STROKE_THICKNESS, EdgeRenderingMode.PreferGeometricAccuracy, lineJoin: lineJoin);
+
+                        colCounter++;
+                    }
+
+                    rowCounter++;
+                }
+
+            }));
+            return model;
+        }
+
         /// <summary>
         /// Represents an annotation that renders by a delegate.
         /// </summary>

--- a/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml
@@ -111,7 +111,8 @@
                             <local:NotNullVisibilityConverter x:Key="NotNullVisibilityConverter" />
                         </Grid.Resources>
                         <oxySkia:PlotView Model="{Binding SkiaModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding SkiaModel, Converter={StaticResource NotNullVisibilityConverter}}" />
-                        <oxyWpf:PlotView x:Name="Plot1" Model="{Binding CanvasModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding CanvasModel, Converter={StaticResource NotNullVisibilityConverter}}" />
+                        <oxyWpf:PlotView Model="{Binding CanvasModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding CanvasModel, Converter={StaticResource NotNullVisibilityConverter}}" />
+                        <local:XamlPlotView Model="{Binding CanvasXamlModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding CanvasXamlModel, Converter={StaticResource NotNullVisibilityConverter}}" />
                     </Grid>
                 </TabItem>
                 <TabItem Header="Code">

--- a/Source/Examples/WPF/ExampleBrowser/Renderer.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Renderer.cs
@@ -9,6 +9,7 @@ namespace ExampleBrowser
     public enum Renderer
     {
         Canvas,
+        Canvas_XAML,
         SkiaSharp
     }
 }

--- a/Source/Examples/WPF/ExampleBrowser/XamlPlotView.cs
+++ b/Source/Examples/WPF/ExampleBrowser/XamlPlotView.cs
@@ -1,0 +1,22 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="XamlPlotView.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ExampleBrowser
+{
+    using OxyPlot;
+    using OxyPlot.Wpf;
+
+    /// <summary>
+    /// Represents a PlotView which uses the XamlRenderContext for rendering.
+    /// </summary>
+    public class XamlPlotView : PlotView
+    {
+        protected override IRenderContext CreateRenderContext()
+        {
+            return new XamlRenderContext(this.Canvas);
+        }
+    }
+}

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -126,19 +126,12 @@ namespace OxyPlot.Wpf
             {
                 foreach (var rect in rectangles)
                 {
-                    const double arcAsBezier = 0.551784;
-
-                    var centerX = rect.Center.X;
                     var centerY = rect.Center.Y;
-
-                    var midX = Math.Abs(rect.Width / 2.0) * arcAsBezier;
-                    var midY = Math.Abs(rect.Height / 2.0) * arcAsBezier;
-
                     sgc.BeginFigure(new Point(rect.Right, centerY), isFilled, true);
-                    sgc.BezierTo(new Point(rect.Right, centerY + midY), new Point(centerX + midX, rect.Bottom), new Point(centerX, rect.Bottom), isStroke, true);
-                    sgc.BezierTo(new Point(centerX - midX, rect.Bottom), new Point(rect.Left, centerY + midY), new Point(rect.Left, centerY), isStroke, true);
-                    sgc.BezierTo(new Point(rect.Left, centerY - midY), new Point(centerX - midX, rect.Top), new Point(centerX, rect.Top), isStroke, true);
-                    sgc.BezierTo(new Point(centerX + midX, rect.Top), new Point(rect.Right, centerY - midY), new Point(rect.Right, centerY), isStroke, true);
+
+                    var size = new Size(rect.Width / 2, rect.Height / 2);
+                    sgc.ArcTo(new Point(rect.Left, centerY), size, 180, false, SweepDirection.Clockwise, isStroke, false);
+                    sgc.ArcTo(new Point(rect.Right, centerY), size, 180, false, SweepDirection.Clockwise, isStroke, false);
                 }
             }
 

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -30,21 +30,6 @@ namespace OxyPlot.Wpf
     public class CanvasRenderContext : ClippingRenderContext
     {
         /// <summary>
-        /// The maximum number of figures per geometry.
-        /// </summary>
-        private const int MaxFiguresPerGeometry = 16;
-
-        /// <summary>
-        /// The maximum number of polylines per line.
-        /// </summary>
-        private const int MaxPolylinesPerLine = 64;
-
-        /// <summary>
-        /// The minimum number of points per polyline.
-        /// </summary>
-        private const int MinPointsPerPolyline = 16;
-
-        /// <summary>
         /// The images in use
         /// </summary>
         private readonly HashSet<OxyImage> imagesInUse = new HashSet<OxyImage>();
@@ -98,9 +83,7 @@ namespace OxyPlot.Wpf
             this.canvas = canvas;
             this.TextFormattingMode = TextFormattingMode.Display;
             this.TextMeasurementMethod = TextMeasurementMethod.TextBlock;
-            this.UseStreamGeometry = true;
             this.RendersToScreen = true;
-            this.BalancedLineDrawingThicknessLimit = 3.5;
         }
 
         /// <summary>
@@ -115,18 +98,6 @@ namespace OxyPlot.Wpf
         /// <value>The text formatting mode. The default value is <see cref="System.Windows.Media.TextFormattingMode.Display"/>.</value>
         public TextFormattingMode TextFormattingMode { get; set; }
 
-        /// <summary>
-        /// Gets or sets the thickness limit for "balanced" line drawing.
-        /// </summary>
-        public double BalancedLineDrawingThicknessLimit { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to use stream geometry for lines and polygons rendering.
-        /// </summary>
-        /// <value><c>true</c> if stream geometry should be used; otherwise, <c>false</c> .</value>
-        /// <remarks>The XamlWriter does not serialize StreamGeometry, so set this to <c>false</c> if you want to export to XAML. Using stream geometry seems to be slightly faster than using path geometry.</remarks>
-        public bool UseStreamGeometry { get; set; }
-
         ///<inheritdoc/>
         public override void DrawEllipse(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
@@ -136,41 +107,11 @@ namespace OxyPlot.Wpf
         ///<inheritdoc/>
         public override void DrawEllipses(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
-            if (this.UseStreamGeometry)
+            if (rectangles.Count == 0)
             {
-                this.DrawEllipsesByStreamGeometry(rectangles, fill, stroke, thickness, edgeRenderingMode);
                 return;
             }
 
-            var path = this.CreateAndAdd<Path>();
-            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
-            if (!fill.IsUndefined())
-            {
-                path.Fill = this.GetCachedBrush(fill);
-            }
-
-            var gg = new GeometryGroup { FillRule = FillRule.Nonzero };
-            foreach (var rect in rectangles)
-            {
-                gg.Children.Add(new EllipseGeometry(ToRect(rect)));
-            }
-
-            path.Data = gg;
-        }
-
-        /// <summary>
-        /// Draws a collection of ellipses, where all have the same stroke and fill, using a StreamGeometry.
-        /// </summary>
-        /// <param name="rectangles">The rectangles defining the extents of the ellipses.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the ellipses will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the ellipses will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        /// <remarks>
-        /// This should have better performance than calling <see cref="DrawEllipse" /> multiple times.
-        /// </remarks>
-        private void DrawEllipsesByStreamGeometry(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
-        {
             var path = this.CreateAndAdd<Path>();
             this.SetStroke(path, stroke, thickness, edgeRenderingMode);
             if (!fill.IsUndefined())
@@ -201,6 +142,7 @@ namespace OxyPlot.Wpf
                 }
             }
 
+            streamGeometry.Freeze();
             path.Data = streamGeometry;
         }
 
@@ -213,53 +155,27 @@ namespace OxyPlot.Wpf
             double[] dashArray,
             LineJoin lineJoin)
         {
-            if (thickness < this.BalancedLineDrawingThicknessLimit)
+            if (points.Count < 2)
             {
-                this.DrawLineBalanced(points, stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
                 return;
             }
 
-            if (this.UseStreamGeometry)
-            {
-                this.DrawLineByStreamGeometry(points, stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
-                return;
-            }
-
-            var e = this.CreateAndAdd<Polyline>();
-            this.SetStroke(e, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-            e.Points = this.ToPointCollection(points, e.StrokeThickness, edgeRenderingMode);
-        }
-
-        /// <summary>
-        /// Draws a polyline using a StreamGeometry.
-        /// </summary>
-        /// <param name="points">The points defining the polyline. The polyline is drawn from point 0, to point 1, to point 2 and so on.</param>
-        /// <param name="stroke">The stroke color.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        /// <param name="dashArray">The dash array (in device independent units, 1/96 inch). Use <c>null</c> to get a solid line.</param>
-        /// <param name="lineJoin">The line join type.</param>
-        public void DrawLineByStreamGeometry(
-            IList<ScreenPoint> points,
-            OxyColor stroke,
-            double thickness,
-            EdgeRenderingMode edgeRenderingMode,
-            double[] dashArray,
-            LineJoin lineJoin)
-        {
             var path = this.CreateAndAdd<Path>();
             this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray);
 
             var actualStrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
-            var actualPoints = this.GetActualPointsForStreamGeometry(points, actualStrokeThickness, edgeRenderingMode);
+
+            var actualPoints = this.GetActualPoints(points, actualStrokeThickness, edgeRenderingMode);
+            var firstPoint = GetFirstAndRest(actualPoints, out var otherPoints);
 
             var streamGeometry = new StreamGeometry();
             using (var streamGeometryContext = streamGeometry.Open())
             {
-                streamGeometryContext.BeginFigure(actualPoints.Item1, false, false);
-                streamGeometryContext.PolyLineTo(actualPoints.Item2, !stroke.IsUndefined(), true);
+                streamGeometryContext.BeginFigure(firstPoint, false, false);
+                streamGeometryContext.PolyLineTo(otherPoints, !stroke.IsUndefined(), false);
             }
 
+            streamGeometry.Freeze();
             path.Data = streamGeometry;
         }
 
@@ -272,47 +188,30 @@ namespace OxyPlot.Wpf
             double[] dashArray,
             LineJoin lineJoin)
         {
-            if (this.UseStreamGeometry)
+            if (points.Count < 2)
             {
-                this.DrawLineSegmentsByStreamGeometry(points, stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
                 return;
             }
 
-            Path path = null;
-            PathGeometry pathGeometry = null;
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
 
-            int count = 0;
+            var actualStrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
+            var actualPoints = this.GetActualPoints(points, actualStrokeThickness, edgeRenderingMode);
+            var firstPoint = GetFirstAndRest(actualPoints, out var otherPoints);
 
-            for (int i = 0; i + 1 < points.Count; i += 2)
+            var streamGeometry = new StreamGeometry();
+            using (var streamGeometryContext = streamGeometry.Open())
             {
-                if (path == null)
+                streamGeometryContext.BeginFigure(firstPoint, false, false);
+                for (var i = 0; i < otherPoints.Count; i++)
                 {
-                    path = this.CreateAndAdd<Path>();
-                    this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-                    pathGeometry = new PathGeometry();
-                }
-
-                var actualPoints = this.GetActualPoints( new[] { points[i], points[i + 1] }, path.StrokeThickness, edgeRenderingMode).ToList();
-
-                var figure = new PathFigure { StartPoint = actualPoints[0], IsClosed = false };
-                figure.Segments.Add(new LineSegment(actualPoints[1], true) { IsSmoothJoin = false });
-                pathGeometry.Figures.Add(figure);
-
-                count++;
-
-                // Must limit the number of figures, otherwise drawing errors...
-                if (count > MaxFiguresPerGeometry || dashArray != null)
-                {
-                    path.Data = pathGeometry;
-                    path = null;
-                    count = 0;
+                    streamGeometryContext.LineTo(otherPoints[i], (i & 0x1) == 0, false);
                 }
             }
 
-            if (path != null)
-            {
-                path.Data = pathGeometry;
-            }
+            streamGeometry.Freeze();
+            path.Data = streamGeometry;
         }
 
         ///<inheritdoc/>
@@ -325,15 +224,7 @@ namespace OxyPlot.Wpf
             double[] dashArray,
             LineJoin lineJoin)
         {
-            var e = this.CreateAndAdd<Polygon>();
-            this.SetStroke(e, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-
-            if (!fill.IsUndefined())
-            {
-                e.Fill = this.GetCachedBrush(fill);
-            }
-
-            e.Points = this.ToPointCollection(points, e.StrokeThickness, edgeRenderingMode);
+            this.DrawPolygons(new[] { points }, fill, stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
         }
 
         ///<inheritdoc/>
@@ -346,133 +237,49 @@ namespace OxyPlot.Wpf
             double[] dashArray,
             LineJoin lineJoin)
         {
-            var usg = this.UseStreamGeometry;
-            Path path = null;
-            StreamGeometry streamGeometry = null;
-            StreamGeometryContext sgc = null;
-            PathGeometry pathGeometry = null;
-            int count = 0;
-
-            foreach (var polygon in polygons)
+            if (polygons.Count == 0)
             {
-                if (path == null)
+                return;
+            }
+
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
+            if (!fill.IsUndefined())
+            {
+                path.Fill = this.GetCachedBrush(fill);
+            }
+
+            var streamGeometry = new StreamGeometry { FillRule = FillRule.Nonzero };
+            using (var sgc = streamGeometry.Open())
+            {
+                foreach (var polygon in polygons)
                 {
-                    path = this.CreateAndAdd<Path>();
-                    this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-                    if (!fill.IsUndefined())
-                    {
-                        path.Fill = this.GetCachedBrush(fill);
-                    }
+                    var points = this.GetActualPoints(polygon, path.StrokeThickness, edgeRenderingMode);
+                    var firstPoint = GetFirstAndRest(points, out var otherPoints);
 
-                    if (usg)
+                    sgc.BeginFigure(firstPoint, !fill.IsUndefined(), true);
+                    foreach (var point in otherPoints)
                     {
-                        streamGeometry = new StreamGeometry { FillRule = FillRule.Nonzero };
-                        sgc = streamGeometry.Open();
+                        sgc.LineTo(point, !stroke.IsUndefined(), false);
                     }
-                    else
-                    {
-                        pathGeometry = new PathGeometry { FillRule = FillRule.Nonzero };
-                    }
-                }
-
-                PathFigure figure = null;
-                bool first = true;
-                foreach (var point in GetActualPoints(polygon, path.StrokeThickness, edgeRenderingMode))
-                {
-                    if (first)
-                    {
-                        if (usg)
-                        {
-                            sgc.BeginFigure(point, !fill.IsUndefined(), true);
-                        }
-                        else
-                        {
-                            figure = new PathFigure
-                            {
-                                StartPoint = point,
-                                IsFilled = !fill.IsUndefined(),
-                                IsClosed = true
-                            };
-                            pathGeometry.Figures.Add(figure);
-                        }
-
-                        first = false;
-                    }
-                    else
-                    {
-                        if (usg)
-                        {
-                            sgc.LineTo(point, !stroke.IsUndefined(), true);
-                        }
-                        else
-                        {
-                            figure.Segments.Add(new LineSegment(point, !stroke.IsUndefined()) { IsSmoothJoin = true });
-                        }
-                    }
-                }
-
-                count++;
-
-                // Must limit the number of figures, otherwise drawing errors...
-                if (count > MaxFiguresPerGeometry)
-                {
-                    if (usg)
-                    {
-                        sgc.Close();
-                        path.Data = streamGeometry;
-                    }
-                    else
-                    {
-                        path.Data = pathGeometry;
-                    }
-
-                    path = null;
-                    count = 0;
                 }
             }
 
-            if (path != null)
-            {
-                if (usg)
-                {
-                    sgc.Close();
-                    path.Data = streamGeometry;
-                }
-                else
-                {
-                    path.Data = pathGeometry;
-                }
-            }
+            streamGeometry.Freeze();
+            path.Data = streamGeometry;
         }
 
         ///<inheritdoc/>
         public override void DrawRectangle(OxyRect rect, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
-            if (this.UseStreamGeometry)
-            {
-                this.DrawRectangleByStreamGeometry(rect, fill, stroke, thickness, edgeRenderingMode);
-                return;
-            }
-
-            var e = this.CreateAndAdd<Path>();
-            this.SetStroke(e, stroke, thickness, edgeRenderingMode);
-
-            if (!fill.IsUndefined())
-            {
-                e.Fill = this.GetCachedBrush(fill);
-            }
-
-            var gg = new GeometryGroup { FillRule = FillRule.Nonzero };
-            gg.Children.Add(new RectangleGeometry { Rect = this.GetActualRect(rect, e.StrokeThickness, edgeRenderingMode) });
-            e.Data = gg;
+            this.DrawRectangles(new[] { rect }, fill, stroke, thickness, edgeRenderingMode);
         }
 
         ///<inheritdoc/>
         public override void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
-            if (this.UseStreamGeometry)
+            if (rectangles.Count == 0)
             {
-                this.DrawRectanglesByStreamGeometry(rectangles, fill, stroke, thickness, edgeRenderingMode);
                 return;
             }
 
@@ -483,92 +290,22 @@ namespace OxyPlot.Wpf
                 path.Fill = this.GetCachedBrush(fill);
             }
 
-            var gg = new GeometryGroup { FillRule = FillRule.Nonzero };
-            foreach (var rect in rectangles)
-            {
-                gg.Children.Add(new RectangleGeometry { Rect = this.GetActualRect(rect, path.StrokeThickness, edgeRenderingMode) });
-            }
-
-            path.Data = gg;
-        }
-
-        /// <summary>
-        /// Draws a collection of rectangles, where all have the same stroke and fill.
-        /// This performs better than calling DrawRectangle multiple times.
-        /// </summary>
-        /// <param name="rectangle">The rectangle.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        private void DrawRectangleByStreamGeometry(OxyRect rectangle, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
-        {
-            var path = this.CreateAndAdd<Path>();
-            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
-            if (!fill.IsUndefined())
-            {
-                path.Fill = this.GetCachedBrush(fill);
-            }
-
-            var sg = new StreamGeometry { FillRule = FillRule.Nonzero };
-            using (var context = sg.Open())
-            {
-                this.DrawRectangleInContext(context, rectangle, !fill.IsUndefined(), !stroke.IsUndefined(), path.StrokeThickness, edgeRenderingMode);
-            }
-
-            path.Data = sg;
-        }
-
-        /// <summary>
-        /// Draws a collection of rectangles, where all have the same stroke and fill.
-        /// This performs better than calling DrawRectangle multiple times.
-        /// </summary>
-        /// <param name="rectangles">The rectangles.</param>
-        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be filled.</param>
-        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the rectangles will not be stroked.</param>
-        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        private void DrawRectanglesByStreamGeometry(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
-        {
-            var path = this.CreateAndAdd<Path>();
-            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
-            if (!fill.IsUndefined())
-            {
-                path.Fill = this.GetCachedBrush(fill);
-            }
-
-            var sg = new StreamGeometry { FillRule = FillRule.Nonzero };
-            using (var context = sg.Open())
+            var streamGeometry = new StreamGeometry { FillRule = FillRule.Nonzero };
+            using (var context = streamGeometry.Open())
             {
                 foreach (var rect in rectangles)
                 {
-                    this.DrawRectangleInContext(context, rect, !fill.IsUndefined(), !stroke.IsUndefined(), path.StrokeThickness, edgeRenderingMode);
+                    var r = this.GetActualRect(rect, thickness, edgeRenderingMode);
+                    context.BeginFigure(r.TopLeft, !fill.IsUndefined(), true);
+                    context.PolyLineTo(new[] { r.TopRight, r.BottomRight, r.BottomLeft }, !stroke.IsUndefined(), false);
                 }
             }
 
-            path.Data = sg;
+            streamGeometry.Freeze();
+            path.Data = streamGeometry;
         }
 
-        private void DrawRectangleInContext(StreamGeometryContext context, OxyRect rect, bool isFilled, bool isStroked, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
-        {
-            var r = this.GetActualRect(rect, strokeThickness, edgeRenderingMode);
-            context.BeginFigure(r.TopLeft, isFilled, true);
-            context.PolyLineTo(new[] { r.TopRight, r.BottomRight, r.BottomLeft}, isStroked, true);
-        }
-
-        /// <summary>
-        /// Draws text.
-        /// </summary>
-        /// <param name="p">The position.</param>
-        /// <param name="text">The text.</param>
-        /// <param name="fill">The text color.</param>
-        /// <param name="fontFamily">The font family.</param>
-        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
-        /// <param name="fontWeight">The font weight.</param>
-        /// <param name="rotate">The rotation angle.</param>
-        /// <param name="halign">The horizontal alignment.</param>
-        /// <param name="valign">The vertical alignment.</param>
-        /// <param name="maxSize">The maximum size of the text (in device independent units, 1/96 inch).</param>
+        ///<inheritdoc/>
         public override void DrawText(
             ScreenPoint p,
             string text,
@@ -662,16 +399,7 @@ namespace OxyPlot.Wpf
             tb.SetValue(RenderOptions.ClearTypeHintProperty, ClearTypeHint.Enabled);
         }
 
-        /// <summary>
-        /// Measures the size of the specified text.
-        /// </summary>
-        /// <param name="text">The text.</param>
-        /// <param name="fontFamily">The font family.</param>
-        /// <param name="fontSize">Size of the font (in device independent units, 1/96 inch).</param>
-        /// <param name="fontWeight">The font weight.</param>
-        /// <returns>
-        /// The size of the text (in device independent units, 1/96 inch).
-        /// </returns>
+        ///<inheritdoc/>
         public override OxySize MeasureText(string text, string fontFamily, double fontSize, double fontWeight)
         {
             if (string.IsNullOrEmpty(text))
@@ -681,7 +409,7 @@ namespace OxyPlot.Wpf
 
             if (this.TextMeasurementMethod == TextMeasurementMethod.GlyphTypeface)
             {
-                return this.MeasureTextByGlyphTypeface(text, fontFamily, fontSize, fontWeight);
+                return MeasureTextByGlyphTypeface(text, fontFamily, fontSize, fontWeight);
             }
 
             var tb = new TextBlock { Text = text };
@@ -708,29 +436,13 @@ namespace OxyPlot.Wpf
             return new OxySize(tb.DesiredSize.Width, tb.DesiredSize.Height);
         }
 
-        /// <summary>
-        /// Sets the tool tip for the following items.
-        /// </summary>
-        /// <param name="text">The text in the tool tip.</param>
+        ///<inheritdoc/>
         public override void SetToolTip(string text)
         {
             this.currentToolTip = text;
         }
 
-        /// <summary>
-        /// Draws a portion of the specified <see cref="OxyImage" />.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="srcX">The x-coordinate of the upper-left corner of the portion of the source image to draw.</param>
-        /// <param name="srcY">The y-coordinate of the upper-left corner of the portion of the source image to draw.</param>
-        /// <param name="srcWidth">Width of the portion of the source image to draw.</param>
-        /// <param name="srcHeight">Height of the portion of the source image to draw.</param>
-        /// <param name="destX">The x-coordinate of the upper-left corner of drawn image.</param>
-        /// <param name="destY">The y-coordinate of the upper-left corner of drawn image.</param>
-        /// <param name="destWidth">The width of the drawn image.</param>
-        /// <param name="destHeight">The height of the drawn image.</param>
-        /// <param name="opacity">The opacity.</param>
-        /// <param name="interpolate">interpolate if set to <c>true</c>.</param>
+        ///<inheritdoc/>
         public override void DrawImage(
             OxyImage source,
             double srcX,
@@ -789,10 +501,7 @@ namespace OxyPlot.Wpf
             this.clip = null;
         }
 
-        /// <summary>
-        /// Cleans up resources not in use.
-        /// </summary>
-        /// <remarks>This method is called at the end of each rendering.</remarks>
+        ///<inheritdoc/>
         public override void CleanUp()
         {
             // Find the images in the cache that has not been used since last call to this method
@@ -815,7 +524,7 @@ namespace OxyPlot.Wpf
         /// <param name="fontSize">The font size.</param>
         /// <param name="fontWeight">The font weight.</param>
         /// <returns>The size of the text.</returns>
-        protected OxySize MeasureTextByGlyphTypeface(string text, string fontFamily, double fontSize, double fontWeight)
+        protected static OxySize MeasureTextByGlyphTypeface(string text, string fontFamily, double fontSize, double fontWeight)
         {
             if (string.IsNullOrEmpty(text))
             {
@@ -852,10 +561,10 @@ namespace OxyPlot.Wpf
         /// <returns>The text size.</returns>
         private static OxySize MeasureTextSize(GlyphTypeface glyphTypeface, double sizeInEm, string s)
         {
-            double width = 0;
-            double lineWidth = 0;
-            int lines = 0;
-            foreach (char ch in s)
+            var width = 0d;
+            var lineWidth = 0d;
+            var lines = 0;
+            foreach (var ch in s)
             {
                 switch (ch)
                 {
@@ -872,8 +581,8 @@ namespace OxyPlot.Wpf
                         continue;
                 }
 
-                ushort glyph = glyphTypeface.CharacterToGlyphMap[ch];
-                double advanceWidth = glyphTypeface.AdvanceWidths[glyph];
+                var glyph = glyphTypeface.CharacterToGlyphMap[ch];
+                var advanceWidth = glyphTypeface.AdvanceWidths[glyph];
                 lineWidth += advanceWidth;
             }
 
@@ -893,7 +602,7 @@ namespace OxyPlot.Wpf
         /// <param name="clipOffsetX">The clip offset executable.</param>
         /// <param name="clipOffsetY">The clip offset asynchronous.</param>
         /// <returns>The element.</returns>
-        private T CreateAndAdd<T>(double clipOffsetX = 0, double clipOffsetY = 0) where T : FrameworkElement, new()
+        protected T CreateAndAdd<T>(double clipOffsetX = 0, double clipOffsetY = 0) where T : FrameworkElement, new()
         {
             // TODO: here we can reuse existing elements in the canvas.Children collection
             var element = new T();
@@ -927,49 +636,11 @@ namespace OxyPlot.Wpf
         }
 
         /// <summary>
-        /// Draws the line segments by stream geometry.
-        /// </summary>
-        /// <param name="points">The points.</param>
-        /// <param name="stroke">The stroke color.</param>
-        /// <param name="thickness">The thickness.</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        /// <param name="dashArray">The dash array. Use <c>null</c> to get a solid line.</param>
-        /// <param name="lineJoin">The line join.</param>
-        private void DrawLineSegmentsByStreamGeometry(
-            IList<ScreenPoint> points,
-            OxyColor stroke,
-            double thickness,
-            EdgeRenderingMode edgeRenderingMode,
-            double[] dashArray,
-            LineJoin lineJoin)
-        {
-            if (points.Count < 2)
-                return;
-
-            var path = this.CreateAndAdd<Path>();
-            this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-
-            var actualStrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
-            var actualPoints = this.GetActualPointsForStreamGeometry(points, actualStrokeThickness, edgeRenderingMode);
-
-            var streamGeometry = new StreamGeometry();
-            using (var streamGeometryContext = streamGeometry.Open())
-            {
-                streamGeometryContext.BeginFigure(actualPoints.Item1, false, false);
-                for (int i = 0; i < actualPoints.Item2.Count; i++)
-                {
-                    streamGeometryContext.LineTo(actualPoints.Item2[i], (i & 0x1) == 0, false);
-                }
-            }
-            path.Data = streamGeometry;
-        }
-
-        /// <summary>
         /// Gets the cached brush.
         /// </summary>
         /// <param name="color">The color.</param>
         /// <returns>The brush.</returns>
-        private Brush GetCachedBrush(OxyColor color)
+        protected Brush GetCachedBrush(OxyColor color)
         {
             if (color.A == 0)
             {
@@ -1017,7 +688,7 @@ namespace OxyPlot.Wpf
         /// <param name="lineJoin">The line join.</param>
         /// <param name="dashArray">The dash array. Use <c>null</c> to get a solid line.</param>
         /// <param name="dashOffset">The dash offset.</param>
-        private void SetStroke(
+        protected void SetStroke(
             Shape shape,
             OxyColor stroke,
             double thickness,
@@ -1041,7 +712,7 @@ namespace OxyPlot.Wpf
 
                     // The default StrokeLineJoin is Miter
                 }
-                
+
                 shape.StrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
 
                 if (dashArray != null)
@@ -1079,92 +750,20 @@ namespace OxyPlot.Wpf
                 this.imagesInUse.Add(image);
             }
 
-            if (this.imageCache.TryGetValue(image, out BitmapSource src))
+            if (this.imageCache.TryGetValue(image, out var src))
             {
                 return src;
             }
 
-            using (var ms = new MemoryStream(image.GetData()))
-            {
-                var btm = new BitmapImage();
-                btm.BeginInit();
-                btm.StreamSource = ms;
-                btm.CacheOption = BitmapCacheOption.OnLoad;
-                btm.EndInit();
-                btm.Freeze();
-                this.imageCache.Add(image, btm);
-                return btm;
-            }
-        }
-
-        /// <summary>
-        /// Draws the line using the MaxPolylinesPerLine and MinPointsPerPolyline properties.
-        /// </summary>
-        /// <param name="points">The points.</param>
-        /// <param name="stroke">The stroke color.</param>
-        /// <param name="thickness">The thickness.</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        /// <param name="dashArray">The dash array. Use <c>null</c> to get a solid line.</param>
-        /// <param name="lineJoin">The line join.</param>
-        private void DrawLineBalanced(IList<ScreenPoint> points, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray, LineJoin lineJoin)
-        {
-            // balance the number of points per polyline and the number of polylines
-            var numPointsPerPolyline = Math.Max(points.Count / MaxPolylinesPerLine, MinPointsPerPolyline);
-
-            var polyline = this.CreateAndAdd<Polyline>();
-            this.SetStroke(polyline, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-            var pc = new PointCollection(numPointsPerPolyline);
-
-            var n = points.Count;
-            double lineLength = 0;
-            var dashPatternLength = (dashArray != null) ? dashArray.Sum() : 0;
-            var last = new Point();
-            var i = 0;
-            foreach (var p in this.GetActualPoints(points, thickness, edgeRenderingMode))
-            {
-                pc.Add(p);
-
-                // alt. 1
-                if (dashArray != null)
-                {
-                    if (i > 0)
-                    {
-                        var delta = p - last;
-                        var dist = Math.Sqrt((delta.X * delta.X) + (delta.Y * delta.Y));
-                        lineLength += dist;
-                    }
-
-                    last = p;
-                }
-
-                // use multiple polylines with limited number of points to improve WPF performance
-                if (pc.Count >= numPointsPerPolyline)
-                {
-                    polyline.Points = pc;
-
-                    if (i < n - 1)
-                    {
-                        // alt.2
-                        ////if (dashArray != null)
-                        ////{
-                        ////    lineLength += this.GetLength(polyline);
-                        ////}
-
-                        // start a new polyline at last point so there is no gap (it is not necessary to use the % operator)
-                        var dashOffset = dashPatternLength > 0 ? lineLength / thickness : 0;
-                        polyline = this.CreateAndAdd<Polyline>();
-                        this.SetStroke(polyline, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, dashOffset);
-                        pc = new PointCollection(numPointsPerPolyline) { pc.Last() };
-                    }
-                }
-
-                i++;
-            }
-
-            if (pc.Count > 1 || n == 1)
-            {
-                polyline.Points = pc;
-            }
+            using var ms = new MemoryStream(image.GetData());
+            var btm = new BitmapImage();
+            btm.BeginInit();
+            btm.StreamSource = ms;
+            btm.CacheOption = BitmapCacheOption.OnLoad;
+            btm.EndInit();
+            btm.Freeze();
+            this.imageCache.Add(image, btm);
+            return btm;
         }
 
         /// <summary>
@@ -1172,7 +771,7 @@ namespace OxyPlot.Wpf
         /// </summary>
         /// <param name="r">The rectangle.</param>
         /// <returns>A <see cref="Rect" />.</returns>
-        private static Rect ToRect(OxyRect r)
+        protected static Rect ToRect(OxyRect r)
         {
             return new Rect(r.Left, r.Top, r.Width, r.Height);
         }
@@ -1184,49 +783,16 @@ namespace OxyPlot.Wpf
         /// <param name="strokeThickness">The stroke thickness.</param>
         /// <param name="edgeRenderingMode">The edge rendering mode.</param>
         /// <returns>The processed points.</returns>
-        private IEnumerable<Point> GetActualPoints(IList<ScreenPoint> points, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        protected IEnumerable<Point> GetActualPoints(IList<ScreenPoint> points, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
         {
             switch (edgeRenderingMode)
             {
-                case EdgeRenderingMode.Adaptive when RenderContextBase.IsStraightLine(points):
-                case EdgeRenderingMode.Automatic when RenderContextBase.IsStraightLine(points):
+                case EdgeRenderingMode.Adaptive when IsStraightLine(points):
+                case EdgeRenderingMode.Automatic when IsStraightLine(points):
                 case EdgeRenderingMode.PreferSharpness:
                     return points.Select(p => PixelLayout.Snap(p.X, p.Y, strokeThickness, this.VisualOffset, this.DpiScale));
                 default:
                     return points.Select(p => new Point(p.X, p.Y));
-            }
-        }
-
-        /// <summary>
-        /// Snaps points to pixels if required by the edge rendering mode.
-        /// </summary>
-        /// <param name="points">The points.</param>
-        /// <param name="strokeThickness">The stroke thickness.</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        /// <returns>The processed points.</returns>
-        private Tuple<Point, IList<Point>> GetActualPointsForStreamGeometry(IList<ScreenPoint> points, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
-        {
-            if (points.Count < 1)
-            {
-                return Tuple.Create(new Point(), (IList<Point>)new Point[0]);
-            }
-            var pointsList = new Point[points.Count - 1];
-            switch (edgeRenderingMode)
-            {
-                case EdgeRenderingMode.Adaptive when RenderContextBase.IsStraightLine(points):
-                case EdgeRenderingMode.Automatic when RenderContextBase.IsStraightLine(points):
-                case EdgeRenderingMode.PreferSharpness:
-                    for (int i = 0; i < pointsList.Length; i++)
-                    {
-                        pointsList[i] = PixelLayout.Snap(points[i + 1].X, points[i + 1].Y, strokeThickness, this.VisualOffset, this.DpiScale);
-                    }
-                    return Tuple.Create(PixelLayout.Snap(points[0].X, points[0].Y, strokeThickness, this.VisualOffset, this.DpiScale), (IList<Point>)pointsList);
-                default:
-                    for (int i = 0; i < pointsList.Length; i++)
-                    {
-                        pointsList[i] = new Point(points[i + 1].X, points[i + 1].Y);
-                    }
-                    return Tuple.Create(new Point(points[0].X, points[0].Y), (IList<Point>)pointsList);
             }
         }
 
@@ -1237,7 +803,7 @@ namespace OxyPlot.Wpf
         /// <param name="strokeThickness">The stroke thickness.</param>
         /// <param name="edgeRenderingMode">The edge rendering mode.</param>
         /// <returns>The processed rectangle.</returns>
-        private Rect GetActualRect(OxyRect rect, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        protected Rect GetActualRect(OxyRect rect, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
         {
             switch (edgeRenderingMode)
             {
@@ -1255,7 +821,7 @@ namespace OxyPlot.Wpf
         /// <param name="strokeThickness">The stroke thickness.</param>
         /// <param name="edgeRenderingMode">The edge rendering mode.</param>
         /// <returns>The processed stroke thickness.</returns>
-        private double GetActualStrokeThickness(double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        protected double GetActualStrokeThickness(double strokeThickness, EdgeRenderingMode edgeRenderingMode)
         {
             switch (edgeRenderingMode)
             {
@@ -1266,16 +832,24 @@ namespace OxyPlot.Wpf
             }
         }
 
-        /// <summary>
-        /// Creates a point collection from the specified points. The points are snapped to pixels if required by the edge rendering mode,
-        /// </summary>
-        /// <param name="points">The points to convert.</param>
-        /// <param name="strokeThickness">The stroke thickness.</param>
-        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
-        /// <returns>The point collection.</returns>
-        private PointCollection ToPointCollection(IList<ScreenPoint> points, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        private static T GetFirstAndRest<T>(IEnumerable<T> items, out IList<T> rest)
         {
-            return new PointCollection(GetActualPoints(points, strokeThickness, edgeRenderingMode));
+            using var e = items.GetEnumerator();
+            if (!e.MoveNext())
+            {
+                rest = new T[0];
+                return default;
+            }
+
+            var ret = e.Current;
+
+            rest = new List<T>();
+            while (e.MoveNext())
+            {
+                rest.Add(e.Current);
+            }
+
+            return ret;
         }
     }
 }

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -776,46 +776,25 @@ namespace OxyPlot.Wpf
             double[] dashArray,
             LineJoin lineJoin)
         {
-            StreamGeometry streamGeometry = null;
-            StreamGeometryContext streamGeometryContext = null;
+            if (points.Count < 2)
+                return;
 
-            int count = 0;
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
+
             var actualStrokeThickness = this.GetActualStrokeThickness(thickness, edgeRenderingMode);
+            var actualPoints = this.GetActualPoints(points, actualStrokeThickness, edgeRenderingMode).ToList();
 
-            for (int i = 0; i + 1 < points.Count; i += 2)
+            var streamGeometry = new StreamGeometry();
+            using (var streamGeometryContext = streamGeometry.Open())
             {
-                if (streamGeometry == null)
-                {
-                    streamGeometry = new StreamGeometry();
-                    streamGeometryContext = streamGeometry.Open();
-                }
-
-                var actualPoints = this.GetActualPoints(new[] { points[i], points[i + 1] }, actualStrokeThickness, edgeRenderingMode).ToList();
-
                 streamGeometryContext.BeginFigure(actualPoints[0], false, false);
-                streamGeometryContext.LineTo(actualPoints[1], true, false);
-
-                count++;
-
-                // Must limit the number of figures, otherwise drawing errors...
-                if (count > MaxFiguresPerGeometry || dashArray != null)
+                for (int i = 1; i < actualPoints.Count; i++)
                 {
-                    streamGeometryContext.Close();
-                    var path = this.CreateAndAdd<Path>();
-                    this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
-                    path.Data = streamGeometry;
-                    streamGeometry = null;
-                    count = 0;
+                    streamGeometryContext.LineTo(actualPoints[i], (i & 0x1) != 0, false);
                 }
             }
-
-            if (streamGeometry != null)
-            {
-                streamGeometryContext.Close();
-                var path = this.CreateAndAdd<Path>();
-                this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, null, 0);
-                path.Data = streamGeometry;
-            }
+            path.Data = streamGeometry;
         }
 
         /// <summary>

--- a/Source/OxyPlot.Wpf/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Wpf/CanvasRenderContext.cs
@@ -136,6 +136,12 @@ namespace OxyPlot.Wpf
         ///<inheritdoc/>
         public override void DrawEllipses(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
         {
+            if (this.UseStreamGeometry)
+            {
+                this.DrawEllipsesByStreamGeometry(rectangles, fill, stroke, thickness, edgeRenderingMode);
+                return;
+            }
+
             var path = this.CreateAndAdd<Path>();
             this.SetStroke(path, stroke, thickness, edgeRenderingMode);
             if (!fill.IsUndefined())
@@ -150,6 +156,52 @@ namespace OxyPlot.Wpf
             }
 
             path.Data = gg;
+        }
+
+        /// <summary>
+        /// Draws a collection of ellipses, where all have the same stroke and fill, using a StreamGeometry.
+        /// </summary>
+        /// <param name="rectangles">The rectangles defining the extents of the ellipses.</param>
+        /// <param name="fill">The fill color. If set to <c>OxyColors.Undefined</c>, the ellipses will not be filled.</param>
+        /// <param name="stroke">The stroke color. If set to <c>OxyColors.Undefined</c>, the ellipses will not be stroked.</param>
+        /// <param name="thickness">The stroke thickness (in device independent units, 1/96 inch).</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <remarks>
+        /// This should have better performance than calling <see cref="DrawEllipse" /> multiple times.
+        /// </remarks>
+        private void DrawEllipsesByStreamGeometry(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
+            if (!fill.IsUndefined())
+            {
+                path.Fill = this.GetCachedBrush(fill);
+            }
+
+            var isFilled = !fill.IsUndefined();
+            var isStroke = !stroke.IsUndefined();
+            var streamGeometry = new StreamGeometry { FillRule = FillRule.Nonzero };
+            using (var sgc = streamGeometry.Open())
+            {
+                foreach (var rect in rectangles)
+                {
+                    const double arcAsBezier = 0.551784;
+
+                    var centerX = rect.Center.X;
+                    var centerY = rect.Center.Y;
+
+                    var midX = Math.Abs(rect.Width / 2.0) * arcAsBezier;
+                    var midY = Math.Abs(rect.Height / 2.0) * arcAsBezier;
+
+                    sgc.BeginFigure(new Point(rect.Right, centerY), isFilled, true);
+                    sgc.BezierTo(new Point(rect.Right, centerY + midY), new Point(centerX + midX, rect.Bottom), new Point(centerX, rect.Bottom), isStroke, true);
+                    sgc.BezierTo(new Point(centerX - midX, rect.Bottom), new Point(rect.Left, centerY + midY), new Point(rect.Left, centerY), isStroke, true);
+                    sgc.BezierTo(new Point(rect.Left, centerY - midY), new Point(centerX - midX, rect.Top), new Point(centerX, rect.Top), isStroke, true);
+                    sgc.BezierTo(new Point(centerX + midX, rect.Top), new Point(rect.Right, centerY - midY), new Point(rect.Right, centerY), isStroke, true);
+                }
+            }
+
+            path.Data = streamGeometry;
         }
 
         ///<inheritdoc/>

--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -82,6 +82,7 @@ namespace OxyPlot.Wpf
         /// <inheritdoc/>
         protected override void RenderOverride()
         {
+            RenderContext.TextMeasurementMethod = TextMeasurementMethod;
             if (this.DisconnectCanvasWhileUpdating)
             {
                 // TODO: profile... not sure if this makes any difference
@@ -124,6 +125,23 @@ namespace OxyPlot.Wpf
             var exporter = new PngExporter() { Width = (int)this.ActualWidth, Height = (int)this.ActualHeight };
             var bitmap = exporter.ExportToBitmap(this.ActualModel);
             Clipboard.SetImage(bitmap);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="TextMeasurementMethod"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty TextMeasurementMethodProperty =
+            DependencyProperty.Register(
+                nameof(TextMeasurementMethod), typeof(TextMeasurementMethod), typeof(PlotViewBase), new PropertyMetadata(TextMeasurementMethod.TextBlock));
+
+        /// <summary>
+        /// Gets or sets the vertical zoom cursor.
+        /// </summary>
+        /// <value>The zoom vertical cursor.</value>
+        public TextMeasurementMethod TextMeasurementMethod
+        {
+            get => (TextMeasurementMethod)this.GetValue(TextMeasurementMethodProperty);
+            set => this.SetValue(TextMeasurementMethodProperty, value);
         }
     }
 }

--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -21,6 +21,13 @@ namespace OxyPlot.Wpf
     public partial class PlotView : PlotViewBase
     {
         /// <summary>
+        /// Identifies the <see cref="TextMeasurementMethod"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty TextMeasurementMethodProperty =
+            DependencyProperty.Register(
+                nameof(TextMeasurementMethod), typeof(TextMeasurementMethod), typeof(PlotViewBase), new PropertyMetadata(TextMeasurementMethod.TextBlock));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PlotView" /> class.
         /// </summary>
         public PlotView()
@@ -36,9 +43,19 @@ namespace OxyPlot.Wpf
         public bool DisconnectCanvasWhileUpdating { get; set; }
 
         /// <summary>
+        /// Gets or sets the vertical zoom cursor.
+        /// </summary>
+        /// <value>The zoom vertical cursor.</value>
+        public TextMeasurementMethod TextMeasurementMethod
+        {
+            get => (TextMeasurementMethod)this.GetValue(TextMeasurementMethodProperty);
+            set => this.SetValue(TextMeasurementMethodProperty, value);
+        }
+
+        /// <summary>
         /// Gets the Canvas.
         /// </summary>
-        private Canvas Canvas => (Canvas)this.plotPresenter;
+        protected Canvas Canvas => (Canvas)this.plotPresenter;
 
         /// <summary>
         /// Gets the CanvasRenderContext.
@@ -82,7 +99,7 @@ namespace OxyPlot.Wpf
         /// <inheritdoc/>
         protected override void RenderOverride()
         {
-            RenderContext.TextMeasurementMethod = TextMeasurementMethod;
+            this.RenderContext.TextMeasurementMethod = this.TextMeasurementMethod;
             if (this.DisconnectCanvasWhileUpdating)
             {
                 // TODO: profile... not sure if this makes any difference
@@ -125,23 +142,6 @@ namespace OxyPlot.Wpf
             var exporter = new PngExporter() { Width = (int)this.ActualWidth, Height = (int)this.ActualHeight };
             var bitmap = exporter.ExportToBitmap(this.ActualModel);
             Clipboard.SetImage(bitmap);
-        }
-
-        /// <summary>
-        /// Identifies the <see cref="TextMeasurementMethod"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty TextMeasurementMethodProperty =
-            DependencyProperty.Register(
-                nameof(TextMeasurementMethod), typeof(TextMeasurementMethod), typeof(PlotViewBase), new PropertyMetadata(TextMeasurementMethod.TextBlock));
-
-        /// <summary>
-        /// Gets or sets the vertical zoom cursor.
-        /// </summary>
-        /// <value>The zoom vertical cursor.</value>
-        public TextMeasurementMethod TextMeasurementMethod
-        {
-            get => (TextMeasurementMethod)this.GetValue(TextMeasurementMethodProperty);
-            set => this.SetValue(TextMeasurementMethodProperty, value);
         }
     }
 }

--- a/Source/OxyPlot.Wpf/TextMeasurementMethod.cs
+++ b/Source/OxyPlot.Wpf/TextMeasurementMethod.cs
@@ -15,12 +15,12 @@ namespace OxyPlot.Wpf
     public enum TextMeasurementMethod
     {
         /// <summary>
-        /// Measurement by TextBlock.
+        /// Measurement by TextBlock. This gives a more accurate result than <see cref="GlyphTypeface"/> as it takes into account text shaping.
         /// </summary>
         TextBlock,
 
         /// <summary>
-        /// Measurement by glyph typeface.
+        /// Measurement by glyph typeface. This is faster than <see cref="TextBlock"/>, but does not take into account text shaping.
         /// </summary>
         GlyphTypeface
     }

--- a/Source/OxyPlot.Wpf/XamlExporter.cs
+++ b/Source/OxyPlot.Wpf/XamlExporter.cs
@@ -75,9 +75,10 @@ namespace OxyPlot.Wpf
             c.Measure(new Size(width, height));
             c.Arrange(new Rect(0, 0, width, height));
 
-            var rc = new CanvasRenderContext(c) { UseStreamGeometry = false };
-
-            rc.TextFormattingMode = TextFormattingMode.Ideal;
+            var rc = new XamlRenderContext(c)
+            {
+                TextFormattingMode = TextFormattingMode.Ideal
+            };
 
             model.Update(true);
             model.Render(rc, new OxyRect(0, 0, width, height));

--- a/Source/OxyPlot.Wpf/XamlRenderContext.cs
+++ b/Source/OxyPlot.Wpf/XamlRenderContext.cs
@@ -1,0 +1,325 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="XamlRenderContext.cs" company="OxyPlot">
+//   Copyright (c) 2020 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Wpf
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Media;
+    using System.Windows.Shapes;
+
+    using Path = System.Windows.Shapes.Path;
+
+    /// <summary>
+    /// Implements <see cref="IRenderContext" /> for <see cref="Canvas" />. This does not use <see cref="StreamGeometry"/> and therefore the output can be serialized to XAML.
+    /// </summary>
+    public class XamlRenderContext : CanvasRenderContext
+    {
+        /// <summary>
+        /// The maximum number of figures per geometry.
+        /// </summary>
+        private const int MaxFiguresPerGeometry = 16;
+
+        /// <summary>
+        /// The maximum number of polylines per line.
+        /// </summary>
+        private const int MaxPolylinesPerLine = 64;
+
+        /// <summary>
+        /// The minimum number of points per polyline.
+        /// </summary>
+        private const int MinPointsPerPolyline = 16;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasRenderContext" /> class.
+        /// </summary>
+        /// <param name="canvas">The canvas.</param>
+        public XamlRenderContext(Canvas canvas) : base(canvas)
+        {
+            this.RendersToScreen = false;
+            this.BalancedLineDrawingThicknessLimit = 3.5;
+        }
+
+        /// <summary>
+        /// Gets or sets the thickness limit for "balanced" line drawing.
+        /// </summary>
+        public double BalancedLineDrawingThicknessLimit { get; set; }
+
+        ///<inheritdoc/>
+        public override void DrawEllipses(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (rectangles.Count == 0)
+            {
+                return;
+            }
+
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
+            if (!fill.IsUndefined())
+            {
+                path.Fill = this.GetCachedBrush(fill);
+            }
+
+            var gg = new GeometryGroup { FillRule = FillRule.Nonzero };
+            foreach (var rect in rectangles)
+            {
+                gg.Children.Add(new EllipseGeometry(ToRect(rect)));
+            }
+
+            path.Data = gg;
+        }
+
+        ///<inheritdoc/>
+        public override void DrawLine(
+            IList<ScreenPoint> points,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray,
+            LineJoin lineJoin)
+        {
+            if (points.Count < 2)
+            {
+                return;
+            }
+
+            if (thickness < this.BalancedLineDrawingThicknessLimit)
+            {
+                this.DrawLineBalanced(points, stroke, thickness, edgeRenderingMode, dashArray, lineJoin);
+                return;
+            }
+
+            var e = this.CreateAndAdd<Polyline>();
+            this.SetStroke(e, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
+            e.Points = this.ToPointCollection(points, e.StrokeThickness, edgeRenderingMode);
+        }
+
+        ///<inheritdoc/>
+        public override void DrawLineSegments(
+            IList<ScreenPoint> points,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray,
+            LineJoin lineJoin)
+        {
+            if (points.Count < 2)
+            {
+                return;
+            }
+
+            Path path = null;
+            PathGeometry pathGeometry = null;
+
+            var count = 0;
+
+            for (var i = 0; i + 1 < points.Count; i += 2)
+            {
+                if (path == null)
+                {
+                    path = this.CreateAndAdd<Path>();
+                    this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
+                    pathGeometry = new PathGeometry();
+                }
+
+                var actualPoints = this.GetActualPoints( new[] { points[i], points[i + 1] }, path.StrokeThickness, edgeRenderingMode).ToList();
+
+                var figure = new PathFigure { StartPoint = actualPoints[0], IsClosed = false };
+                figure.Segments.Add(new LineSegment(actualPoints[1], true) { IsSmoothJoin = false });
+                pathGeometry.Figures.Add(figure);
+
+                count++;
+
+                // Must limit the number of figures, otherwise drawing errors...
+                if (count > MaxFiguresPerGeometry || dashArray != null)
+                {
+                    path.Data = pathGeometry;
+                    path = null;
+                    count = 0;
+                }
+            }
+
+            if (path != null)
+            {
+                path.Data = pathGeometry;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override void DrawPolygons(
+            IList<IList<ScreenPoint>> polygons,
+            OxyColor fill,
+            OxyColor stroke,
+            double thickness,
+            EdgeRenderingMode edgeRenderingMode,
+            double[] dashArray,
+            LineJoin lineJoin)
+        {
+            if (polygons.Count == 0)
+            {
+                return;
+            }
+
+            Path path = null;
+            PathGeometry pathGeometry = null;
+            var count = 0;
+
+            foreach (var polygon in polygons)
+            {
+                if (path == null)
+                {
+                    path = this.CreateAndAdd<Path>();
+                    this.SetStroke(path, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
+                    if (!fill.IsUndefined())
+                    {
+                        path.Fill = this.GetCachedBrush(fill);
+                    }
+
+                    pathGeometry = new PathGeometry { FillRule = FillRule.Nonzero };
+                }
+
+                PathFigure figure = null;
+                var first = true;
+                foreach (var point in this.GetActualPoints(polygon, path.StrokeThickness, edgeRenderingMode))
+                {
+                    if (first)
+                    {
+                        figure = new PathFigure
+                        {
+                            StartPoint = point,
+                            IsFilled = !fill.IsUndefined(),
+                            IsClosed = true
+                        };
+
+                        pathGeometry.Figures.Add(figure);
+                        first = false;
+                    }
+                    else
+                    {
+                        figure.Segments.Add(new LineSegment(point, !stroke.IsUndefined()));
+                    }
+                }
+
+                count++;
+
+                // Must limit the number of figures, otherwise drawing errors...
+                if (count > MaxFiguresPerGeometry)
+                {
+                    path.Data = pathGeometry;
+                    path = null;
+                    count = 0;
+                }
+            }
+
+            if (path != null)
+            {
+                path.Data = pathGeometry;
+            }
+        }
+
+        ///<inheritdoc/>
+        public override void DrawRectangles(IList<OxyRect> rectangles, OxyColor fill, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            if (rectangles.Count == 0)
+            {
+                return;
+            }
+
+            var path = this.CreateAndAdd<Path>();
+            this.SetStroke(path, stroke, thickness, edgeRenderingMode);
+            if (!fill.IsUndefined())
+            {
+                path.Fill = this.GetCachedBrush(fill);
+            }
+
+            var gg = new GeometryGroup { FillRule = FillRule.Nonzero };
+            foreach (var rect in rectangles)
+            {
+                gg.Children.Add(new RectangleGeometry { Rect = this.GetActualRect(rect, path.StrokeThickness, edgeRenderingMode) });
+            }
+
+            path.Data = gg;
+        }
+
+        /// <summary>
+        /// Draws the line using the MaxPolylinesPerLine and MinPointsPerPolyline properties.
+        /// </summary>
+        /// <param name="points">The points.</param>
+        /// <param name="stroke">The stroke color.</param>
+        /// <param name="thickness">The thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <param name="dashArray">The dash array. Use <c>null</c> to get a solid line.</param>
+        /// <param name="lineJoin">The line join.</param>
+        private void DrawLineBalanced(IList<ScreenPoint> points, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray, LineJoin lineJoin)
+        {
+            // balance the number of points per polyline and the number of polylines
+            var numPointsPerPolyline = Math.Max(points.Count / MaxPolylinesPerLine, MinPointsPerPolyline);
+
+            var polyline = this.CreateAndAdd<Polyline>();
+            this.SetStroke(polyline, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, 0);
+            var pc = new PointCollection(numPointsPerPolyline);
+
+            var n = points.Count;
+            double lineLength = 0;
+            var dashPatternLength = (dashArray != null) ? dashArray.Sum() : 0;
+            var last = new Point();
+            var i = 0;
+            foreach (var p in this.GetActualPoints(points, thickness, edgeRenderingMode))
+            {
+                pc.Add(p);
+
+                if (dashArray != null)
+                {
+                    if (i > 0)
+                    {
+                        var delta = p - last;
+                        var dist = Math.Sqrt((delta.X * delta.X) + (delta.Y * delta.Y));
+                        lineLength += dist;
+                    }
+
+                    last = p;
+                }
+
+                // use multiple polylines with limited number of points to improve WPF performance
+                if (pc.Count >= numPointsPerPolyline)
+                {
+                    polyline.Points = pc;
+
+                    if (i < n - 1)
+                    {
+                        // start a new polyline at last point so there is no gap (it is not necessary to use the % operator)
+                        var dashOffset = dashPatternLength > 0 ? lineLength / thickness : 0;
+                        polyline = this.CreateAndAdd<Polyline>();
+                        this.SetStroke(polyline, stroke, thickness, edgeRenderingMode, lineJoin, dashArray, dashOffset);
+                        pc = new PointCollection(numPointsPerPolyline) { pc.Last() };
+                    }
+                }
+
+                i++;
+            }
+
+            if (pc.Count > 1 || n == 1)
+            {
+                polyline.Points = pc;
+            }
+        }
+
+        /// <summary>
+        /// Creates a point collection from the specified points. The points are snapped to pixels if required by the edge rendering mode,
+        /// </summary>
+        /// <param name="points">The points to convert.</param>
+        /// <param name="strokeThickness">The stroke thickness.</param>
+        /// <param name="edgeRenderingMode">The edge rendering mode.</param>
+        /// <returns>The point collection.</returns>
+        private PointCollection ToPointCollection(IList<ScreenPoint> points, double strokeThickness, EdgeRenderingMode edgeRenderingMode)
+        {
+            return new PointCollection(this.GetActualPoints(points, strokeThickness, edgeRenderingMode));
+        }
+    }
+}


### PR DESCRIPTION
Improves #1673.

This PR is based on #1609 where @imalip did the heavy lifting. I fixed some minor issues and moved the non-`StreamGeometry` code into its own class (`XamlRenderContext`).

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Improve performance of `CanvasRenderContext` by using `StreamGeometry` as much as possible instead of drawing individual paths
- Add `PlotView.TextMeasurementMethod` property to `OxyPlot.WPF.PlotView` to allow using the much faster `GlyphTypeface`-based measurement
- As stuff that is drawn using `StreamGeometry` is not serializable, we need to keep the 'regular' rendering functions for the `XamlExporter` to work properly. Previously this was integrated into `CanvasRenderContext` and controlled by the `UseStreamGeometry` property, but that was a bit messy and made the class needlessly complicated. So I decided to actually move this code into its own class, `XamlRenderContext`, which is only used by the `XamlExporter`.

### Notes

- To make the new `XamlRenderContext` testable, I added the renderer 'Canvas_XAML' to the WPF ExampleBrowser
- As line joins were problematic initially with `StreamGeometry`, I added a `LineJoin` example to the rendering capabilities section.
_sidenote: This revealed that the `SkiaSharp` renderer actually ignores `LineJoin=Miter` for small angles. Fix to follow._
- I would have loved to resurrect the Benchmark functionality of the WPF ExampleBrowser to actually see some numbers regarding performance. But I couldn't find a straight-forward way to make this work with both Canvas and Skia. @imalip did some Benchmarks in #1609. Also the difference is quite noticeable with certain examples (`Performance>LineSeries, 100k points, markers` and `Polar Plots>Spiral full plot area` for example).
- I did not make any effort optimizing the `XamlRenderContext`. I have no idea what the `DrawLineBalanced` stuff is all about, so I didn't touch it. But I guess that's ok, because it's for XAML export only.

@oxyplot/admins
