### PR TITLE
Fix clipping rects for transposed plot elements (#1688)

### DIFF
--- a/Source/OxyPlot/Annotations/TransposableAnnotation.cs
+++ b/Source/OxyPlot/Annotations/TransposableAnnotation.cs
@@ -15,7 +15,7 @@ namespace OxyPlot.Annotations
         public override OxyRect GetClippingRect()
         {
             var rect = this.PlotModel.PlotArea;
-            var axisRect = PlotElementUtilities.GetOrientatedClippingRect(this);
+            var axisRect = PlotElementUtilities.GetClippingRect(this);
 
             var minX = 0d;
             var maxX = double.PositiveInfinity;

--- a/Source/OxyPlot/PlotModel/PlotElementUtilities.cs
+++ b/Source/OxyPlot/PlotModel/PlotElementUtilities.cs
@@ -18,21 +18,9 @@ namespace OxyPlot
         /// <returns>The clipping rectangle.</returns>
         public static OxyRect GetClippingRect(IXyAxisPlotElement element)
         {
-            var p1 = new ScreenPoint(element.XAxis.ScreenMin.X, element.YAxis.ScreenMin.Y);
-            var p2 = new ScreenPoint(element.XAxis.ScreenMax.X, element.YAxis.ScreenMax.Y);
-            return new OxyRect(p1, p2);
-        }
-
-        /// <summary>
-        /// Gets the clipping rectangle defined by the Axis the <see cref="ITransposablePlotElement"/> uses while being aware of the orientation.
-        /// </summary>
-        /// <param name="element">The <see cref="ITransposablePlotElement" />.</param>
-        /// <returns>The clipping rectangle.</returns>
-        public static OxyRect GetOrientatedClippingRect(ITransposablePlotElement element)
-        {
-            var p1 = new ScreenPoint(element.XAxis.ScreenMin.X, element.YAxis.ScreenMin.Y);
-            var p2 = new ScreenPoint(element.XAxis.ScreenMax.X, element.YAxis.ScreenMax.Y);
-            return new OxyRect(element.Orientate(p1), element.Orientate(p2));
+            var xrect = new OxyRect(element.XAxis.ScreenMin, element.XAxis.ScreenMax);
+            var yrect = new OxyRect(element.YAxis.ScreenMin, element.YAxis.ScreenMax);
+            return xrect.Intersect(yrect);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -104,7 +104,7 @@ namespace OxyPlot.Series
         /// <inheritdoc/>
         public override OxyRect GetClippingRect()
         {
-            return PlotElementUtilities.GetOrientatedClippingRect(this);
+            return PlotElementUtilities.GetClippingRect(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1688

### Checklist

- [ ] I have included examples or tests (almost any example will do)
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fixes `PlotElementUtilities.GetClippingRect` so that it doesn't assume the x axis is horizontal and y axis vertical (broken by #1682, somehow I didn't notice this).
- Removes `PlotElementUtilities.GetOrientatedClippingRect` as it is redundant

@oxyplot/admins
