### PR TITLE
Ceil measured text sizes in WinForms (#1659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ All notable changes to this project will be documented in this file.
 - OpenStreetMap example (#1642)
 - Incorrect clipping in TwoColorAreaSeries (#1678)
 - ScreenMin and ScreenMax on Horizontal and Vertical Axes depends on plot bounds (#1652)
+- Windows Forms clipping last line of measured text (#1659)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -2359,6 +2359,19 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
+        [Example("#1659: Last line of series titles in legend not displayed in Chinese on WinForms (Closed)")]
+        public static PlotModel LastLineOfSeriesTitlesNotDisplayedInChineseOnWindows()
+        {
+            var plot = new PlotModel() { Title = "#1659: Last line of series titles in legend not displayed in Chinese on WinForms" };
+
+            plot.Legends.Add(new Legend() { LegendTitle = "漂亮的天鹅" });
+            plot.Series.Add(new FunctionSeries(x => x, 0, 1, 0.1, "漂亮的天鹅"));
+            plot.Series.Add(new FunctionSeries(x => x, 0, 1, 0.1, "漂亮的天鹅\n友好的天鹅"));
+            plot.Series.Add(new FunctionSeries(x => x, 0, 1, 0.1, "漂亮的天鹅\n友好的天鹅\n尼斯天鹅"));
+
+            return plot;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -295,7 +295,7 @@ namespace OxyPlot.WindowsForms
             {
                 this.stringFormat.Alignment = StringAlignment.Near;
                 this.stringFormat.LineAlignment = StringAlignment.Near;
-                var size = this.g.MeasureString(text, font, int.MaxValue, this.stringFormat);
+                var size = Ceiling(this.g.MeasureString(text, font, int.MaxValue, this.stringFormat));
                 return new OxySize(size.Width, size.Height);
             }
         }


### PR DESCRIPTION
Fixes #1659 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- `Ceil`s the size of measured text, so that text rendered within the measured bounds is not clipped. Essentially the same fix as #1387, which probably should have been done at the same time.

@oxyplot/admins
