### PR TITLE
Add SkiaRenderContext.MiterLimit property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 - netstandard2.0 TargetFramework (#1668)
 - Add a PlotView.TextMeasurementMethod property to allow using the much faster GlyphTypeface based measurement at runtime (#1673)
 - OxyPlot.Wpf.XamlRenderContext - this doesn't use StreamGeometry and can be used for rendering to XAML (#1673)
+- SkiaRenderContext.MiterLimit property (#1690)
 
 ### Changed
 - Legends model (#644)

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -46,6 +46,11 @@ namespace OxyPlot.SkiaSharp
         public bool UseTextShaping { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the Miter limit. This is the maximum ratio between Miter length and stroke thickness. When this ration is exceeded, the join falls back to a Bevel. The default value is 10.
+        /// </summary>
+        public float MiterLimit { get; set; } = 10;
+
+        /// <summary>
         /// Gets a value indicating whether the context renders to pixels.
         /// </summary>
         /// <value><c>true</c> if the context renders to pixels; otherwise, <c>false</c>.</value>
@@ -826,6 +831,7 @@ namespace OxyPlot.SkiaSharp
             this.paint.StrokeWidth = this.GetActualThickness(strokeThickness, edgeRenderingMode);
             this.paint.PathEffect = null;
             this.paint.StrokeJoin = SKStrokeJoin.Miter;
+            this.paint.StrokeMiter = this.MiterLimit;
             return this.paint;
         }
 


### PR DESCRIPTION
Fixes #1690.

### Checklist

- [ ] I have included examples or tests (existing LineJoin example demonstrates the behavior)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add `SkiaRenderContext.MiterLimit` property with a default value of 10 to be consistent with WPF and WinForms

@oxyplot/admins
