### PR TITLE
Fix inconsistent zooming behaviour (#1648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ All notable changes to this project will be documented in this file.
 - Incorrect clipping in TwoColorAreaSeries (#1678)
 - ScreenMin and ScreenMax on Horizontal and Vertical Axes depends on plot bounds (#1652)
 - Windows Forms clipping last line of measured text (#1659)
+- Inconsistent Zooming behaviour (#1648)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/OxyPlot/PlotController/Manipulators/ZoomStepManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/ZoomStepManipulator.cs
@@ -57,12 +57,13 @@ namespace OxyPlot
                 scale *= 3;
             }
 
-            scale = 1 + scale;
-
-            // make sure the zoom factor is not negative
-            if (scale < 0.1)
+            if (scale > 0)
             {
-                scale = 0.1;
+                scale = 1 + scale;
+            }
+            else
+            {
+                scale = 1.0 / (1 - scale);
             }
 
             if (this.XAxis != null)


### PR DESCRIPTION
Fixes #1648 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Makes zooming in and out proper reciprocals, so that when you zoom in 5 times, zooming out 5 times takes you to the same zoom level.

The implementation is that suggested by jupistar over in #1648

@oxyplot/admins
