### PR TITLE
Overhaul ContourSeries.JoinContourSegments()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project will be documented in this file.
 - Optimize clipping calls (#1661)
 - Mark CandleStickAndVolumeSeries as obsolete (#1661)
 - Implement StreamGeometry-based implementations of DrawEllipses, DrawLine, DrawLineSegments and DrawRectangle(s) which improves the rendering speed on WPF (#1673)
+- Change algorithm of ContourSeries.JoinContourSegments(). This should improve performance in most cases, but will cause labels to appear in different spots than before (#1685)
 
 ### Removed
 - Remove PlotModel.Legends (#644)
@@ -121,6 +122,7 @@ All notable changes to this project will be documented in this file.
 - ScreenMin and ScreenMax on Horizontal and Vertical Axes depends on plot bounds (#1652)
 - Windows Forms clipping last line of measured text (#1659)
 - Inconsistent Zooming behaviour (#1648)
+- ContourSeries produce fake connections (#1685)
 
 ## [2.0.0] - 2019-10-19
 ### Added 

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -18,7 +18,8 @@ namespace ExampleLibrary
         private static Func<double, double, double> peaks = (x, y) =>
                3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1))
                - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y)
-               - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
+               - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y)
+               + 0.2 * x * y;
 
         [Example("Peaks")]
         public static PlotModel Peaks()

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -20,6 +20,10 @@ namespace ExampleLibrary
                - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y)
                - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
 
+        private static Func<double, double, double> openContours = (x, y) =>
+            (x * x) / (y * y + 1)
+          + (y * y) / (x * x + 1);
+
         [Example("Peaks")]
         public static PlotModel Peaks()
         {
@@ -165,6 +169,21 @@ namespace ExampleLibrary
             };
             cs.Data = ArrayBuilder.Evaluate(peaks, cs.ColumnCoordinates, cs.RowCoordinates);
             model.Subtitle = cs.Data.GetLength(0) + "×" + cs.Data.GetLength(1);
+            model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Open Contours")]
+        public static PlotModel OpenContours()
+        {
+            var model = new PlotModel();
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05),
+                RowCoordinates = ArrayBuilder.CreateVector(-3, 3, 0.05)
+            };
+
+            cs.Data = ArrayBuilder.Evaluate(openContours, cs.ColumnCoordinates, cs.RowCoordinates);
             model.Series.Add(cs);
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -18,8 +18,7 @@ namespace ExampleLibrary
         private static Func<double, double, double> peaks = (x, y) =>
                3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1))
                - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y)
-               - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y)
-               + 0.2 * x * y;
+               - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
 
         [Example("Peaks")]
         public static PlotModel Peaks()

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -191,13 +191,13 @@ namespace ExampleLibrary
         [Example("Logarithmic Peaks")]
         public static PlotModel LogPeaks()
         {
-            Func<double, double, double> logPeaks = (x, y) => peaks(Math.Log(x) / 3 - 3.1, Math.Log(y) / 3 - 3.1);
+            Func<double, double, double> logPeaks = (x, y) => peaks(Math.Log(x) / 10, Math.Log(y) / 10);
 
             var model = new PlotModel();
             var coordinates = ArrayBuilder.CreateVector(-3, 3, 0.05);
             for (var i = 0; i < coordinates.Length; i++)
             {
-                coordinates[i] = Math.Exp((coordinates[i] + 3.1) * 3);
+                coordinates[i] = Math.Exp(coordinates[i] * 10);
             }
 
             var cs = new ContourSeries

--- a/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/ContourSeriesExamples.cs
@@ -7,7 +7,7 @@
 namespace ExampleLibrary
 {
     using System;
-
+    using System.Linq;
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
@@ -185,6 +185,31 @@ namespace ExampleLibrary
 
             cs.Data = ArrayBuilder.Evaluate(openContours, cs.ColumnCoordinates, cs.RowCoordinates);
             model.Series.Add(cs);
+            return model;
+        }
+
+        [Example("Logarithmic Peaks")]
+        public static PlotModel LogPeaks()
+        {
+            Func<double, double, double> logPeaks = (x, y) => peaks(Math.Log(x) / 3 - 3.1, Math.Log(y) / 3 - 3.1);
+
+            var model = new PlotModel();
+            var coordinates = ArrayBuilder.CreateVector(-3, 3, 0.05);
+            for (var i = 0; i < coordinates.Length; i++)
+            {
+                coordinates[i] = Math.Exp((coordinates[i] + 3.1) * 3);
+            }
+
+            var cs = new ContourSeries
+            {
+                ColumnCoordinates = coordinates,
+                RowCoordinates = coordinates
+            };
+
+            cs.Data = ArrayBuilder.Evaluate(logPeaks, cs.ColumnCoordinates, cs.RowCoordinates);
+            model.Series.Add(cs);
+            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left });
             return model;
         }
     }

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -462,8 +462,8 @@ namespace OxyPlot.Series
         /// <summary>
         /// Joins the contour segments.
         /// </summary>
-        /// <param name="eps">The tolerance for segment ends to connect (squared distance).</param>
-        private void JoinContourSegments(double eps = 1e-10)
+        /// <param name="epsFactor">The tolerance for segment ends to connect (maximum allowed [length of distance vector] / [length of position vector]).</param>
+        private void JoinContourSegments(double epsFactor = 1e-10)
         {
             this.contours = new List<Contour>();
 
@@ -491,13 +491,16 @@ namespace OxyPlot.Series
                         continue;
                     }
 
+                    var positionVectorLength = Math.Sqrt(Math.Pow(currentPoint.Point.X, 2) + Math.Pow(currentPoint.Point.Y, 2));
+                    var eps = positionVectorLength * epsFactor;
+
                     var maxX = currentPoint.Point.X + eps;
                     var i2 = i + 1;
                     SegmentPoint joinPoint;
 
                     // search for a point with the same coordinates (within eps) as the current point
                     // as points are sorted by X, we typically only need to check the point immediately following the current point
-                    do
+                    while (true)
                     {
                         if (i2 >= points.Count)
                         {
@@ -517,8 +520,13 @@ namespace OxyPlot.Series
                             joinPoint = null;
                             break;
                         }
+
+                        var distance = Math.Sqrt(Math.Pow(joinPoint.Point.X - currentPoint.Point.X, 2) + Math.Pow(joinPoint.Point.Y - currentPoint.Point.Y, 2));
+                        if (distance < eps)
+                        {
+                            break;
+                        }
                     }
-                    while (Math.Abs(joinPoint.Point.Y - currentPoint.Point.Y) > eps);
 
                     // join the two points together
                     if (joinPoint != null)

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -492,20 +492,20 @@ namespace OxyPlot.Series
                     }
 
                     var maxX = currentPoint.Point.X + eps;
-                    var i2 = 1;
+                    var i2 = i + 1;
                     SegmentPoint joinPoint;
 
                     // search for a point with the same coordinates (within eps) as the current point
                     // as points are sorted by X, we typically only need to check the point immediately following the current point
                     do
                     {
-                        if (i + i2 >= points.Count)
+                        if (i2 >= points.Count)
                         {
                             joinPoint = null;
                             break;
                         }
 
-                        joinPoint = points[i + i2];
+                        joinPoint = points[i2];
                         i2++;
                         if (joinPoint.Join != null)
                         {
@@ -537,22 +537,21 @@ namespace OxyPlot.Series
                     }
 
                     var currentPoint = segmentPoint;
-                    var dataPoints = new List<DataPoint>();
 
-                    if (currentPoint.Join == null) // we are the first point of the contour
+                    // search for the beginning of the contour (or use the entry point if the contour is closed)
+                    while (currentPoint.Join != null)
                     {
-                        dataPoints.Add(currentPoint.Point);
-                        currentPoint = currentPoint.Partner;
-                        dataPoints.Add(currentPoint.Point);
-                    }
-                    else // we are somewhere in the middle of the contour, our partner might be the first, so add it first
-                    {
-                        dataPoints.Add(currentPoint.Partner.Point);
-                        dataPoints.Add(currentPoint.Point);
+                        currentPoint = currentPoint.Join.Partner;
+                        if (currentPoint == segmentPoint)
+                        {
+                            break;
+                        }
                     }
 
+                    var dataPoints = new List<DataPoint> { currentPoint.Point, currentPoint.Partner.Point };
                     currentPoint.Processed = true;
-                    currentPoint.Partner.Processed = true;
+                    currentPoint = currentPoint.Partner;
+                    currentPoint.Processed = true;
 
                     // follow the chain of joined points and add their coordinates until we find the last point of the contour (or complete a rotation)
                     while (currentPoint.Join != null)

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -398,33 +398,6 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Determines if two values are close.
-        /// </summary>
-        /// <param name="x1">The first value.</param>
-        /// <param name="x2">The second value.</param>
-        /// <param name="eps">The squared tolerance.</param>
-        /// <returns>True if the values are close.</returns>
-        private static bool AreClose(double x1, double x2, double eps = 1e-6)
-        {
-            double dx = x1 - x2;
-            return dx * dx < eps;
-        }
-
-        /// <summary>
-        /// Determines if two points are close.
-        /// </summary>
-        /// <param name="p0">The first point.</param>
-        /// <param name="p1">The second point.</param>
-        /// <param name="eps">The squared tolerance.</param>
-        /// <returns>True if the points are close.</returns>
-        private static bool AreClose(DataPoint p0, DataPoint p1, double eps = 1e-6)
-        {
-            double dx = p0.X - p1.X;
-            double dy = p0.Y - p1.Y;
-            return (dx * dx) + (dy * dy) < eps;
-        }
-
-        /// <summary>
         /// Gets the index of item that is closest to the specified value.
         /// </summary>
         /// <param name="values">A list of values.</param>
@@ -487,99 +460,117 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Finds the connected segment.
-        /// </summary>
-        /// <param name="point">The point.</param>
-        /// <param name="contourLevel">The contour level.</param>
-        /// <param name="eps">The distance tolerance.</param>
-        /// <param name="reverse">reverse the segment if set to <c>true</c>.</param>
-        /// <returns>The connected segment, or <c>null</c> if no segment was found.</returns>
-        private ContourSegment FindConnectedSegment(DataPoint point, double contourLevel, double eps, out bool reverse)
-        {
-            reverse = false;
-            foreach (var s in this.segments)
-            {
-                if (!AreClose(s.ContourLevel, contourLevel, eps))
-                {
-                    continue;
-                }
-
-                if (AreClose(point, s.StartPoint, eps))
-                {
-                    return s;
-                }
-
-                if (AreClose(point, s.EndPoint, eps))
-                {
-                    reverse = true;
-                    return s;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
         /// Joins the contour segments.
         /// </summary>
         /// <param name="eps">The tolerance for segment ends to connect (squared distance).</param>
         private void JoinContourSegments(double eps = 1e-10)
         {
-            // This is a simple, slow, naïve method - should be improved:
-            // http://stackoverflow.com/questions/1436091/joining-unordered-line-segments
             this.contours = new List<Contour>();
-            var contourPoints = new List<DataPoint>();
-            int contourPointsCount = 0;
 
-            ContourSegment firstSegment = null;
-            int segmentCount = this.segments.Count;
-            while (segmentCount > 0)
+            static IEnumerable<SegmentPoint> GetPoints(ContourSegment segment)
             {
-                ContourSegment segment1 = null, segment2 = null;
+                var p1 = new SegmentPoint(segment.StartPoint);
+                var p2 = new SegmentPoint(segment.EndPoint);
+                p1.Partner = p2;
+                p2.Partner = p1;
+                yield return p1;
+                yield return p2;
+            }
 
-                if (firstSegment != null)
+            foreach (var group in this.segments.GroupBy(p => p.ContourLevel))
+            {
+                var level = group.Key;
+                var points = group.SelectMany(GetPoints).OrderBy(p => p.Point.X).ToList();
+
+                // first, go through the sorted points, find identical points and join them together 
+                for (var i = 0; i < points.Count - 1; i++)
                 {
-                    bool reverse;
-
-                    // Find a segment that is connected to the head of the contour
-                    segment1 = this.FindConnectedSegment(contourPoints[0], firstSegment.ContourLevel, eps, out reverse);
-                    if (segment1 != null)
+                    var currentPoint = points[i];
+                    if (currentPoint.Join != null)
                     {
-                        contourPoints.Insert(0, reverse ? segment1.StartPoint : segment1.EndPoint);
-                        contourPointsCount++;
-                        this.segments.Remove(segment1);
-                        segmentCount--;
+                        continue;
                     }
 
-                    // Find a segment that is connected to the tail of the contour
-                    segment2 = this.FindConnectedSegment(contourPoints[contourPointsCount - 1], firstSegment.ContourLevel, eps, out reverse);
-                    if (segment2 != null)
+                    var maxX = currentPoint.Point.X + eps;
+                    var i2 = 1;
+                    SegmentPoint joinPoint;
+
+                    // search for a point with the same coordinates (within eps) as the current point
+                    // as points are sorted by X, we typically only need to check the point immediately following the current point
+                    do
                     {
-                        contourPoints.Add(reverse ? segment2.StartPoint : segment2.EndPoint);
-                        contourPointsCount++;
-                        this.segments.Remove(segment2);
-                        segmentCount--;
+                        if (i + i2 >= points.Count)
+                        {
+                            joinPoint = null;
+                            break;
+                        }
+
+                        joinPoint = points[i + i2];
+                        i2++;
+                        if (joinPoint.Join != null)
+                        {
+                            continue;
+                        }
+
+                        if (joinPoint.Point.X > maxX)
+                        {
+                            joinPoint = null;
+                            break;
+                        }
+                    }
+                    while (Math.Abs(joinPoint.Point.Y - currentPoint.Point.Y) > eps);
+
+                    // join the two points together
+                    if (joinPoint != null)
+                    {
+                        currentPoint.Join = joinPoint;
+                        joinPoint.Join = currentPoint;
                     }
                 }
 
-                if ((segment1 == null && segment2 == null) || segmentCount == 0)
+                // go through the points again, this time we follow the joined point chains to obtain the contours
+                foreach (var segmentPoint in points)
                 {
-                    if (contourPointsCount > 0 && firstSegment != null)
+                    if (segmentPoint.Processed)
                     {
-                        this.contours.Add(new Contour(contourPoints, firstSegment.ContourLevel));
-                        contourPoints = new List<DataPoint>();
-                        contourPointsCount = 0;
+                        continue;
                     }
 
-                    if (segmentCount > 0)
+                    var currentPoint = segmentPoint;
+                    var dataPoints = new List<DataPoint>();
+
+                    if (currentPoint.Join == null) // we are the first point of the contour
                     {
-                        firstSegment = this.segments.First();
-                        contourPoints.Add(firstSegment.StartPoint);
-                        contourPoints.Add(firstSegment.EndPoint);
-                        contourPointsCount += 2;
-                        this.segments.Remove(firstSegment);
-                        segmentCount--;
+                        dataPoints.Add(currentPoint.Point);
+                        currentPoint = currentPoint.Partner;
+                        dataPoints.Add(currentPoint.Point);
                     }
+                    else // we are somewhere in the middle of the contour, our partner might be the first, so add it first
+                    {
+                        dataPoints.Add(currentPoint.Partner.Point);
+                        dataPoints.Add(currentPoint.Point);
+                    }
+
+                    currentPoint.Processed = true;
+                    currentPoint.Partner.Processed = true;
+
+                    // follow the chain of joined points and add their coordinates until we find the last point of the contour (or complete a rotation)
+                    while (currentPoint.Join != null)
+                    {
+                        currentPoint = currentPoint.Join;
+                        if (currentPoint.Processed)
+                        {
+                            break;
+                        }
+
+                        currentPoint.Processed = true;
+                        currentPoint = currentPoint.Partner;
+                        currentPoint.Processed = true;
+                        dataPoints.Add(currentPoint.Point);
+                    }
+
+                    var contour = new Contour(dataPoints, level);
+                    this.contours.Add(contour);
                 }
             }
         }
@@ -639,6 +630,42 @@ namespace OxyPlot.Series
                                new ScreenPoint(x - (size.Width * ux) + (size.Height * vx), y - (size.Width * uy) + (size.Height * vy))
                            };
             rc.DrawPolygon(bpts, this.LabelBackground, OxyColors.Undefined, 0, this.EdgeRenderingMode);
+        }
+
+
+        /// <summary>
+        /// Represents one of the two points of a segment.
+        /// </summary>
+        private class SegmentPoint
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SegmentPoint" /> class.
+            /// </summary>
+            /// <param name="point">The segment point.</param>
+            public SegmentPoint(DataPoint point)
+            {
+                this.Point = point;
+            }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether this <see cref="SegmentPoint"/> already was added to a <see cref="Contour"/>.
+            /// </summary>
+            public bool Processed { get; set; }
+
+            /// <summary>
+            /// Gets or sets the partner point. This point and its partner together define a segment.
+            /// </summary>
+            public SegmentPoint Partner { get; set; }
+
+            /// <summary>
+            /// Gets or sets the join point. This is a point from another segment with the same coordinates as this point (within eps).
+            /// </summary>
+            public SegmentPoint Join { get; set; }
+
+            /// <summary>
+            /// Gets the data point.
+            /// </summary>
+            public DataPoint Point { get; }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1685.

### Checklist

- [ ] I have included examples or tests (example already added in #1698)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use a new algorithm for `ContourSeries.JoinContourSegments()`. This fixes the 'fake connections' problem and also should improve performance: While the previous algorithm was O(n²), the new one should usually be O(n log(n)).
- Small concern: the new algorithm also results in a different 'start' point of the contours, causing labels to be placed in different locations than before. I guess there is not really a 'correct' position for these labels to be in, so it should be fine?! If there are suggestions how to make this more consistent I'd be happy to take another look.

 @oxyplot/admins
