### PR TITLE
Fix zero-crossing axis bounds (#1708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+- Zero-crossing axis bounds (#1708)
+
 ## [2.1.0-Preview1] - 2020-10-18
 
 ### Added

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -76,11 +76,11 @@ namespace OxyPlot.Axes
                 axisPosition = perpendicularAxis.Transform(0);
 
                 var p0 = axis.IsHorizontal()
-                    ? perpendicularAxis.ScreenMin.X
-                    : perpendicularAxis.ScreenMin.Y;
+                    ? perpendicularAxis.ScreenMin.Y
+                    : perpendicularAxis.ScreenMin.X;
                 var p1 = axis.IsHorizontal()
-                    ? perpendicularAxis.ScreenMax.X
-                    : perpendicularAxis.ScreenMax.Y;
+                    ? perpendicularAxis.ScreenMax.Y
+                    : perpendicularAxis.ScreenMax.X;
 
                 // find the min/max positions
                 var min = Math.Min(p0, p1);


### PR DESCRIPTION
Fixes #1708 .

### Checklist

- [ ] I have included examples or tests (existing zero-crossing examples)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

 - Fixes the `ScreenMin/Max` lookups. Looks like I got the bounds the wrong way around a while back, and #1682 revealed this mistake.

@oxyplot/admins
