### PR TITLE
Add Example for Issue #1716

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Example for Issue #1716 showing poor tick spacing on DateTimeAxis with interval types of Weeks or Years
 
 ### Changed
 

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -2466,6 +2466,50 @@ namespace ExampleLibrary
             return plot;
         }
 
+        [Example("#1716: DateTimeAxis sometimes ignores IntervalLength")]
+        public static PlotModel DateTimeAxisSometimesIgnoresIntervalLength()
+        {
+            var plot = new PlotModel();
+
+            plot.Title = "IntervalLength is ignored for large ranges with IntervalType of Years or Weeks";
+
+            var days = new DateTimeAxis
+            {
+                IntervalType = DateTimeIntervalType.Days,
+                Position = AxisPosition.Bottom,
+                PositionTier = 1,
+                Minimum = DateTimeAxis.ToDouble(new DateTime(2000, 1, 1)),
+                Maximum = DateTimeAxis.ToDouble(new DateTime(2001, 1, 1)),
+                Title = "Days (mostly fine)",
+            };
+
+            var weeks = new DateTimeAxis
+            {
+                IntervalType = DateTimeIntervalType.Weeks,
+                Position = AxisPosition.Bottom,
+                PositionTier = 2,
+                Minimum = DateTimeAxis.ToDouble(new DateTime(2000, 1, 1)),
+                Maximum = DateTimeAxis.ToDouble(new DateTime(2001, 1, 1)),
+                Title = "Weeks (nothing is fine)",
+            };
+
+            var years = new DateTimeAxis
+            {
+                IntervalType = DateTimeIntervalType.Years,
+                Position = AxisPosition.Bottom,
+                PositionTier = 3,
+                Minimum = DateTimeAxis.ToDouble(new DateTime(2000, 1, 1)),
+                Maximum = DateTimeAxis.ToDouble(new DateTime(2100, 1, 1)),
+                Title = "Years (minor ticks not fine)",
+            };
+
+            plot.Axes.Add(days);
+            plot.Axes.Add(weeks);
+            plot.Axes.Add(years);
+
+            return plot;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }


### PR DESCRIPTION
Adds an example for #1716.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- The example has 3 DateTimeAxis axes, one with `IntervalType` of `Days`, another with `Weeks`, another with `Years`.
    - The first (days) is included for comparison, and is pretty much OK.
    - The second (weeks) makes all major ticks exactly on week apart, and minor ticks exactly one day apart (and they don't line up...).
    - The third (years) is supposed - I think - to place minor ticks 31 days apart... but even this it doesn't seem to manage.

@oxyplot/admins
