### PR TITLE
Fix incorrect label placement on BarSeries with non-zero BaseValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Example for Issue #1716 showing poor tick spacing on DateTimeAxis with interval types of Weeks or Years
+- Example for label placement on BarSeries with non-zero BaseValue (#1726)
 
 ### Changed
 
@@ -12,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Zero-crossing axis bounds (#1708)
+- Incorrect label placement on BarSeries with non-zero BaseValue (#1726)
 
 ## [2.1.0-Preview1] - 2020-10-18
 

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -932,6 +932,37 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("BaseValue (labels)")]
+        public static PlotModel BaseValueLabels()
+        {
+            var model = new PlotModel { Title = "BaseValue with Labels" };
+
+            foreach (var placement in new[] { LabelPlacement.Base, LabelPlacement.Inside, LabelPlacement.Middle, LabelPlacement.Outside })
+            {
+                var bs = new BarSeries { Title = placement.ToString(), BaseValue = -25, LabelPlacement = placement, LabelFormatString = "{0:0}" };
+                bs.Items.Add(new BarItem { Value = -40 });
+                bs.Items.Add(new BarItem { Value = -25 });
+                bs.Items.Add(new BarItem { Value = -10 });
+                bs.Items.Add(new BarItem { Value = 0 });
+                bs.Items.Add(new BarItem { Value = 10 });
+                model.Series.Add(bs);
+            }
+
+            var categoryAxis = new CategoryAxis
+            {
+                Title = "Category",
+                Position = AxisPosition.Left,
+                StartPosition = 1,
+                EndPosition = 0,
+            };
+            categoryAxis.Labels.AddRange(new[] { "A", "B", "C", "D", "E" });
+            model.Axes.Add(categoryAxis);
+
+            model.Legends.Add(new Legend());
+
+            return model;
+        }
+
         [Example("GapWidth 0%")]
         public static PlotModel GapWidth0()
         {

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -310,7 +310,7 @@ namespace OxyPlot.Series
             HorizontalAlignment ha;
             ScreenPoint pt;
             var y = (categoryEndValue + categoryValue) / 2;
-            var sign = Math.Sign(item.Value);
+            var sign = Math.Sign(item.Value - baseValue);
             var marginVector = new ScreenVector(this.LabelMargin, 0) * sign;
 
             switch (this.LabelPlacement)


### PR DESCRIPTION
Fixes #1726 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds an example for label placement on `BarSeries` with non-zero `BaseValue`
- Fixes a bug where bar-series didn't consider the `BaseValue` when determining label placement

@oxyplot/admins
