### PR TITLE
Add control over how far from the series the tracker fires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,6 @@ _Pvt_Extensions
 # OxyPlot specific
 Output/
 launchSettings.json
+
+# Rider
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Example for Issue #1716 showing poor tick spacing on DateTimeAxis with interval types of Weeks or Years
 - Example for label placement on BarSeries with non-zero BaseValue (#1726)
 - Add control over how far from the series the tracker fires (#1736)
+- Add option to check distance for result between data points (#1736)
 
 ### Changed
 
@@ -15,7 +16,6 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Zero-crossing axis bounds (#1708)
 - Incorrect label placement on BarSeries with non-zero BaseValue (#1726)
-- Add checking distance for result between data points (#1736)
 
 ## [2.1.0-Preview1] - 2020-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Example for Issue #1716 showing poor tick spacing on DateTimeAxis with interval types of Weeks or Years
 - Example for label placement on BarSeries with non-zero BaseValue (#1726)
+- Add control over how far from the series the tracker fires (#1736)
 
 ### Changed
 
@@ -14,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Zero-crossing axis bounds (#1708)
 - Incorrect label placement on BarSeries with non-zero BaseValue (#1726)
+- Add checking distance for result between data points (#1736)
 
 ## [2.1.0-Preview1] - 2020-10-18
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -133,3 +133,4 @@ Duncan Robertson <duncanjacobrobertson@gmail.com>
 LauXjpn <laucomm@gmail.com>
 R. Usamentiaga
 Dmytro Shaurin
+Rustam Sayfutdinov

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -67,5 +67,38 @@ namespace ExampleLibrary
             };
             return model;
         }
+
+        [Example("Specified distance of the tracker fires")]
+        public static Example TrackerFiresDistance()
+        {
+            var model = new PlotModel
+            {
+                Title = "Specified distance of the tracker fires",
+                Subtitle = "Press the left mouse button to test the tracker.",
+            };
+            model.Series.Add(new FunctionSeries(Math.Sin, 0, 10, 100));
+            
+            // create a new plot controller with default bindings
+            var plotController = new PlotController();
+
+            // remove a tracker command to the left mouse down event by default
+            plotController.Unbind(PlotCommands.SnapTrack);
+            
+            // add a tracker command to the left mouse down event with specified distance
+            plotController.BindMouseDown(
+                OxyMouseButton.Left,
+                new DelegatePlotCommand<OxyMouseDownEventArgs>((view, controller, args) =>
+                    controller.AddMouseManipulator(
+                        view,
+                        new TrackerManipulator(view)
+                        {
+                            Snap = true,
+                            PointsOnly = false,
+                            FiresDistance = 2.0,
+                        },
+                        args)));
+
+            return new Example(model, plotController);
+        }
     }
 }

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -96,7 +96,7 @@ namespace ExampleLibrary
                             Snap = true,
                             PointsOnly = false,
                             FiresDistance = 2.0,
-                            IsCheckDistanceBetweenPoints = true,
+                            CheckDistanceBetweenPoints = true,
                         },
                         args)));
             plotController.BindTouchDown(

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -22,7 +22,6 @@ namespace ExampleLibrary
             {
                 Title = "No tracker interpolation",
                 Subtitle = "Used for discrete values or scatter plots.",
-                TrackerFiresDistance = 4.0,
             };
             var l = new Legend
             {
@@ -32,16 +31,16 @@ namespace ExampleLibrary
             model.Legends.Add(l);
 
             var s1 = new LineSeries
-                         {
-                             Title = "Series 1",
-                             CanTrackerInterpolatePoints = false,
-                             Color = OxyColors.SkyBlue,
-                             MarkerType = MarkerType.Circle,
-                             MarkerSize = 6,
-                             MarkerStroke = OxyColors.White,
-                             MarkerFill = OxyColors.SkyBlue,
-                             MarkerStrokeThickness = 1.5
-                         };
+            {
+                Title = "Series 1",
+                CanTrackerInterpolatePoints = false,
+                Color = OxyColors.SkyBlue,
+                MarkerType = MarkerType.Circle,
+                MarkerSize = 6,
+                MarkerStroke = OxyColors.White,
+                MarkerFill = OxyColors.SkyBlue,
+                MarkerStrokeThickness = 1.5
+            };
             for (int i = 0; i < 63; i++)
             {
                 s1.Points.Add(new DataPoint((int)(Math.Sqrt(i) * Math.Cos(i * 0.1)), (int)(Math.Sqrt(i) * Math.Sin(i * 0.1))));
@@ -59,7 +58,6 @@ namespace ExampleLibrary
             {
                 Title = "Handling the TrackerChanged event",
                 Subtitle = "Press the left mouse button to test the tracker.",
-                TrackerFiresDistance = 4.0,
             };
             model.Series.Add(new FunctionSeries(Math.Sin, 0, 10, 100));
             model.TrackerChanged += (s, e) =>

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -96,6 +96,7 @@ namespace ExampleLibrary
                             Snap = true,
                             PointsOnly = false,
                             FiresDistance = 2.0,
+                            IsCheckDistanceBetweenPoints = true,
                         },
                         args)));
             plotController.BindTouchDown(

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -81,16 +81,28 @@ namespace ExampleLibrary
             // create a new plot controller with default bindings
             var plotController = new PlotController();
 
-            // remove a tracker command to the left mouse down event by default
+            // remove a tracker command to the mouse-left/touch down event by default
             plotController.Unbind(PlotCommands.SnapTrack);
+            plotController.Unbind(PlotCommands.SnapTrackTouch);
             
-            // add a tracker command to the left mouse down event with specified distance
+            // add a tracker command to the mouse-left/touch down event with specified distance
             plotController.BindMouseDown(
                 OxyMouseButton.Left,
                 new DelegatePlotCommand<OxyMouseDownEventArgs>((view, controller, args) =>
                     controller.AddMouseManipulator(
                         view,
                         new TrackerManipulator(view)
+                        {
+                            Snap = true,
+                            PointsOnly = false,
+                            FiresDistance = 2.0,
+                        },
+                        args)));
+            plotController.BindTouchDown(
+                new DelegatePlotCommand<OxyTouchEventArgs>((view, controller, args) =>
+                    controller.AddTouchManipulator(
+                        view,
+                        new TouchTrackerManipulator(view)
                         {
                             Snap = true,
                             PointsOnly = false,

--- a/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/TrackerExamples.cs
@@ -18,7 +18,12 @@ namespace ExampleLibrary
         [Example("No interpolation")]
         public static PlotModel NoInterpolation()
         {
-            var model = new PlotModel { Title = "No tracker interpolation", Subtitle = "Used for discrete values or scatter plots." };
+            var model = new PlotModel
+            {
+                Title = "No tracker interpolation",
+                Subtitle = "Used for discrete values or scatter plots.",
+                TrackerFiresDistance = 4.0,
+            };
             var l = new Legend
             {
                 LegendSymbolLength = 30
@@ -50,7 +55,12 @@ namespace ExampleLibrary
         [Example("TrackerChangedEvent")]
         public static PlotModel TrackerChangedEvent()
         {
-            var model = new PlotModel { Title = "Handling the TrackerChanged event", Subtitle = "Press the left mouse button to test the tracker." };
+            var model = new PlotModel
+            {
+                Title = "Handling the TrackerChanged event",
+                Subtitle = "Press the left mouse button to test the tracker.",
+                TrackerFiresDistance = 4.0,
+            };
             model.Series.Add(new FunctionSeries(Math.Sin, 0, 10, 100));
             model.TrackerChanged += (s, e) =>
             {

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -30,7 +30,7 @@ namespace OxyPlot
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
             this.FiresDistance = 20.0;
-            this.IsCheckDistanceBetweenPoints = false;
+            this.CheckDistanceBetweenPoints = false;
 
             // Note: the tracker manipulator should not handle pan or zoom
             this.SetHandledForPanOrZoom = false;
@@ -60,7 +60,8 @@ namespace OxyPlot
         /// <summary>
         /// Gets or sets a value indicating whether to check distance when showing tracker between data points.
         /// </summary>
-        public bool IsCheckDistanceBetweenPoints { get; set; }
+        /// <remarks>This parameter is ignored if <see cref="PointsOnly"/> is equal to <c>False</c>.</remarks>
+        public bool CheckDistanceBetweenPoints { get; set; }
 
         /// <summary>
         /// Occurs when a manipulation is complete.
@@ -136,7 +137,7 @@ namespace OxyPlot
             }
 
             var result = Utilities.TrackerHelper.GetNearestHit(
-                this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance, this.IsCheckDistanceBetweenPoints);
+                this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance, this.CheckDistanceBetweenPoints);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -30,6 +30,7 @@ namespace OxyPlot
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
             this.FiresDistance = 20.0;
+            this.IsCheckDistanceBetweenPoints = false;
 
             // Note: the tracker manipulator should not handle pan or zoom
             this.SetHandledForPanOrZoom = false;
@@ -55,6 +56,12 @@ namespace OxyPlot
         /// Gets or sets the distance from the series at which the tracker fires.
         /// </summary>
         public double FiresDistance { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to check distance when showing tracker between data points.
+        /// </summary>
+        [System.Obsolete("")]
+        public bool IsCheckDistanceBetweenPoints { get; set; }
 
         /// <summary>
         /// Occurs when a manipulation is complete.
@@ -130,7 +137,7 @@ namespace OxyPlot
             }
 
             var result = Utilities.TrackerHelper.GetNearestHit(
-                this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance);
+                this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance, this.IsCheckDistanceBetweenPoints);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -60,7 +60,6 @@ namespace OxyPlot
         /// <summary>
         /// Gets or sets a value indicating whether to check distance when showing tracker between data points.
         /// </summary>
-        [System.Obsolete("")]
         public bool IsCheckDistanceBetweenPoints { get; set; }
 
         /// <summary>

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -29,6 +29,7 @@ namespace OxyPlot
             this.Snap = true;
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
+            this.FiresDistance = 20.0;
 
             // Note: the tracker manipulator should not handle pan or zoom
             this.SetHandledForPanOrZoom = false;
@@ -49,6 +50,11 @@ namespace OxyPlot
         /// </summary>
         /// <value><c>true</c> if the tracker should be locked; otherwise, <c>false</c>.</value>
         public bool LockToInitialSeries { get; set; }
+
+        /// <summary>
+        /// Gets or sets the distance from the series at which the tracker fires.
+        /// </summary>
+        public double FiresDistance { get; set; }
 
         /// <summary>
         /// Occurs when a manipulation is complete.
@@ -85,8 +91,7 @@ namespace OxyPlot
         public override void Started(OxyTouchEventArgs e)
         {
             base.Started(e);
-            this.currentSeries = this.PlotView.ActualModel?
-                .GetSeriesFromPoint(e.Position, this.PlotView.ActualModel.TrackerFiresDistance);
+            this.currentSeries = this.PlotView.ActualModel?.GetSeriesFromPoint(e.Position, this.FiresDistance);
 
             UpdateTracker(e.Position);
         }
@@ -100,8 +105,7 @@ namespace OxyPlot
             if (this.currentSeries == null || !this.LockToInitialSeries)
             {
                 // get the nearest
-                this.currentSeries = this.PlotView.ActualModel?
-                    .GetSeriesFromPoint(position, this.PlotView.ActualModel.TrackerFiresDistance);
+                this.currentSeries = this.PlotView.ActualModel?.GetSeriesFromPoint(position, this.FiresDistance);
             }
 
             if (this.currentSeries == null)
@@ -125,8 +129,7 @@ namespace OxyPlot
                 return;
             }
 
-            var result = GetNearestHit(
-                this.currentSeries, position, this.Snap, this.PointsOnly, this.PlotView.ActualModel.TrackerFiresDistance);
+            var result = GetNearestHit(this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;
@@ -156,7 +159,7 @@ namespace OxyPlot
             if (snap || pointsOnly)
             {
                 var result = series.GetNearestPoint(point, false);
-                if (IsAcceptableResult(result, point, firesDistance))
+                if (IsTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }
@@ -166,7 +169,7 @@ namespace OxyPlot
             if (!pointsOnly)
             {
                 var result = series.GetNearestPoint(point, true);
-                if (IsAcceptableResult(result, point, firesDistance))
+                if (IsTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }
@@ -175,7 +178,7 @@ namespace OxyPlot
             return null;
         }
 
-        private static bool IsAcceptableResult(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
+        private static bool IsTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
             result?.Position.DistanceTo(point) < firesDistance;
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -85,7 +85,8 @@ namespace OxyPlot
         public override void Started(OxyTouchEventArgs e)
         {
             base.Started(e);
-            this.currentSeries = this.PlotView.ActualModel != null ? this.PlotView.ActualModel.GetSeriesFromPoint(e.Position) : null;
+            this.currentSeries = this.PlotView.ActualModel?
+                .GetSeriesFromPoint(e.Position, this.PlotView.ActualModel.TrackerFiresDistance);
 
             UpdateTracker(e.Position);
         }
@@ -99,7 +100,8 @@ namespace OxyPlot
             if (this.currentSeries == null || !this.LockToInitialSeries)
             {
                 // get the nearest
-                this.currentSeries = this.PlotView.ActualModel != null ? this.PlotView.ActualModel.GetSeriesFromPoint(position, 20) : null;
+                this.currentSeries = this.PlotView.ActualModel?
+                    .GetSeriesFromPoint(position, this.PlotView.ActualModel.TrackerFiresDistance);
             }
 
             if (this.currentSeries == null)
@@ -123,7 +125,8 @@ namespace OxyPlot
                 return;
             }
 
-            var result = GetNearestHit(this.currentSeries, position, this.Snap, this.PointsOnly);
+            var result = GetNearestHit(
+                this.currentSeries, position, this.Snap, this.PointsOnly, this.PlotView.ActualModel.TrackerFiresDistance);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;
@@ -139,8 +142,10 @@ namespace OxyPlot
         /// <param name="point">The point.</param>
         /// <param name="snap">Snap to points.</param>
         /// <param name="pointsOnly">Check points only (no interpolation).</param>
+        /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
         /// <returns>A tracker hit result.</returns>
-        private static TrackerHitResult GetNearestHit(Series.Series series, ScreenPoint point, bool snap, bool pointsOnly)
+        private static TrackerHitResult GetNearestHit(
+            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance)
         {
             if (series == null)
             {
@@ -153,7 +158,7 @@ namespace OxyPlot
                 var result = series.GetNearestPoint(point, false);
                 if (result != null)
                 {
-                    if (result.Position.DistanceTo(point) < 20)
+                    if (result.Position.DistanceTo(point) < firesDistance)
                     {
                         return result;
                     }

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -129,7 +129,8 @@ namespace OxyPlot
                 return;
             }
 
-            var result = GetNearestHit(this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance);
+            var result = Utilities.TrackerHelper.GetNearestHit(
+                this.currentSeries, position, this.Snap, this.PointsOnly, this.FiresDistance);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;
@@ -137,48 +138,5 @@ namespace OxyPlot
                 this.PlotView.ActualModel.RaiseTrackerChanged(result);
             }
         }
-
-        /// <summary>
-        /// Gets the nearest tracker hit.
-        /// </summary>
-        /// <param name="series">The series.</param>
-        /// <param name="point">The point.</param>
-        /// <param name="snap">Snap to points.</param>
-        /// <param name="pointsOnly">Check points only (no interpolation).</param>
-        /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
-        /// <returns>A tracker hit result.</returns>
-        private static TrackerHitResult GetNearestHit(
-            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance)
-        {
-            if (series == null)
-            {
-                return null;
-            }
-
-            // Check data points only
-            if (snap || pointsOnly)
-            {
-                var result = series.GetNearestPoint(point, false);
-                if (IsTrackerOpen(result, point, firesDistance))
-                {
-                    return result;
-                }
-            }
-
-            // Check between data points (if possible)
-            if (!pointsOnly)
-            {
-                var result = series.GetNearestPoint(point, true);
-                if (IsTrackerOpen(result, point, firesDistance))
-                {
-                    return result;
-                }
-            }
-
-            return null;
-        }
-
-        private static bool IsTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
-            result?.Position.DistanceTo(point) < firesDistance;
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TouchTrackerManipulator.cs
@@ -156,12 +156,9 @@ namespace OxyPlot
             if (snap || pointsOnly)
             {
                 var result = series.GetNearestPoint(point, false);
-                if (result != null)
+                if (IsAcceptableResult(result, point, firesDistance))
                 {
-                    if (result.Position.DistanceTo(point) < firesDistance)
-                    {
-                        return result;
-                    }
+                    return result;
                 }
             }
 
@@ -169,10 +166,16 @@ namespace OxyPlot
             if (!pointsOnly)
             {
                 var result = series.GetNearestPoint(point, true);
-                return result;
+                if (IsAcceptableResult(result, point, firesDistance))
+                {
+                    return result;
+                }
             }
 
             return null;
         }
+
+        private static bool IsAcceptableResult(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
+            result?.Position.DistanceTo(point) < firesDistance;
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -29,6 +29,7 @@ namespace OxyPlot
             this.Snap = true;
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
+            this.FiresDistance = 20.0;
         }
 
         /// <summary>
@@ -46,6 +47,11 @@ namespace OxyPlot
         /// </summary>
         /// <value><c>true</c> if the tracker should be locked; otherwise, <c>false</c>.</value>
         public bool LockToInitialSeries { get; set; }
+
+        /// <summary>
+        /// Gets or sets the distance from the series at which the tracker fires.
+        /// </summary>
+        public double FiresDistance { get; set; }
 
         /// <summary>
         /// Occurs when a manipulation is complete.
@@ -76,8 +82,7 @@ namespace OxyPlot
             if (this.currentSeries == null || !this.LockToInitialSeries)
             {
                 // get the nearest
-                this.currentSeries = this.PlotView.ActualModel?
-                    .GetSeriesFromPoint(e.Position, this.PlotView.ActualModel.TrackerFiresDistance);
+                this.currentSeries = this.PlotView.ActualModel?.GetSeriesFromPoint(e.Position, this.FiresDistance);
             }
 
             if (this.currentSeries == null)
@@ -101,8 +106,7 @@ namespace OxyPlot
                 return;
             }
 
-            var result = GetNearestHit(
-                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.PlotView.ActualModel.TrackerFiresDistance);
+            var result = GetNearestHit(this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;
@@ -118,8 +122,7 @@ namespace OxyPlot
         public override void Started(OxyMouseEventArgs e)
         {
             base.Started(e);
-            this.currentSeries = this.PlotView.ActualModel?
-                .GetSeriesFromPoint(e.Position, this.PlotView.ActualModel.TrackerFiresDistance);
+            this.currentSeries = this.PlotView.ActualModel?.GetSeriesFromPoint(e.Position, FiresDistance);
             this.Delta(e);
         }
 
@@ -144,7 +147,7 @@ namespace OxyPlot
             if (snap || pointsOnly)
             {
                 var result = series.GetNearestPoint(point, false);
-                if (IsAcceptableResult(result, point, firesDistance))
+                if (IsTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }
@@ -154,7 +157,7 @@ namespace OxyPlot
             if (!pointsOnly)
             {
                 var result = series.GetNearestPoint(point, true);
-                if (IsAcceptableResult(result, point, firesDistance))
+                if (IsTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }
@@ -163,7 +166,7 @@ namespace OxyPlot
             return null;
         }
 
-        private static bool IsAcceptableResult(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
+        private static bool IsTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
             result?.Position.DistanceTo(point) < firesDistance;
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -144,12 +144,9 @@ namespace OxyPlot
             if (snap || pointsOnly)
             {
                 var result = series.GetNearestPoint(point, false);
-                if (result != null)
+                if (IsAcceptableResult(result, point, firesDistance))
                 {
-                    if (result.Position.DistanceTo(point) < firesDistance)
-                    {
-                        return result;
-                    }
+                    return result;
                 }
             }
 
@@ -157,10 +154,16 @@ namespace OxyPlot
             if (!pointsOnly)
             {
                 var result = series.GetNearestPoint(point, true);
-                return result;
+                if (IsAcceptableResult(result, point, firesDistance))
+                {
+                    return result;
+                }
             }
 
             return null;
         }
+
+        private static bool IsAcceptableResult(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
+            result?.Position.DistanceTo(point) < firesDistance;
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -57,7 +57,6 @@ namespace OxyPlot
         /// <summary>
         /// Gets or sets a value indicating whether to check distance when showing tracker between data points.
         /// </summary>
-        [System.Obsolete("")]
         public bool IsCheckDistanceBetweenPoints { get; set; }
 
         /// <summary>

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -30,6 +30,7 @@ namespace OxyPlot
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
             this.FiresDistance = 20.0;
+            this.IsCheckDistanceBetweenPoints = false;
         }
 
         /// <summary>
@@ -52,6 +53,12 @@ namespace OxyPlot
         /// Gets or sets the distance from the series at which the tracker fires.
         /// </summary>
         public double FiresDistance { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to check distance when showing tracker between data points.
+        /// </summary>
+        [System.Obsolete("")]
+        public bool IsCheckDistanceBetweenPoints { get; set; }
 
         /// <summary>
         /// Occurs when a manipulation is complete.
@@ -107,7 +114,7 @@ namespace OxyPlot
             }
 
             var result = Utilities.TrackerHelper.GetNearestHit(
-                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance);
+                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance, this.IsCheckDistanceBetweenPoints);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -106,7 +106,8 @@ namespace OxyPlot
                 return;
             }
 
-            var result = GetNearestHit(this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance);
+            var result = Utilities.TrackerHelper.GetNearestHit(
+                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;
@@ -125,48 +126,5 @@ namespace OxyPlot
             this.currentSeries = this.PlotView.ActualModel?.GetSeriesFromPoint(e.Position, FiresDistance);
             this.Delta(e);
         }
-
-        /// <summary>
-        /// Gets the nearest tracker hit.
-        /// </summary>
-        /// <param name="series">The series.</param>
-        /// <param name="point">The point.</param>
-        /// <param name="snap">Snap to points.</param>
-        /// <param name="pointsOnly">Check points only (no interpolation).</param>
-        /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
-        /// <returns>A tracker hit result.</returns>
-        private static TrackerHitResult GetNearestHit(
-            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance)
-        {
-            if (series == null)
-            {
-                return null;
-            }
-
-            // Check data points only
-            if (snap || pointsOnly)
-            {
-                var result = series.GetNearestPoint(point, false);
-                if (IsTrackerOpen(result, point, firesDistance))
-                {
-                    return result;
-                }
-            }
-
-            // Check between data points (if possible)
-            if (!pointsOnly)
-            {
-                var result = series.GetNearestPoint(point, true);
-                if (IsTrackerOpen(result, point, firesDistance))
-                {
-                    return result;
-                }
-            }
-
-            return null;
-        }
-
-        private static bool IsTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
-            result?.Position.DistanceTo(point) < firesDistance;
     }
 }

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -30,7 +30,7 @@ namespace OxyPlot
             this.PointsOnly = false;
             this.LockToInitialSeries = true;
             this.FiresDistance = 20.0;
-            this.IsCheckDistanceBetweenPoints = false;
+            this.CheckDistanceBetweenPoints = false;
         }
 
         /// <summary>
@@ -57,7 +57,8 @@ namespace OxyPlot
         /// <summary>
         /// Gets or sets a value indicating whether to check distance when showing tracker between data points.
         /// </summary>
-        public bool IsCheckDistanceBetweenPoints { get; set; }
+        /// <remarks>This parameter is ignored if <see cref="PointsOnly"/> is equal to <c>False</c>.</remarks>
+        public bool CheckDistanceBetweenPoints { get; set; }
 
         /// <summary>
         /// Occurs when a manipulation is complete.
@@ -113,7 +114,7 @@ namespace OxyPlot
             }
 
             var result = Utilities.TrackerHelper.GetNearestHit(
-                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance, this.IsCheckDistanceBetweenPoints);
+                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.FiresDistance, this.CheckDistanceBetweenPoints);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;

--- a/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/TrackerManipulator.cs
@@ -76,7 +76,8 @@ namespace OxyPlot
             if (this.currentSeries == null || !this.LockToInitialSeries)
             {
                 // get the nearest
-                this.currentSeries = this.PlotView.ActualModel != null ? this.PlotView.ActualModel.GetSeriesFromPoint(e.Position, 20) : null;
+                this.currentSeries = this.PlotView.ActualModel?
+                    .GetSeriesFromPoint(e.Position, this.PlotView.ActualModel.TrackerFiresDistance);
             }
 
             if (this.currentSeries == null)
@@ -100,7 +101,8 @@ namespace OxyPlot
                 return;
             }
 
-            var result = GetNearestHit(this.currentSeries, e.Position, this.Snap, this.PointsOnly);
+            var result = GetNearestHit(
+                this.currentSeries, e.Position, this.Snap, this.PointsOnly, this.PlotView.ActualModel.TrackerFiresDistance);
             if (result != null)
             {
                 result.PlotModel = this.PlotView.ActualModel;
@@ -116,7 +118,8 @@ namespace OxyPlot
         public override void Started(OxyMouseEventArgs e)
         {
             base.Started(e);
-            this.currentSeries = this.PlotView.ActualModel != null ? this.PlotView.ActualModel.GetSeriesFromPoint(e.Position) : null;
+            this.currentSeries = this.PlotView.ActualModel?
+                .GetSeriesFromPoint(e.Position, this.PlotView.ActualModel.TrackerFiresDistance);
             this.Delta(e);
         }
 
@@ -127,8 +130,10 @@ namespace OxyPlot
         /// <param name="point">The point.</param>
         /// <param name="snap">Snap to points.</param>
         /// <param name="pointsOnly">Check points only (no interpolation).</param>
+        /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
         /// <returns>A tracker hit result.</returns>
-        private static TrackerHitResult GetNearestHit(Series.Series series, ScreenPoint point, bool snap, bool pointsOnly)
+        private static TrackerHitResult GetNearestHit(
+            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance)
         {
             if (series == null)
             {
@@ -141,7 +146,7 @@ namespace OxyPlot
                 var result = series.GetNearestPoint(point, false);
                 if (result != null)
                 {
-                    if (result.Position.DistanceTo(point) < 20)
+                    if (result.Position.DistanceTo(point) < firesDistance)
                     {
                         return result;
                     }

--- a/Source/OxyPlot/PlotModel/PlotElement.cs
+++ b/Source/OxyPlot/PlotModel/PlotElement.cs
@@ -78,7 +78,7 @@ namespace OxyPlot
         /// <summary>
         /// Gets or sets the edge rendering mode that is used for rendering the plot element.
         /// </summary>
-        /// <value>The edge rendering mode. The default is <see cref="EdgeRenderingMode.Automatic"/>.</value>
+        /// <value>The edge rendering mode. The default is <see cref="OxyPlot.EdgeRenderingMode.Automatic"/>.</value>
         public EdgeRenderingMode EdgeRenderingMode { get; set; }
 
         /// <summary>

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -147,6 +147,7 @@ namespace OxyPlot
                 };
 
             this.AxisTierDistance = 4.0;
+            this.TrackerFiresDistance = 20.0;
         }
 
         /// <summary>
@@ -250,7 +251,7 @@ namespace OxyPlot
         /// <summary>
         /// Gets or sets the edge rendering mode that is used for rendering the plot bounds and backgrounds.
         /// </summary>
-        /// <value>The edge rendering mode. The default is <see cref="EdgeRenderingMode.Automatic"/>.</value>
+        /// <value>The edge rendering mode. The default is <see cref="OxyPlot.EdgeRenderingMode.Automatic"/>.</value>
         public EdgeRenderingMode EdgeRenderingMode { get; set; }
 
         /// <summary>
@@ -300,6 +301,11 @@ namespace OxyPlot
         /// Gets or sets the distance between two neighborhood tiers of the same AxisPosition.
         /// </summary>
         public double AxisTierDistance { get; set; }
+
+        /// <summary>
+        /// Gets or sets the distance from the series at which the tracker fires.
+        /// </summary>
+        public double TrackerFiresDistance { get; set; }
 
         /// <summary>
         /// Gets or sets the color of the background of the plot area.

--- a/Source/OxyPlot/PlotModel/PlotModel.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.cs
@@ -147,7 +147,6 @@ namespace OxyPlot
                 };
 
             this.AxisTierDistance = 4.0;
-            this.TrackerFiresDistance = 20.0;
         }
 
         /// <summary>
@@ -301,11 +300,6 @@ namespace OxyPlot
         /// Gets or sets the distance between two neighborhood tiers of the same AxisPosition.
         /// </summary>
         public double AxisTierDistance { get; set; }
-
-        /// <summary>
-        /// Gets or sets the distance from the series at which the tracker fires.
-        /// </summary>
-        public double TrackerFiresDistance { get; set; }
 
         /// <summary>
         /// Gets or sets the color of the background of the plot area.

--- a/Source/OxyPlot/Utilities/TrackerHelper.cs
+++ b/Source/OxyPlot/Utilities/TrackerHelper.cs
@@ -10,9 +10,14 @@ namespace OxyPlot.Utilities
         /// <param name="snap">Snap to points.</param>
         /// <param name="pointsOnly">Check points only (no interpolation).</param>
         /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
+        /// <param name="isCheck"></param>
         /// <returns>A tracker hit result.</returns>
+        /// <remarks>
+        /// TODO: With removing <see cref="TrackerManipulator.IsCheckDistanceBetweenPoints" />
+        /// and <see cref="TouchTrackerManipulator.IsCheckDistanceBetweenPoints"/> remove also the isCheck parameter
+        /// </remarks>
         public static TrackerHitResult GetNearestHit(
-            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance)
+            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance, bool isCheck)
         {
             if (series == null)
             {
@@ -33,7 +38,7 @@ namespace OxyPlot.Utilities
             if (!pointsOnly)
             {
                 var result = series.GetNearestPoint(point, true);
-                if (IsTrackerOpen(result, point, firesDistance))
+                if (!isCheck || IsTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }

--- a/Source/OxyPlot/Utilities/TrackerHelper.cs
+++ b/Source/OxyPlot/Utilities/TrackerHelper.cs
@@ -1,0 +1,48 @@
+namespace OxyPlot.Utilities
+{
+    internal static class TrackerHelper
+    {
+        /// <summary>
+        /// Gets the nearest tracker hit.
+        /// </summary>
+        /// <param name="series">The series.</param>
+        /// <param name="point">The point.</param>
+        /// <param name="snap">Snap to points.</param>
+        /// <param name="pointsOnly">Check points only (no interpolation).</param>
+        /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
+        /// <returns>A tracker hit result.</returns>
+        public static TrackerHitResult GetNearestHit(
+            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance)
+        {
+            if (series == null)
+            {
+                return null;
+            }
+
+            // Check data points only
+            if (snap || pointsOnly)
+            {
+                var result = series.GetNearestPoint(point, false);
+                if (IsTrackerOpen(result, point, firesDistance))
+                {
+                    return result;
+                }
+            }
+
+            // Check between data points (if possible)
+            if (!pointsOnly)
+            {
+                var result = series.GetNearestPoint(point, true);
+                if (IsTrackerOpen(result, point, firesDistance))
+                {
+                    return result;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
+            result?.Position.DistanceTo(point) < firesDistance;
+    }
+}

--- a/Source/OxyPlot/Utilities/TrackerHelper.cs
+++ b/Source/OxyPlot/Utilities/TrackerHelper.cs
@@ -13,7 +13,7 @@ namespace OxyPlot.Utilities
         /// <param name="checkDistanceBetweenPoints">The value indicating whether to check distance
         /// when showing tracker between data points.</param>
         /// <remarks>
-        /// <see cref="checkDistanceBetweenPoints"/> is ignored if <see cref="pointsOnly"/> is equal to <c>False</c>.
+        /// <paramref name="checkDistanceBetweenPoints" /> is ignored if <paramref name="pointsOnly"/> is equal to <c>False</c>.
         /// </remarks>
         /// <returns>A tracker hit result.</returns>
         public static TrackerHitResult GetNearestHit(

--- a/Source/OxyPlot/Utilities/TrackerHelper.cs
+++ b/Source/OxyPlot/Utilities/TrackerHelper.cs
@@ -10,14 +10,19 @@ namespace OxyPlot.Utilities
         /// <param name="snap">Snap to points.</param>
         /// <param name="pointsOnly">Check points only (no interpolation).</param>
         /// <param name="firesDistance">The distance from the series at which the tracker fires</param>
-        /// <param name="isCheck"></param>
-        /// <returns>A tracker hit result.</returns>
+        /// <param name="checkDistanceBetweenPoints">The value indicating whether to check distance
+        /// when showing tracker between data points.</param>
         /// <remarks>
-        /// TODO: With removing <see cref="TrackerManipulator.IsCheckDistanceBetweenPoints" />
-        /// and <see cref="TouchTrackerManipulator.IsCheckDistanceBetweenPoints"/> remove also the isCheck parameter
+        /// <see cref="checkDistanceBetweenPoints"/> is ignored if <see cref="pointsOnly"/> is equal to <c>False</c>.
         /// </remarks>
+        /// <returns>A tracker hit result.</returns>
         public static TrackerHitResult GetNearestHit(
-            Series.Series series, ScreenPoint point, bool snap, bool pointsOnly, double firesDistance, bool isCheck)
+            Series.Series series,
+            ScreenPoint point,
+            bool snap,
+            bool pointsOnly,
+            double firesDistance,
+            bool checkDistanceBetweenPoints)
         {
             if (series == null)
             {
@@ -28,7 +33,7 @@ namespace OxyPlot.Utilities
             if (snap || pointsOnly)
             {
                 var result = series.GetNearestPoint(point, false);
-                if (IsTrackerOpen(result, point, firesDistance))
+                if (ShouldTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }
@@ -38,7 +43,7 @@ namespace OxyPlot.Utilities
             if (!pointsOnly)
             {
                 var result = series.GetNearestPoint(point, true);
-                if (!isCheck || IsTrackerOpen(result, point, firesDistance))
+                if (!checkDistanceBetweenPoints || ShouldTrackerOpen(result, point, firesDistance))
                 {
                     return result;
                 }
@@ -47,7 +52,7 @@ namespace OxyPlot.Utilities
             return null;
         }
 
-        private static bool IsTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
+        private static bool ShouldTrackerOpen(TrackerHitResult result, ScreenPoint point, double firesDistance) =>
             result?.Position.DistanceTo(point) < firesDistance;
     }
 }


### PR DESCRIPTION
Closes #1731 

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add control over how far from the series the tracker fires
- Add checking distance for result between data points (breaking change?)

@oxyplot/admins
