### PR TITLE
Add Legend.AllowUseFullExtent property (#1743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Example for label placement on BarSeries with non-zero BaseValue (#1726)
 - Add control over how far from the series the tracker fires (#1736)
 - Add option to check distance for result between data points (#1736)
+- Legend.AllowUseFullExtent property to control whether legends should be able to use the full extent of the plot (#1743)
 
 ### Changed
 

--- a/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
@@ -387,6 +387,60 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Full width legend")]
+        public static PlotModel LegendFullWidth()
+        {
+            var model = CreateModel(21);
+
+            var l1 = new Legend
+            {
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.TopCenter,
+                LegendOrientation = LegendOrientation.Horizontal,
+                AllowUseFullExtent = true,
+            };
+
+            var l2 = new Legend
+            {
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.BottomCenter,
+                LegendOrientation = LegendOrientation.Horizontal,
+                AllowUseFullExtent = true,
+            };
+
+            model.Legends.Add(l1);
+            model.Legends.Add(l2);
+
+            return model;
+        }
+
+        [Example("Full height legend")]
+        public static PlotModel LegendFullHeight()
+        {
+            var model = CreateModel(21);
+
+            var l1 = new Legend
+            {
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.LeftTop,
+                LegendOrientation = LegendOrientation.Vertical,
+                AllowUseFullExtent = true,
+            };
+
+            var l2 = new Legend
+            {
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.RightTop,
+                LegendOrientation = LegendOrientation.Vertical,
+                AllowUseFullExtent = true,
+            };
+
+            model.Legends.Add(l1);
+            model.Legends.Add(l2);
+
+            return model;
+        }
+
         private static PlotModel CreateModel(int n = 20)
         {
             var model = new PlotModel { Title = "LineSeries" };

--- a/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
@@ -408,8 +408,12 @@ namespace ExampleLibrary
                 AllowUseFullExtent = true,
             };
 
+            model.PlotMargins = new OxyThickness(50);
+
             model.Legends.Add(l1);
             model.Legends.Add(l2);
+
+            model.InvalidatePlot(true);
 
             return model;
         }

--- a/Source/OxyPlot/Legends/Legend.Rendering.cs
+++ b/Source/OxyPlot/Legends/Legend.Rendering.cs
@@ -101,31 +101,35 @@ namespace OxyPlot.Legends
                         break;
                 }
 
+                var bounds = this.AllowUseFullExtent
+                    ? this.PlotModel.PlotAndAxisArea
+                    : this.PlotModel.PlotArea;
+
                 switch (this.LegendPosition)
                 {
                     case LegendPosition.TopLeft:
                     case LegendPosition.BottomLeft:
-                        left = this.PlotModel.PlotArea.Left;
+                        left = bounds.Left;
                         break;
                     case LegendPosition.TopRight:
                     case LegendPosition.BottomRight:
-                        left = this.PlotModel.PlotArea.Right - legendSize.Width;
+                        left = bounds.Right - legendSize.Width;
                         break;
                     case LegendPosition.LeftTop:
                     case LegendPosition.RightTop:
-                        top = this.PlotModel.PlotArea.Top;
+                        top = bounds.Top;
                         break;
                     case LegendPosition.LeftBottom:
                     case LegendPosition.RightBottom:
-                        top = this.PlotModel.PlotArea.Bottom - legendSize.Height;
+                        top = bounds.Bottom - legendSize.Height;
                         break;
                     case LegendPosition.LeftMiddle:
                     case LegendPosition.RightMiddle:
-                        top = (this.PlotModel.PlotArea.Top + this.PlotModel.PlotArea.Bottom - legendSize.Height) * 0.5;
+                        top = (bounds.Top + bounds.Bottom - legendSize.Height) * 0.5;
                         break;
                     case LegendPosition.TopCenter:
                     case LegendPosition.BottomCenter:
-                        left = (this.PlotModel.PlotArea.Left + this.PlotModel.PlotArea.Right - legendSize.Width) * 0.5;
+                        left = (bounds.Left + bounds.Right - legendSize.Width) * 0.5;
                         break;
                 }
             }

--- a/Source/OxyPlot/Legends/LegendBase.cs
+++ b/Source/OxyPlot/Legends/LegendBase.cs
@@ -347,6 +347,12 @@ namespace OxyPlot.Legends
         public LegendPosition LegendPosition { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the legend should use the full extend of the plot when <see cref="LegendPlacement"/> equals <c>LegendPlacement.Outside</c>.
+        /// </summary>
+        /// <value>Whether the legends is allowed to use the full extent of the plot.</value>
+        public bool AllowUseFullExtent { get; set; }
+
+        /// <summary>
         /// Makes the LegendOrientation property safe.
         /// </summary>
         /// <remarks>If Legend is positioned left or right, force it to vertical orientation</remarks>

--- a/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
@@ -457,7 +457,7 @@ namespace OxyPlot
         /// <param name="rc">The rendering context.</param>
         private void UpdatePlotArea(IRenderContext rc)
         {
-            var plotArea = new OxyRect(
+            var plotAndAxisArea = new OxyRect(
                 this.PlotBounds.Left + this.Padding.Left,
                 this.PlotBounds.Top + this.Padding.Top,
                 Math.Max(0, this.Width - this.Padding.Left - this.Padding.Right),
@@ -468,10 +468,10 @@ namespace OxyPlot
             if (titleSize.Height > 0)
             {
                 var titleHeight = titleSize.Height + this.TitlePadding;
-                plotArea = new OxyRect(plotArea.Left, plotArea.Top + titleHeight, plotArea.Width, Math.Max(0, plotArea.Height - titleHeight));
+                plotAndAxisArea = new OxyRect(plotAndAxisArea.Left, plotAndAxisArea.Top + titleHeight, plotAndAxisArea.Width, Math.Max(0, plotAndAxisArea.Height - titleHeight));
             }
 
-            plotArea = plotArea.Deflate(this.ActualPlotMargins);
+            var plotArea = plotAndAxisArea.Deflate(this.ActualPlotMargins);
 
             if (this.IsLegendVisible)
             {
@@ -486,10 +486,10 @@ namespace OxyPlot
                 {
                     // Find the available size for the legend box
                     var availableLegendWidth = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Width
+                        ? plotAndAxisArea.Width
                         : plotArea.Width;
                     var availableLegendHeight = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Height
+                        ? plotAndAxisArea.Height
                         : plotArea.Height;
                     availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
                         availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
@@ -517,10 +517,10 @@ namespace OxyPlot
                 {
                     // Find the available size for the legend box
                     var availableLegendWidth = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Width
+                        ? plotAndAxisArea.Width
                         : plotArea.Width;
                     var availableLegendHeight = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Height
+                        ? plotAndAxisArea.Height
                         : plotArea.Height;
                     availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
                         availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
@@ -548,10 +548,10 @@ namespace OxyPlot
                 {
                     // Find the available size for the legend box
                     var availableLegendWidth = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Width
+                        ? plotAndAxisArea.Width
                         : plotArea.Width;
                     var availableLegendHeight = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Height
+                        ? plotAndAxisArea.Height
                         : plotArea.Height;
                     availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
                         availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
@@ -579,10 +579,10 @@ namespace OxyPlot
                 {
                     // Find the available size for the legend box
                     var availableLegendWidth = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Width
+                        ? plotAndAxisArea.Width
                         : plotArea.Width;
                     var availableLegendHeight = legend.AllowUseFullExtent
-                        ? PlotAndAxisArea.Height
+                        ? plotAndAxisArea.Height
                         : plotArea.Height;
                     availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
                         availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);

--- a/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
+++ b/Source/OxyPlot/PlotModel/PlotModel.Rendering.cs
@@ -485,9 +485,14 @@ namespace OxyPlot
                     (l.LegendPosition == LegendPosition.LeftTop || l.LegendPosition == LegendPosition.LeftMiddle || l.LegendPosition == LegendPosition.LeftBottom))))
                 {
                     // Find the available size for the legend box
-                    var availableLegendWidth = plotArea.Width;
-                    var availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
-                        plotArea.Height : Math.Min(plotArea.Height, legend.LegendMaxHeight);
+                    var availableLegendWidth = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Width
+                        : plotArea.Width;
+                    var availableLegendHeight = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Height
+                        : plotArea.Height;
+                    availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
+                        availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
 
                     var lsiz = legend.GetLegendSize(rc, new OxySize(availableLegendWidth, availableLegendHeight));
                     legend.LegendSize = lsiz;
@@ -511,9 +516,14 @@ namespace OxyPlot
                     (l.LegendPosition == LegendPosition.RightTop || l.LegendPosition == LegendPosition.RightMiddle || l.LegendPosition == LegendPosition.RightBottom))))
                 {
                     // Find the available size for the legend box
-                    var availableLegendWidth = plotArea.Width;
-                    var availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
-                        plotArea.Height : Math.Min(plotArea.Height, legend.LegendMaxHeight);
+                    var availableLegendWidth = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Width
+                        : plotArea.Width;
+                    var availableLegendHeight = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Height
+                        : plotArea.Height;
+                    availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
+                        availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
 
                     var lsiz = legend.GetLegendSize(rc, new OxySize(availableLegendWidth, availableLegendHeight));
                     legend.LegendSize = lsiz;
@@ -537,9 +547,14 @@ namespace OxyPlot
                     (l.LegendPosition == LegendPosition.TopLeft || l.LegendPosition == LegendPosition.TopCenter || l.LegendPosition == LegendPosition.TopRight))))
                 {
                     // Find the available size for the legend box
-                    var availableLegendWidth = plotArea.Width;
-                    var availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
-                        plotArea.Height : Math.Min(plotArea.Height, legend.LegendMaxHeight);
+                    var availableLegendWidth = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Width
+                        : plotArea.Width;
+                    var availableLegendHeight = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Height
+                        : plotArea.Height;
+                    availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
+                        availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
 
                     var lsiz = legend.GetLegendSize(rc, new OxySize(availableLegendWidth, availableLegendHeight));
                     legend.LegendSize = lsiz;
@@ -563,9 +578,14 @@ namespace OxyPlot
                     (l.LegendPosition == LegendPosition.BottomLeft || l.LegendPosition == LegendPosition.BottomCenter || l.LegendPosition == LegendPosition.BottomRight))))
                 {
                     // Find the available size for the legend box
-                    var availableLegendWidth = plotArea.Width;
-                    var availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
-                        plotArea.Height : Math.Min(plotArea.Height, legend.LegendMaxHeight);
+                    var availableLegendWidth = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Width
+                        : plotArea.Width;
+                    var availableLegendHeight = legend.AllowUseFullExtent
+                        ? PlotAndAxisArea.Height
+                        : plotArea.Height;
+                    availableLegendHeight = double.IsNaN(legend.LegendMaxHeight) ?
+                        availableLegendHeight : Math.Min(availableLegendHeight, legend.LegendMaxHeight);
 
                     var lsiz = legend.GetLegendSize(rc, new OxySize(availableLegendWidth, availableLegendHeight));
                     legend.LegendSize = lsiz;


### PR DESCRIPTION
Fixes #1743 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds the `LegendBase.AllowUseFullExtent` property, which controls whether the legend should be allowed to fill the whole extent of the plot

Would be nice to refactor the legend code in `PlotModel.UpdatePlotArea`, which has lots of duplication for outside legends.

@oxyplot/admins
