### PR TITLE
Add Legend.ShowInvisibleSeries property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Add control over how far from the series the tracker fires (#1736)
 - Add option to check distance for result between data points (#1736)
 - Legend.AllowUseFullExtent property to control whether legends should be able to use the full extent of the plot (#1743)
+- Legend.ShowInvisibleSeries property to control whether invisible series should be shown on the legend (#1730)
 
 ### Changed
 - Updated Series.cd with ExtrapolationLineSeries and removed classes that do not exist anymore

--- a/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/LegendExamples.cs
@@ -445,6 +445,37 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Legend showing invisible series")]
+        public static PlotModel LegendShowingInivisbleSeries()
+        {
+            return CreateModelWithInivisbleSeries(true);
+        }
+
+        [Example("Legend not showing invisible series")]
+        public static PlotModel LegendNotShowingInivisbleSeries()
+        {
+            return CreateModelWithInivisbleSeries(false);
+        }
+
+        private static PlotModel CreateModelWithInivisbleSeries(bool showInvisibleSeries)
+        {
+            var model = CreateModel();
+            var l = new Legend()
+            {
+                ShowInvisibleSeries = showInvisibleSeries,
+            };
+
+            model.Legends.Add(l);
+
+            for (int i = 0; i < model.Series.Count; i += 2)
+            {
+                model.Series[i].IsVisible = false;
+            }
+
+            model.InvalidatePlot(false);
+            return model;
+        }
+
         private static PlotModel CreateModel(int n = 20)
         {
             var model = new PlotModel { Title = "LineSeries" };

--- a/Source/OxyPlot/Legends/Legend.Rendering.cs
+++ b/Source/OxyPlot/Legends/Legend.Rendering.cs
@@ -467,6 +467,12 @@ namespace OxyPlot.Legends
                         continue;
                     }
 
+                    // Skip invisible series if we are not configured to show them
+                    if (!s.IsVisible && !this.ShowInvisibleSeries)
+                    {
+                        continue;
+                    }
+
                     var textSize = rc.MeasureMathText(s.Title, this.LegendFont ?? this.PlotModel.DefaultFont, actualLegendFontSize, this.LegendFontWeight);
                     double itemWidth = this.LegendSymbolLength + this.LegendSymbolMargin + textSize.Width;
                     double itemHeight = textSize.Height;

--- a/Source/OxyPlot/Legends/Legend.cs
+++ b/Source/OxyPlot/Legends/Legend.cs
@@ -60,6 +60,8 @@ namespace OxyPlot.Legends
             this.LegendItemAlignment = HorizontalAlignment.Left;
             this.LegendSymbolPlacement = LegendSymbolPlacement.Left;
 
+            this.ShowInvisibleSeries = true;
+
             this.SeriesInvisibleTextColor = OxyColor.FromAColor(64, this.LegendTextColor);
 
             this.SeriesPosMap = new Dictionary<Series.Series, OxyRect>();
@@ -84,9 +86,12 @@ namespace OxyPlot.Legends
                     {
                         if (kvp.Value.Contains(point))
                         {
-                            kvp.Key.IsVisible = !kvp.Key.IsVisible;
-                            this.PlotModel.InvalidatePlot(false);
-                            break;
+                            if (this.ShowInvisibleSeries)
+                            {
+                                kvp.Key.IsVisible = !kvp.Key.IsVisible;
+                                this.PlotModel.InvalidatePlot(false);
+                                break;
+                            }
                         }
                     }
                 }

--- a/Source/OxyPlot/Legends/LegendBase.cs
+++ b/Source/OxyPlot/Legends/LegendBase.cs
@@ -353,6 +353,13 @@ namespace OxyPlot.Legends
         public bool AllowUseFullExtent { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the legend should show invisible series. The default is <c>true</c>.
+        /// </summary>
+        /// <value>Whether the legends should show invisible series.</value>
+        /// <remarks>Invisible series will appear in the listening, but will be grayed out.</remarks>
+        public bool ShowInvisibleSeries { get; set; }
+
+        /// <summary>
         /// Makes the LegendOrientation property safe.
         /// </summary>
         /// <remarks>If Legend is positioned left or right, force it to vertical orientation</remarks>


### PR DESCRIPTION
Adds the `Legend.ShowInvisibleSeries` property to control whether invisible series should be shown on the legend

Fixes #1730, by providing a way to turn off the new behaviour. The default behaviour is `true`, such that the new behaviour is enabled by default.

When `false`, this property also disables the visibility toggling behaviour per #1723. With the various issues around events and the less-than-ideal situation of processing input upon hit-test, a more proper solution will be needed to #1723 in the future; however, this should suffice for 2.1, so that users can disable the new functionality if they wish.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add `Legend.ShowInvisibleSeries` property
- Don't show invisible series in a legend when `ShowInvisibleSeries` is `false` (fixes #1730)
- Don't toggle series visibility on hit-test when `ShowInvisibleSeries` is `false` (addresses #1723 prior to a re-working of legend interaction)

Does this seem reasonable for the time being?
@oxyplot/admins
