### PR TITLE
Fix LineAnnotation Text Placement on Reversed Axes (#1741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Zero-crossing axis bounds (#1708)
 - Incorrect label placement on BarSeries with non-zero BaseValue (#1726)
+- LineAnnotation Text Placement on Reversed Axes (#1741)
 
 ## [2.1.0-Preview1] - 2020-10-18
 

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -145,6 +145,11 @@ namespace OxyPlot.Annotations
 
             this.CalculateActualMinimumsMaximums();
 
+            if (ActualMinimumX > ActualMaximumX || ActualMinimumY > ActualMaximumY)
+            {
+                return;
+            }
+
             this.screenPoints = this.GetScreenPoints();
 
             const double MinimumSegmentLength = 4;
@@ -170,23 +175,27 @@ namespace OxyPlot.Annotations
 
             this.GetActualTextAlignment(out var ha, out var va);
 
+            var effectiveTextLinePosition = this.IsTransposed()
+                ? (this.YAxis.IsReversed ? 1 - this.TextLinePosition : this.TextLinePosition)
+                : (this.XAxis.IsReversed ? 1 - this.TextLinePosition : this.TextLinePosition);
+
             if (ha == HorizontalAlignment.Center)
             {
                 margin = 0;
             }
             else
             {
-                margin *= this.TextLinePosition < 0.5 ? 1 : -1;
+                margin *= effectiveTextLinePosition < 0.5 ? 1 : -1;
             }
 
-            if (GetPointAtRelativeDistance(clippedPoints, this.TextLinePosition, margin, out var position, out var angle))
+            if (GetPointAtRelativeDistance(clippedPoints, effectiveTextLinePosition, margin, out var position, out var angle))
             {
                 if (angle < -90)
                 {
                     angle += 180;
                 }
 
-                if (angle > 90)
+                if (angle >= 90)
                 {
                     angle -= 180;
                 }

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -145,7 +145,7 @@ namespace OxyPlot.Annotations
 
             this.CalculateActualMinimumsMaximums();
 
-            if (ActualMinimumX > ActualMaximumX || ActualMinimumY > ActualMaximumY)
+            if (this.ActualMinimumX > this.ActualMaximumX || this.ActualMinimumY > this.ActualMaximumY)
             {
                 return;
             }

--- a/Source/OxyPlot/Annotations/TextualAnnotation.cs
+++ b/Source/OxyPlot/Annotations/TextualAnnotation.cs
@@ -74,7 +74,6 @@ namespace OxyPlot.Annotations
         {
             ha = this.TextHorizontalAlignment;
             va = this.TextVerticalAlignment;
-            //this.Orientate(ref ha, ref va);
         }
     }
 }


### PR DESCRIPTION
Fixes #1741 and an old bug where labels are rendered on LineAnnotation that are off the far side of the plot.

### Checklist

- [ ] I have included examples or tests -> existing examples suffice
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Don't reverse line positions on reversed axes
- Don't render `LineAnnotation`s where the max>min in either X or Y dimension

@oxyplot/admins
