### PR TITLE
Fix image opacity in WinForms and Core Drawing (#1766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Zero-crossing axis bounds (#1708)
 - Incorrect label placement on BarSeries with non-zero BaseValue (#1726)
 - LineAnnotation Text Placement on Reversed Axes (#1741)
+- Image opacity in WinForms and Core Drawing (#1766)
 
 ## [2.1.0-Preview1] - 2020-10-18
 

--- a/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.WindowsForms/GraphicsRenderContext.cs
@@ -340,13 +340,13 @@ namespace OxyPlot.WindowsForms
                 if (opacity < 1)
                 {
                     var cm = new ColorMatrix
-                                 {
-                                     Matrix00 = 1f,
-                                     Matrix11 = 1f,
-                                     Matrix22 = 1f,
-                                     Matrix33 = 1f,
-                                     Matrix44 = (float)opacity
-                                 };
+                    {
+                        Matrix00 = 1f,
+                        Matrix11 = 1f,
+                        Matrix22 = 1f,
+                        Matrix33 = (float)opacity,
+                        Matrix44 = 1f
+                    };
 
                     ia = new ImageAttributes();
                     ia.SetColorMatrix(cm, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);


### PR DESCRIPTION
Fixes #1766 .

### Checklist

- [ ] I have included examples or tests -> existing `ImageAnnotation` examples suffice
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix opacity in `DrawImage` by changing the color matrix so that it transforms the alpha channel, not the homogeneity channel.

@oxyplot/admins
