### PR TITLE
Fix Issue 1787 "The specified Visual is not an ancestor of this Visual" exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Incorrect label placement on BarSeries with non-zero BaseValue (#1726)
 - LineAnnotation Text Placement on Reversed Axes (#1741)
 - Image opacity in WinForms and Core Drawing (#1766)
+- Fix specified Visual is not an ancestor of this Visual issue in WPF rendering (#1787) 
 
 ## [2.1.0-Preview1] - 2020-10-18
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Don Syme <donsyme@fastmail.fm>
 DotNetDoctor <dotnetdoctor@outlook.com>
 efontana2
 elliatab
+Elmar Strittmatter
 episage <tilosag@gmail.com>
 eric
 Federico Coppola <fede@silentman.it>

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
@@ -114,7 +114,7 @@ namespace OxyPlot.SkiaSharp.Wpf
             this.bitmap.Unlock();
 
             // get window to screen offset
-            var visualOffset = this.TransformToAncestor(Window.GetWindow(this)).Transform(default);
+            var visualOffset = this.TransformToAncestor(GetAncestorWindowFromVisualTree(this)).Transform(default);
 
             // calculate offset to physical pixels
             var offsetX = ((visualOffset.X * scaleX) % 1) / scaleX;
@@ -157,6 +157,17 @@ namespace OxyPlot.SkiaSharp.Wpf
             {
                 return !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
             }
+        }
+
+        private Window GetAncestorWindowFromVisualTree(DependencyObject startElement)
+        {
+            DependencyObject parent = startElement;
+            while (!(parent is Window))
+            {
+                if (parent == null) { break; }
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+            return parent as Window ?? Window.GetWindow(this);
         }
     }
 }

--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -128,7 +128,7 @@ namespace OxyPlot.Wpf
         {
             var scale = base.UpdateDpi();
             this.RenderContext.DpiScale = scale;
-            this.RenderContext.VisualOffset = this.TransformToAncestor(Window.GetWindow(this)).Transform(default);
+            this.RenderContext.VisualOffset = this.TransformToAncestor(this.GetAncestorWindowFromVisualTree(this)).Transform(default);
             return scale;
         }
 
@@ -142,6 +142,22 @@ namespace OxyPlot.Wpf
             var exporter = new PngExporter() { Width = (int)this.ActualWidth, Height = (int)this.ActualHeight };
             var bitmap = exporter.ExportToBitmap(this.ActualModel);
             Clipboard.SetImage(bitmap);
+        }
+
+
+        /// <summary>
+        /// Returns a reference to the window object that hosts the dependency object in the visual tree.
+        /// </summary>
+        /// <returns> The host window from the visual tree.</returns>
+        private Window GetAncestorWindowFromVisualTree(DependencyObject startElement)
+        {
+            DependencyObject parent = startElement;
+            while (!(parent is Window))
+            {
+                if (parent == null) { break; }
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+            return parent as Window ?? Window.GetWindow(this);
         }
     }
 }


### PR DESCRIPTION

Fixes #1787.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Get the window object that hosts the plot from the visual tree, not using Window.GetWindow()

My changes has a duplication of GetAncestorWindowFromVisualTree() in OxySKElement, but I think this is only a workaround, this should be fixed in the original SkiaSharp SKElement.

@oxyplot/admins
