### PR TITLE
Add OxyPlot.SkiaShap.Wpf PlotView support for simple render transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add option to check distance for result between data points (#1736)
 - Legend.AllowUseFullExtent property to control whether legends should be able to use the full extent of the plot (#1743)
 - Legend.ShowInvisibleSeries property to control whether invisible series should be shown on the legend (#1730)
+- OxyPlot.SkiaSharp.Wpf PlotView support for simple render transforms (#1785)
 
 ### Changed
 - Updated Series.cd with ExtrapolationLineSeries and removed classes that do not exist anymore

--- a/Source/Examples/WPF/ExampleBrowser/MainWindowViewModel.cs
+++ b/Source/Examples/WPF/ExampleBrowser/MainWindowViewModel.cs
@@ -94,7 +94,7 @@ namespace ExampleBrowser
 
         private void CoerceRenderer()
         {
-            ((IPlotModel)this._PlotModel).AttachPlotView(null);
+            ((IPlotModel)this._PlotModel)?.AttachPlotView(null);
             this.RaisePropertyChanged(nameof(this.SkiaModel));
             this.RaisePropertyChanged(nameof(this.CanvasXamlModel));
             this.RaisePropertyChanged(nameof(this.CanvasModel));

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
@@ -22,12 +22,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ------------------------------------------
 
-The modifications are a workaround for https://github.com/mono/SkiaSharp/issues/1236.
-Once the issue is fixed on their side, we should remove this file and replace usages by SKElement from the SkiaSharp.Views.WPF nuget package.
+Mmodifications include
+ - A workaround for https://github.com/mono/SkiaSharp/issues/1236. Once the issue is fixed on their side, we should remove this file and replace usages by SKElement from the SkiaSharp.Views.WPF nuget package.
+ - Simple RenderTransform detection to allow for non-unity scaling per https://github.com/oxyplot/oxyplot/issues/1785.
 
 */
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace OxyPlot.SkiaSharp.Wpf
 {
@@ -39,27 +38,53 @@ namespace OxyPlot.SkiaSharp.Wpf
     using System.Windows.Media;
     using System.Windows.Media.Imaging;
 
+    /// <summary>
+    /// Provides a surface on which to render with the SkiaSharp graphics APIs.
+    /// </summary>
     public class OxySKElement : FrameworkElement
     {
+        /// <summary>
+        /// A value indicating whether the element is being presented in design mode. 
+        /// </summary>
         private readonly bool designMode;
+
+        /// <summary>
+        /// The bitmap to which to render.
+        /// </summary>
         private WriteableBitmap bitmap;
+
+        /// <summary>
+        /// A value indicating whether to ignore pixel scaling when determining the render buffer bitmap dimensions.
+        /// </summary>
         private bool ignorePixelScaling;
 
+        /// <summary>
+        /// Initialises an instance of the <see cref="OxySKElement"/> class.
+        /// </summary>
         public OxySKElement()
         {
             this.designMode = DesignerProperties.GetIsInDesignMode(this);
             RenderOptions.SetBitmapScalingMode(this, BitmapScalingMode.NearestNeighbor);
         }
 
+        /// <summary>
+        /// Invoked when the surface is painting.
+        /// </summary>
         [Category("Appearance")]
         public event EventHandler<SKPaintSurfaceEventArgs> PaintSurface;
 
+        /// <summary>
+        /// Gets the size of the render buffer bitmap, or <c>SKSize.Empty</c> if there is no current render buffer bitmap.
+        /// </summary>
         [Bindable(false)]
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SKSize CanvasSize => this.bitmap == null ? SKSize.Empty : new SKSize(this.bitmap.PixelWidth, this.bitmap.PixelHeight);
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore pixel scaling when determining the render buffer bitmap dimensions.
+        /// </summary>
         public bool IgnorePixelScaling
         {
             get { return this.ignorePixelScaling; }
@@ -70,12 +95,17 @@ namespace OxyPlot.SkiaSharp.Wpf
             }
         }
 
+        /// <summary>
+        /// Raises the <see cref="PaintSurface"/> event with the given <see cref="SKPaintSurfaceEventArgs"/>.
+        /// </summary>
+        /// <param name="e">The skia surface and associated information ready for drawing.</param>
         protected virtual void OnPaintSurface(SKPaintSurfaceEventArgs e)
         {
             // invoke the event
             PaintSurface?.Invoke(this, e);
         }
 
+        /// <inheritdoc/>
         protected override void OnRender(DrawingContext drawingContext)
         {
             if (this.designMode)
@@ -89,17 +119,23 @@ namespace OxyPlot.SkiaSharp.Wpf
             }
 
             var size = this.CreateSize(out var scaleX, out var scaleY);
+            var renderScale = this.GetRenderScale();
+
+            // scale bitmap according to the renderScale
+            var bitmapWidth = (int)(size.Width * renderScale);
+            var bitmapHeight = (int)(size.Height * renderScale);
+
             if (size.Width <= 0 || size.Height <= 0)
             {
                 return;
             }
 
-            var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+            var info = new SKImageInfo(bitmapWidth, bitmapHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
 
             // reset the bitmap if the size has changed
             if (this.bitmap == null || info.Width != this.bitmap.PixelWidth || info.Height != this.bitmap.PixelHeight)
             {
-                this.bitmap = new WriteableBitmap(size.Width, size.Height, 96 * scaleX, 96 * scaleY, PixelFormats.Pbgra32, null);
+                this.bitmap = new WriteableBitmap(bitmapWidth, bitmapHeight, 96 * scaleX, 96 * scaleY, PixelFormats.Pbgra32, null);
             }
 
             // draw on the bitmap
@@ -110,7 +146,7 @@ namespace OxyPlot.SkiaSharp.Wpf
             }
 
             // draw the bitmap to the screen
-            this.bitmap.AddDirtyRect(new Int32Rect(0, 0, size.Width, size.Height));
+            this.bitmap.AddDirtyRect(new Int32Rect(0, 0, bitmapWidth, bitmapHeight));
             this.bitmap.Unlock();
 
             // get window to screen offset
@@ -120,9 +156,11 @@ namespace OxyPlot.SkiaSharp.Wpf
             var offsetX = ((visualOffset.X * scaleX) % 1) / scaleX;
             var offsetY = ((visualOffset.Y * scaleY) % 1) / scaleY;
 
-            drawingContext.DrawImage(this.bitmap, new Rect(-offsetX, -offsetY, this.bitmap.Width, this.bitmap.Height));
+            // draw, scaling back down from the (rounded) bitmap dimensions
+            drawingContext.DrawImage(this.bitmap, new Rect(-offsetX, -offsetY, bitmapWidth / renderScale, bitmapHeight / renderScale));
         }
 
+        /// <inheritdoc/>
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {
             base.OnRenderSizeChanged(sizeInfo);
@@ -130,6 +168,12 @@ namespace OxyPlot.SkiaSharp.Wpf
             this.InvalidateVisual();
         }
 
+        /// <summary>
+        /// Determines the size of the render buffer bitmap, and the scale at which to draw.
+        /// </summary>
+        /// <param name="scaleX">The horizontal scale.</param>
+        /// <param name="scaleY">The vertical scale.</param>
+        /// <returns>The size in pixels of the bitmap.</returns>
         private SKSizeI CreateSize(out double scaleX, out double scaleY)
         {
             scaleX = 1.0;
@@ -159,6 +203,10 @@ namespace OxyPlot.SkiaSharp.Wpf
             }
         }
 
+        /// <summary>
+        /// Returns a reference to the window object that hosts the dependency object in the visual tree.
+        /// </summary>
+        /// <returns> The host window from the visual tree.</returns>
         private Window GetAncestorWindowFromVisualTree(DependencyObject startElement)
         {
             DependencyObject parent = startElement;
@@ -168,6 +216,26 @@ namespace OxyPlot.SkiaSharp.Wpf
                 parent = VisualTreeHelper.GetParent(parent);
             }
             return parent as Window ?? Window.GetWindow(this);
+        }
+
+        /// <summary>
+        /// Determines the scaling transform applied to the control.
+        /// </summary>
+        /// <returns>The scale factor.</returns>
+        public virtual double GetRenderScale()
+        {
+            var transform = VisualTreeHelper.GetTransform(this)?.Value ?? Matrix.Identity;
+            DependencyObject control = VisualTreeHelper.GetParent(this);
+            while (control != null)
+            {
+                if (control is Visual v && VisualTreeHelper.GetTransform(v) is Transform vt)
+                {
+                    transform *= vt.Value;
+                }
+                control = VisualTreeHelper.GetParent(control);
+            }
+
+            return Math.Max(transform.M11, transform.M22);
         }
     }
 }

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
@@ -122,20 +122,20 @@ namespace OxyPlot.SkiaSharp.Wpf
             var renderScale = this.GetRenderScale();
 
             // scale bitmap according to the renderScale
-            var bitmapWidth = (int)(size.Width * renderScale);
-            var bitmapHeight = (int)(size.Height * renderScale);
+            var bitmapPixelWidth = (int)(size.Width * renderScale);
+            var bitmapPixelHeight = (int)(size.Height * renderScale);
 
             if (size.Width <= 0 || size.Height <= 0)
             {
                 return;
             }
 
-            var info = new SKImageInfo(bitmapWidth, bitmapHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+            var info = new SKImageInfo(bitmapPixelWidth, bitmapPixelHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
 
             // reset the bitmap if the size has changed
             if (this.bitmap == null || info.Width != this.bitmap.PixelWidth || info.Height != this.bitmap.PixelHeight)
             {
-                this.bitmap = new WriteableBitmap(bitmapWidth, bitmapHeight, 96 * scaleX, 96 * scaleY, PixelFormats.Pbgra32, null);
+                this.bitmap = new WriteableBitmap(bitmapPixelWidth, bitmapPixelHeight, 96 * scaleX, 96 * scaleY, PixelFormats.Pbgra32, null);
             }
 
             // draw on the bitmap
@@ -146,7 +146,7 @@ namespace OxyPlot.SkiaSharp.Wpf
             }
 
             // draw the bitmap to the screen
-            this.bitmap.AddDirtyRect(new Int32Rect(0, 0, bitmapWidth, bitmapHeight));
+            this.bitmap.AddDirtyRect(new Int32Rect(0, 0, bitmapPixelWidth, bitmapPixelHeight));
             this.bitmap.Unlock();
 
             // get window to screen offset

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
@@ -157,7 +157,7 @@ namespace OxyPlot.SkiaSharp.Wpf
             var offsetY = ((visualOffset.Y * scaleY) % 1) / scaleY;
 
             // draw, scaling back down from the (rounded) bitmap dimensions
-            drawingContext.DrawImage(this.bitmap, new Rect(-offsetX, -offsetY, bitmapWidth / renderScale, bitmapHeight / renderScale));
+            drawingContext.DrawImage(this.bitmap, new Rect(-offsetX, -offsetY, this.bitmap.Width / renderScale, this.bitmap.Height / renderScale));
         }
 
         /// <inheritdoc/>

--- a/Source/OxyPlot.SkiaSharp.Wpf/PlotView.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/PlotView.cs
@@ -23,6 +23,11 @@ namespace OxyPlot.SkiaSharp.Wpf
         /// </summary>
         private SkiaRenderContext SkiaRenderContext => (SkiaRenderContext)this.renderContext;
 
+        /// <summary>
+        /// Gets the OxySKElement.
+        /// </summary>
+        private OxySKElement OxySKElement => (OxySKElement)this.plotPresenter;
+
         /// <inheritdoc/>
         protected override void ClearBackground()
         {
@@ -59,7 +64,7 @@ namespace OxyPlot.SkiaSharp.Wpf
         protected override double UpdateDpi()
         {
             var scale = base.UpdateDpi();
-            this.SkiaRenderContext.DpiScale = (float)scale;
+            this.SkiaRenderContext.DpiScale = (float)(scale * OxySKElement.GetRenderScale());
             return scale;
         }
 

--- a/Source/OxyPlot.SkiaSharp.Wpf/PlotView.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/PlotView.cs
@@ -63,9 +63,13 @@ namespace OxyPlot.SkiaSharp.Wpf
         /// <inheritdoc/>
         protected override double UpdateDpi()
         {
-            var scale = base.UpdateDpi();
-            this.SkiaRenderContext.DpiScale = (float)(scale * OxySKElement.GetRenderScale());
-            return scale;
+            var dpiScale = base.UpdateDpi();
+            var renderScale = this.OxySKElement.GetRenderScale();
+            var skiaScale = (float)(dpiScale * renderScale);
+
+            this.SkiaRenderContext.DpiScale = skiaScale;
+
+            return dpiScale;
         }
 
         /// <summary>


### PR DESCRIPTION
A jab at addressing #1785.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds a `GetRenderScale` method to `OxySKElement` which tried to detect the render transform on the control and produce a single value scaling
- The value is used to change the render buffer width/height and effective DPI
- Adds inline doc for OxySKElement

It seems to work in the simplest case (a uniform scaling), but I've not thoroughly checked the implementation of `GetRenderScale` (are the matmuls backwards?) and we probably need an example to go with it. Also need to see what happens when you rotate one of these, to check it doesn't do something completely ridiculous, though I don't think that's a scenario we should be trying to support.

The `GetRenderScale` method is intentionally virtual so that it can be overridden (e.g. so that a user could change it if it's assumptions are not appropriate for their use-case). It must be public so that `PlotView` can determine the change in effective DPI. Importantly, no attempt is made to support non-uniform scaling.

@oxyplot/admins
