### PR TITLE
Fix NullReference in SkiaSharp WPF renderer if UIElement has no Prese…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
 ### Fixed
 - WPF - OxyPlot doesn't render inside a Popup (#1796)
+- NullReference in SkiaSharp WPF renderer if UIElement has no PresentationSource  (#1798)
 
 ## [2.1.0] - 2021-10-02
 

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxySKElement.cs
@@ -150,7 +150,8 @@ namespace OxyPlot.SkiaSharp.Wpf
             this.bitmap.Unlock();
 
             // get window to screen offset
-            var visualOffset = this.TransformToAncestor(GetAncestorWindowFromVisualTree(this)).Transform(default);
+            var ancestor = GetAncestorVisualFromVisualTree(this);
+            var visualOffset = ancestor != null ? this.TransformToAncestor(ancestor).Transform(default) : default;
 
             // calculate offset to physical pixels
             var offsetX = ((visualOffset.X * scaleX) % 1) / scaleX;
@@ -192,9 +193,13 @@ namespace OxyPlot.SkiaSharp.Wpf
                 return new SKSizeI((int)w, (int)h);
             }
 
-            var m = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice;
-            scaleX = m.M11;
-            scaleY = m.M22;
+            var compositionTarget = PresentationSource.FromVisual(this)?.CompositionTarget;
+            if (compositionTarget != null)
+            {
+                var m = compositionTarget.TransformToDevice;
+                scaleX = m.M11;
+                scaleY = m.M22;
+            }
             return new SKSizeI((int)(w * scaleX), (int)(h * scaleY));
 
             static bool IsPositive(double value)
@@ -204,18 +209,21 @@ namespace OxyPlot.SkiaSharp.Wpf
         }
 
         /// <summary>
-        /// Returns a reference to the window object that hosts the dependency object in the visual tree.
+        /// Returns a reference to the visual object that hosts the dependency object in the visual tree.
         /// </summary>
         /// <returns> The host window from the visual tree.</returns>
-        private Window GetAncestorWindowFromVisualTree(DependencyObject startElement)
+        private Visual GetAncestorVisualFromVisualTree(DependencyObject startElement)
         {
-            DependencyObject parent = startElement;
-            while (!(parent is Window))
+
+            DependencyObject child = startElement;
+            DependencyObject parent = VisualTreeHelper.GetParent(child);
+            while (parent != null)
             {
-                if (parent == null) { break; }
-                parent = VisualTreeHelper.GetParent(parent);
+                child = parent;
+                parent = VisualTreeHelper.GetParent(child);
             }
-            return parent as Window ?? Window.GetWindow(this);
+
+            return child is Visual visualChild ? visualChild : Window.GetWindow(this);
         }
 
         /// <summary>

--- a/Source/OxyPlot.SkiaSharp.Wpf/PlotView.cs
+++ b/Source/OxyPlot.SkiaSharp.Wpf/PlotView.cs
@@ -79,6 +79,10 @@ namespace OxyPlot.SkiaSharp.Wpf
         /// <param name="e">The surface paint event args.</param>
         private void SkElement_PaintSurface(object sender, SKPaintSurfaceEventArgs e)
         {
+            if (this.plotPresenter == null || this.renderContext == null)
+            {
+                return;
+            }
             this.SkiaRenderContext.SkCanvas = e.Surface.Canvas;
             base.RenderOverride();
             this.SkiaRenderContext.SkCanvas = null;

--- a/Source/OxyPlot.Wpf.Shared/PlotViewBase.cs
+++ b/Source/OxyPlot.Wpf.Shared/PlotViewBase.cs
@@ -373,10 +373,11 @@ namespace OxyPlot.Wpf
         /// </summary>
         protected void Render()
         {
-            if (this.plotPresenter == null || this.renderContext == null || !(this.isInVisualTree = this.IsInVisualTree()))
+            if (this.plotPresenter == null || this.renderContext == null)
             {
                 return;
             }
+            this.isInVisualTree = this.IsInVisualTree();
 
             this.RenderOverride();
         }

--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -127,8 +127,8 @@ namespace OxyPlot.Wpf
         protected override double UpdateDpi()
         {
             var scale = base.UpdateDpi();
-            this.RenderContext.DpiScale = scale;
-            this.RenderContext.VisualOffset = this.TransformToAncestor(this.GetAncestorVisualFromVisualTree(this)).Transform(default);
+            var ancestor = this.GetAncestorVisualFromVisualTree(this);
+            this.RenderContext.VisualOffset = ancestor != null ? this.TransformToAncestor(ancestor).Transform(default) : default;
             return scale;
         }
 


### PR DESCRIPTION
…ntationSource  (#1798)

Fixes #1798 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Return/use the default values if the PresentationSource or the ancestor visual is null:


@oxyplot/admins
