### PR TITLE
Use renamed DrawReducedLine method. (Renamed in d02fe7d.)

### DIFF
--- a/Source/Examples/PerformanceTest/EmptyRenderContext.cs
+++ b/Source/Examples/PerformanceTest/EmptyRenderContext.cs
@@ -42,6 +42,19 @@ namespace PerformanceTest
         }
 
         /// <inheritdoc/>
+        public void PushClip(OxyRect clippingRectangle)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void PopClip()
+        {
+        }
+
+        /// <inheritdoc/>
+        public int ClipCount => 0;
+
+        /// <inheritdoc/>
         public void DrawLine(IList<ScreenPoint> points, OxyColor stroke, double thickness, EdgeRenderingMode edgeRenderingMode, double[] dashArray = null, LineJoin lineJoin = LineJoin.Miter)
         {
         }
@@ -80,17 +93,6 @@ namespace PerformanceTest
         public OxySize MeasureText(string text, string fontFamily = null, double fontSize = 10, double fontWeight = 500)
         {
             return OxySize.Empty;
-        }
-
-        /// <inheritdoc/>
-        public void ResetClip()
-        {
-        }
-
-        /// <inheritdoc/>
-        public bool SetClip(OxyRect clippingRectangle)
-        {
-            return true;
         }
 
         /// <inheritdoc/>

--- a/Source/Examples/PerformanceTest/Program.cs
+++ b/Source/Examples/PerformanceTest/Program.cs
@@ -44,9 +44,9 @@ namespace PerformanceTest
                 Console.WriteLine();
             }
 
-            Console.WriteLine("DrawClippedLine test:");
-            var t0 = TestDrawClippedLine(10000, 1000, false);
-            var t1 = TestDrawClippedLine(10000, 1000, true);
+            Console.WriteLine("DrawReducedLine test:");
+            var t0 = TestDrawReducedLine(10000, 1000, false);
+            var t1 = TestDrawReducedLine(10000, 1000, true);
             Console.WriteLine("{0:P1}", (t0 - t1) / t0);
             Console.ReadKey();
         }
@@ -110,13 +110,13 @@ namespace PerformanceTest
         }
 
         /// <summary>
-        /// Tests the <see cref="RenderingExtensions.DrawClippedLine" /> method.
+        /// Tests the <see cref="RenderingExtensions.DrawReducedLine" /> method.
         /// </summary>
         /// <param name="n">The number of points.</param>
         /// <param name="m">The number of repetitions.</param>
         /// <param name="useOutputBuffer"><c>true</c> to use an output buffer.</param>
         /// <returns>The elapsed time in milliseconds.</returns>
-        public static double TestDrawClippedLine(int n, int m, bool useOutputBuffer)
+        public static double TestDrawReducedLine(int n, int m, bool useOutputBuffer)
         {
             var points = new ScreenPoint[n];
             for (int i = 0; i < n; i++)
@@ -124,14 +124,12 @@ namespace PerformanceTest
                 points[i] = new ScreenPoint((double)i / n, Math.Sin(40d * i / n));
             }
 
-            var clippingRectangle = new OxyRect(0.3, -0.5, 0.5, 1);
             var rc = new EmptyRenderContext();
             var outputBuffer = useOutputBuffer ? new List<ScreenPoint>(n) : null;
             var stopwatch = Stopwatch.StartNew();
             for (int i = 0; i < m; i++)
             {
-                rc.DrawClippedLine(
-                    clippingRectangle,
+                rc.DrawReducedLine(
                     points,
                     1,
                     OxyColors.Black,


### PR DESCRIPTION
Fixes build errors for `OxyPlot.WPF.sln`.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins