### PR TITLE
Axis should always honor absolute minimum /maximum as well as minimum/maximum range properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - SkiaSharp.WPF - OxyPlot doesn't render inside an ElementHost (#1800)
 - NullReference in SkiaSharp WPF renderer if UIElement has no PresentationSource  (#1798)
 - WPF DPI Regression (#1799)
+- Axes not always honoring AbsoluteMinimum/AbsoluteMaximum and/or MinimumRange/MaximumRange properties (#1812)
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -90,6 +90,7 @@ Memphisch <memphis@machzwo.de>
 Mendel Monteiro-Beckerman
 Menno Deij - van Rijswijk <m.deij@marin.nl>
 methdotnet
+Michael Hieke <mghie@gmx.net>
 Mikant <a.mikant@gmail.com>
 mirolev <miroslav.levicky@gmail.com>
 Mitch-Connor <acm@htri.net>

--- a/Source/OxyPlot.Tests/Axes/AxisTests.cs
+++ b/Source/OxyPlot.Tests/Axes/AxisTests.cs
@@ -518,6 +518,58 @@ namespace OxyPlot.Tests
         }
 
         /// <summary>
+        /// Tests the initial axis range, if absolute and minimum range are set and data is partially out-of-range
+        /// </summary>
+        [Test]
+        public void Axis_MinimumRange_AbsoluteRange_DataOutOfRange()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Bottom,
+                AbsoluteMinimum = -100,
+                AbsoluteMaximum = 0,
+                MinimumRange = 100,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(-50.0, 0));
+            series.Points.Add(new DataPoint(100.0, 0));
+
+            plot.Series.Add(series);
+
+            ((IPlotModel)plot).Update(true);
+
+            Assert.AreEqual(-100, plot.Axes[0].ActualMinimum, 1e-5, "minimum");
+            Assert.AreEqual(0.0, plot.Axes[0].ActualMaximum, 1e-5, "maximum");
+        }
+
+        /// <summary>
+        /// Tests the initial axis range, if absolute and minimum range are set but no data is available
+        /// </summary>
+        [Test]
+        public void Axis_MinimumRange_AbsoluteRange_NoData()
+        {
+            var plot = new PlotModel();
+            var yaxis = new LinearAxis()
+            {
+                Position = AxisPosition.Bottom,
+                AbsoluteMinimum = -100,
+                AbsoluteMaximum = 0,
+                MinimumRange = 100,
+            };
+
+            plot.Axes.Add(yaxis);
+
+            ((IPlotModel)plot).Update(true);
+
+            Assert.AreEqual(-100, plot.Axes[0].ActualMinimum, 1e-5, "minimum");
+            Assert.AreEqual(0.0, plot.Axes[0].ActualMaximum, 1e-5, "maximum");
+        }
+
+        /// <summary>
         /// Tests the alignment of the series, if minimum range is set
         /// </summary>
         [Test]

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1571,6 +1571,20 @@ namespace OxyPlot.Axes
         /// </summary>
         protected virtual void CoerceActualMaxMin()
         {
+            // Check consistency of properties
+            if (this.AbsoluteMaximum <= this.AbsoluteMinimum)
+            {
+                throw new InvalidOperationException("AbsoluteMaximum must be larger than AbsoluteMinimum.");
+            }
+            if (this.AbsoluteMaximum - this.AbsoluteMinimum < this.MinimumRange)
+            {
+                throw new InvalidOperationException("MinimumRange must not be larger than AbsoluteMaximum-AbsoluteMinimum.");
+            }
+            if (this.MaximumRange < this.MinimumRange)
+            {
+                throw new InvalidOperationException("MinimumRange must not be larger than MaximumRange.");
+            }
+
             // Coerce actual minimum
             if (double.IsNaN(this.ActualMinimum) || double.IsInfinity(this.ActualMinimum))
             {
@@ -1583,13 +1597,21 @@ namespace OxyPlot.Axes
                 this.ActualMaximum = 100;
             }
 
-            if (this.AbsoluteMaximum - this.AbsoluteMinimum < this.MinimumRange)
+            if (this.AbsoluteMinimum > double.MinValue && this.AbsoluteMinimum < double.MaxValue)
             {
-                throw new InvalidOperationException("MinimumRange must not be larger than AbsoluteMaximum-AbsoluteMinimum.");
+                this.ActualMinimum = Math.Max(this.ActualMinimum, this.AbsoluteMinimum);
+                if (this.MaximumRange < double.MaxValue)
+                {
+                    this.ActualMaximum = Math.Min(this.ActualMaximum, this.AbsoluteMinimum + this.MaximumRange);
+                }
             }
-            if (this.MaximumRange < this.MinimumRange)
+            if (this.AbsoluteMaximum > double.MinValue && this.AbsoluteMaximum < double.MaxValue)
             {
-                throw new InvalidOperationException("MinimumRange must not be larger than MaximumRange.");
+                this.ActualMaximum = Math.Min(this.ActualMaximum, this.AbsoluteMaximum);
+                if (this.MaximumRange < double.MaxValue)
+                {
+                    this.ActualMinimum = Math.Max(this.ActualMinimum, this.AbsoluteMaximum - this.MaximumRange);
+                }
             }
 
             // Coerce the minimum range
@@ -1671,34 +1693,9 @@ namespace OxyPlot.Axes
             }
 
             // Coerce the absolute maximum/minimum
-            if (this.AbsoluteMaximum <= this.AbsoluteMinimum)
-            {
-                throw new InvalidOperationException("AbsoluteMaximum should be larger than AbsoluteMinimum.");
-            }
-
             if (this.ActualMaximum <= this.ActualMinimum)
             {
                 this.ActualMaximum = this.ActualMinimum + 100;
-            }
-
-            if (this.ActualMinimum < this.AbsoluteMinimum)
-            {
-                this.ActualMinimum = this.AbsoluteMinimum;
-            }
-
-            if (this.ActualMinimum > this.AbsoluteMaximum)
-            {
-                this.ActualMinimum = this.AbsoluteMaximum;
-            }
-
-            if (this.ActualMaximum < this.AbsoluteMinimum)
-            {
-                this.ActualMaximum = this.AbsoluteMinimum;
-            }
-
-            if (this.ActualMaximum > this.AbsoluteMaximum)
-            {
-                this.ActualMaximum = this.AbsoluteMaximum;
             }
         }
 

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1585,7 +1585,11 @@ namespace OxyPlot.Axes
 
             if (this.AbsoluteMaximum - this.AbsoluteMinimum < this.MinimumRange)
             {
-                throw new InvalidOperationException("MinimumRange should be larger than AbsoluteMaximum-AbsoluteMinimum.");
+                throw new InvalidOperationException("MinimumRange must not be larger than AbsoluteMaximum-AbsoluteMinimum.");
+            }
+            if (this.MaximumRange < this.MinimumRange)
+            {
+                throw new InvalidOperationException("MinimumRange must not be larger than MaximumRange.");
             }
 
             // Coerce the minimum range


### PR DESCRIPTION
Fixes #1812.

### Checklist

- [*] I have included examples or tests
- [*] I have updated the change log
- [*] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- check of property consistency moved to beginning of `Axis.CoerceActualMaxMin()`
- calculation of `ActualMaximum` and `ActualMinimum` improved to always honor absolute minimum and maximum as well as minimum and maximum range
- tests added

@oxyplot/admins
