### PR TITLE
Update ScatterSeries{T}.cs

### DIFF
--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -246,7 +246,7 @@ namespace OxyPlot.Series
                 return null;
             }
 
-            var actualPoints = this.ActualPointsList;
+            var actualPoints = new List<T>(this.ActualPointsList);
             if (actualPoints == null || actualPoints.Count == 0)
             {
                 return null;
@@ -321,7 +321,7 @@ namespace OxyPlot.Series
         /// <inheritdoc/>
         public override void Render(IRenderContext rc)
         {
-            var actualPoints = this.ActualPointsList;
+            var actualPoints = new List<T>(this.ActualPointsList);
 
             if (actualPoints == null || actualPoints.Count == 0)
             {
@@ -534,7 +534,7 @@ namespace OxyPlot.Series
         /// <param name="clippingRect">The clipping rectangle.</param>
         protected void RenderPointLabels(IRenderContext rc, OxyRect clippingRect)
         {
-            var actualPoints = this.ActualPointsList;
+            var actualPoints = new List<T>(this.ActualPointsList);
             if (actualPoints == null || actualPoints.Count == 0)
             {
                 return;


### PR DESCRIPTION
if you do a live update of the chart, then you get an error "Collection was modified; enumeration operation may not execute", because the collection changes during the iteration

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-

@oxyplot/admins
