### PR TITLE
Fix zooming of Logarithmic axes (#1825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - WPF - OxyPlot doesn't render inside a Popup (#1796)
+- Odd behavior of zooming of Logarithmic axis in Cartesian plot (#1825)
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -106,6 +106,7 @@ Rik Borger <isolocis@gmail.com>
 ryang <decatf@gmail.com>
 Sarah Müller <sy-mueller@gmx-topmail.de>
 Senen Fernandez <senenf@gmail.com>
+Sergey Miryanov <sergey.miryanov@gmail.com>
 Scott W Harden <swharden@gmail.com>
 Shankar Mathiah Nanjundan <shankar.ooty@hotmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>

--- a/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/AxisExamples.cs
@@ -414,6 +414,35 @@ namespace ExampleLibrary
             return plotModel1;
         }
 
+        [Example("Logarithmic axes Cartesian Plot")]
+        public static PlotModel CartesianPlotLogarithmicAxes()
+        {
+            var plotModel1 = new PlotModel
+            {
+                PlotType = PlotType.Cartesian,
+            };
+            plotModel1.Axes.Add(new LogarithmicAxis
+            {
+                Maximum = 1000000,
+                Minimum = 1,
+                Title = "Log axis",
+                UseSuperExponentialFormat = true,
+                MajorGridlineStyle = LineStyle.Solid,
+                IsPanEnabled = true,
+            });
+            plotModel1.Axes.Add(new LogarithmicAxis
+            {
+                Maximum = 10000,
+                Minimum = 0.001,
+                Position = AxisPosition.Bottom,
+                Title = "Log axis",
+                UseSuperExponentialFormat = true,
+                MajorGridlineStyle = LineStyle.Solid,
+                IsPanEnabled = true,
+            });
+            return plotModel1;
+        }
+
         [Example("Big numbers")]
         public static PlotModel BigNumbers()
         {

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1163,7 +1163,8 @@ namespace OxyPlot.Axes
             double sx0 = this.Transform(this.ActualMinimum);
 
             double sgn = Math.Sign(this.scale);
-            double mid = (this.ActualMaximum + this.ActualMinimum) / 2;
+            double mid = (this.PreTransform(this.ActualMaximum) + this.PreTransform(this.ActualMinimum)) / 2;
+
 
             double dx = (this.offset - mid) * this.scale;
             var newOffset = (dx / (sgn * newScale)) + mid;


### PR DESCRIPTION
Also add example of Cartesian plot with Logarithmic axis, to demonstrate odd behavior of zooming of Logarithmic axes for cartesian plots

Fixes #1825 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fixes one line in Axis.cs/Zoom


@oxyplot/admins
