### PR TITLE
Add property to customize tracker line thickness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+### Added
+- Add LineThickness property to TrackerControl (#1831)
+
 ### Fixed
 - WPF - OxyPlot doesn't render inside a Popup (#1796)
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -81,6 +81,7 @@ Linquize
 lsowen
 Luka B
 Nils Haferkemper <nils@haferkemper.de>
+Matt Ickstadt <mattico8@gmail.com>
 Matt Williams
 Matthew Leibowitz <mattleibow@live.com>
 Memphisch <memphis@machzwo.de>

--- a/Source/OxyPlot.Wpf.Shared/Themes/Generic.xaml
+++ b/Source/OxyPlot.Wpf.Shared/Themes/Generic.xaml
@@ -12,6 +12,7 @@
         <Setter Property="LineStroke" Value="#80000000" />
         <Setter Property="HorizontalLineVisibility" Value="Visible" />
         <Setter Property="VerticalLineVisibility" Value="Visible" />
+        <Setter Property="LineThickness" Value="1" />
         <Setter Property="Distance" Value="7" />
         <Setter Property="CornerRadius" Value="0" />
         <Setter Property="ShowPointer" Value="true" />
@@ -24,10 +25,10 @@
                     <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Line x:Name="PART_HorizontalLine" Visibility="{TemplateBinding HorizontalLineVisibility}"
                               Stroke="{TemplateBinding LineStroke}" RenderOptions.EdgeMode="Aliased"
-                              StrokeDashArray="{TemplateBinding LineDashArray}" />
+                              StrokeDashArray="{TemplateBinding LineDashArray}" StrokeThickness="{TemplateBinding LineThickness}" />
                         <Line x:Name="PART_VerticalLine" Visibility="{TemplateBinding VerticalLineVisibility}"
                               Stroke="{TemplateBinding LineStroke}" RenderOptions.EdgeMode="Aliased"
-                              StrokeDashArray="{TemplateBinding LineDashArray}" />
+                              StrokeDashArray="{TemplateBinding LineDashArray}" StrokeThickness="{TemplateBinding LineThickness}" />
                         <Grid x:Name="PART_ContentContainer">
                             <Path x:Name="PART_Path" Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}"
                                   StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessConverter}}"

--- a/Source/OxyPlot.Wpf.Shared/Tracker/TrackerControl.cs
+++ b/Source/OxyPlot.Wpf.Shared/Tracker/TrackerControl.cs
@@ -41,6 +41,12 @@ namespace OxyPlot.Wpf
                 new PropertyMetadata(Visibility.Visible));
 
         /// <summary>
+        /// Identifies the <see cref="LineThickness"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty LineThicknessProperty = DependencyProperty.Register(
+            nameof(LineThickness), typeof(double), typeof(TrackerControl), new PropertyMetadata(1.0));
+
+        /// <summary>
         /// Identifies the <see cref="LineStroke"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty LineStrokeProperty = DependencyProperty.Register(
@@ -189,6 +195,15 @@ namespace OxyPlot.Wpf
         {
             get => (Visibility)this.GetValue(VerticalLineVisibilityProperty);
             set => this.SetValue(VerticalLineVisibilityProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets LineThickness.
+        /// </summary>
+        public double LineThickness
+        {
+            get => (double)this.GetValue(LineThicknessProperty);
+            set => this.SetValue(LineThicknessProperty, value);
         }
 
         /// <summary>


### PR DESCRIPTION
### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Added a property to customize the tracker line thickness.

Maybe we could have separate thickness properties for horizontal and vertical lines?
Maybe we could name it something else to specify that "line" refers to the lines projected on the X and Y axis from the tracker's position. I decided against this since e.g. HorizontalLineVisibility already just calls it "line".
Don't think this needs an example but I could add one.

@oxyplot/admins
