### PR TITLE
Tidy up, modernise code and improve render performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-
+- Core - Update to net452, modernise code and improve rendering performance of financial series (#1836)
 ### Removed
 
 ### Fixed

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Auriou
 Bartłomiej Szypelow <bszypelow@users.noreply.github.com>
 benjaminrupp
 Benoit Blanchon <>
+BobLd
 br
 brantheman
 Brannon King

--- a/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net452</TargetFrameworks>
     <PackageId>OxyPlot.ExampleLibrary</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Example models for OxyPlot.</Description>

--- a/Source/Examples/ExampleLibrary/Series/LinearBarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/LinearBarSeriesExamples.cs
@@ -68,7 +68,7 @@
             var linearBarSeries = new LinearBarSeries();
             var r = new Random(31);
             var y = r.Next(10, 30);
-            for (int x = 0; x <= 50; x++)
+            for (int x = 0; x <= 500; x++)
             {
                 linearBarSeries.Points.Add(new DataPoint(x, y));
                 y += r.Next(-5, 5);
@@ -84,7 +84,7 @@
         {
             var linearBarSeries = new LinearBarSeries();
             var r = new Random(31);
-            for (int x = 0; x <= 50; x++)
+            for (int x = 0; x <= 500; x++)
             {
                 var y = -200 + r.Next(1000);
                 linearBarSeries.Points.Add(new DataPoint(x, y));

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>OxyPlot is a plotting library for .NET. This package targets WPF applications and uses the SkiaSharp renderer.</Description>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>8</LangVersion>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.3;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright (c) 2020 OxyPlot contributors</Copyright>
     <Authors>OxyPlot contributors</Authors>

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
-        <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <Description>OxyPlot is a plotting library for .NET. This package targets Windows Forms applications.</Description>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>

--- a/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
+++ b/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>8</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
+++ b/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net45;net40;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>OxyPlot.Wpf.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Source/OxyPlot.Wpf/XpsExporter.cs
+++ b/Source/OxyPlot.Wpf/XpsExporter.cs
@@ -9,7 +9,7 @@
 
 namespace OxyPlot.Wpf
 {
-#if !NET40
+#if !NETFRAMEWORK
     using System.IO;
     using System.IO.Packaging;
     using System.Printing;

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
@@ -84,6 +84,8 @@ namespace OxyPlot.Axes
                 }
             }
 
+            const double degree = Math.PI / 180d;
+
             //Text rendering
             foreach (var value in this.MajorLabelValues.Take(majorTickCount))
             {
@@ -91,7 +93,6 @@ namespace OxyPlot.Axes
 
                 var angle = Math.Atan2(pt.y - magnitudeAxis.MidPoint.y, pt.x - magnitudeAxis.MidPoint.x);
 
-                double degree = Math.PI / 180d;
                 // Convert to degrees
                 angle /= degree;
 
@@ -131,10 +132,6 @@ namespace OxyPlot.Axes
                     va = VerticalAlignment.Middle;
                     pt.x -= axis.AxisTickToLabelDistance;
                 }
-                else
-                {
-
-                }
 
                 if (Math.Abs(Math.Abs(angle) - 90) < 10)
                 {
@@ -169,8 +166,7 @@ namespace OxyPlot.Axes
             ScreenPoint result = new ScreenPoint();
             //I think the key is to NOT compute the axis scaled value of the angle, BUT to just draw it from the Midpoint to the end of the PlotView
             //For each MinorTickValue, compute an intersection point within the client area
-            double width_to_height = plotArea.Width / plotArea.Height;
-
+            //double width_to_height = plotArea.Width / plotArea.Height;
 
             double theta = (x - axis.Offset) * axis.Scale;
             theta %= 360.0d;
@@ -194,19 +190,19 @@ namespace OxyPlot.Axes
                 double lineend_y = x_portion * _y;
                 if (lineend_y + midPoint.Y > plotArea.Bottom || lineend_y + midPoint.Y < plotArea.Top)
                 {
-                    double delta_y = 0;
+                    double delta_y;
                     if (_y > 0)
                         delta_y = plotArea.Bottom - midPoint.Y;
                     else
                         delta_y = plotArea.Top - midPoint.Y;
 
                     double y_portion = delta_y / _y;
-                    lineend_x = y_portion * _x;
-                    lineend_y = y_portion * _y;
                     result = new ScreenPoint((y_portion * _x) + midPoint.X, (y_portion * _y) + midPoint.Y);
                 }
                 else
+                {
                     result = new ScreenPoint(lineend_x + midPoint.X, lineend_y + midPoint.Y);
+                }
             }
             return result;
         }

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.0;netstandard2.0;net45;net40</TargetFrameworks>
+        <TargetFrameworks>netstandard1.0;netstandard2.0;net452</TargetFrameworks>
         <PackageId>OxyPlot.Core</PackageId>
         <Description>OxyPlot is a plotting library for .NET. This is the core library including the foundation classes and plot model. To display the plots, you also need to add a platform-specific OxyPlot package that contains a PlotView component.</Description>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>

--- a/Source/OxyPlot/Series/AreaSeries.cs
+++ b/Source/OxyPlot/Series/AreaSeries.cs
@@ -18,11 +18,6 @@ namespace OxyPlot.Series
     public class AreaSeries : LineSeries
     {
         /// <summary>
-        /// The second list of points.
-        /// </summary>
-        private readonly List<DataPoint> points2 = new List<DataPoint>();
-
-        /// <summary>
         /// The secondary data points from the <see cref="P:ItemsSource" /> collection.
         /// </summary>
         private readonly List<DataPoint> itemsSourcePoints2 = new List<DataPoint>();
@@ -47,8 +42,8 @@ namespace OxyPlot.Series
         /// This is used if DataFieldBase and BaselineValues are <c>null</c>.
         /// </summary>
         /// <value>The baseline.</value>
-        /// <remarks><see cref="P:ConstantY2" /> is used if <see cref="P:ItemsSource" /> is set 
-        /// and <see cref="P:DataFieldX2" /> or <see cref="P:DataFieldY2" /> are <c>null</c>, 
+        /// <remarks><see cref="P:ConstantY2" /> is used if <see cref="P:ItemsSource" /> is set
+        /// and <see cref="P:DataFieldX2" /> or <see cref="P:DataFieldY2" /> are <c>null</c>,
         /// or if <see cref="P:ItemsSource" /> is <c>null</c> and <see cref="P:Points2" /> is empty.</remarks>
         public double ConstantY2 { get; set; }
 
@@ -105,13 +100,7 @@ namespace OxyPlot.Series
         /// </summary>
         /// <value>The second list of points.</value>
         /// <remarks>This property is not used if <see cref="P:ItemsSource" /> is set.</remarks>
-        public List<DataPoint> Points2
-        {
-            get
-            {
-                return this.points2;
-            }
-        }
+        public List<DataPoint> Points2 { get; } = new List<DataPoint>();
 
         /// <summary>
         /// Gets or sets a value indicating whether the second data collection should be reversed.
@@ -154,7 +143,7 @@ namespace OxyPlot.Series
         {
             var xy = this.InverseTransform(point);
             var targetX = xy.X;
-            int startIdx = this.IsXMonotonic 
+            int startIdx = this.IsXMonotonic
                 ? this.FindWindowStartIndex(this.ActualPoints, p => p.x, targetX, this.WindowStartIndex)
                 : 0;
             int startIdx2 = this.IsXMonotonic
@@ -192,9 +181,9 @@ namespace OxyPlot.Series
                     this.TrackerFormatString,
                     result.Item,
                     this.Title,
-                    this.XAxis.Title ?? XYAxisSeries.DefaultXAxisTitle,
+                    this.XAxis.Title ?? DefaultXAxisTitle,
                     this.XAxis.GetValue(result.DataPoint.X),
-                    this.YAxis.Title ?? XYAxisSeries.DefaultYAxisTitle,
+                    this.YAxis.Title ?? DefaultYAxisTitle,
                     this.YAxis.GetValue(result.DataPoint.Y));
             }
 
@@ -257,7 +246,7 @@ namespace OxyPlot.Series
             areaContext.WindowStartIndex = startIdx2;
             areaContext.Reverse = this.Reverse2;
             areaContext.Color = this.ActualColor2;
-            
+
             var chunksOfPoints2 = this.RenderChunkedPoints(areaContext);
 
             if (chunksOfPoints.Count != chunksOfPoints2.Count)
@@ -344,11 +333,11 @@ namespace OxyPlot.Series
 
             if (this.ItemsSource == null)
             {
-                this.IsPoints2Defined = this.points2.Count > 0;
+                this.IsPoints2Defined = this.Points2.Count > 0;
 
                 if (this.IsPoints2Defined)
                 {
-                    this.actualPoints2 = this.points2;
+                    this.actualPoints2 = this.Points2;
                 }
                 else
                 {

--- a/Source/OxyPlot/Series/BarSeries/LinearBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/LinearBarSeries.cs
@@ -122,8 +122,8 @@ namespace OxyPlot.Series
             {
                 this.Title,
                 this.XAxis.Title ?? "X",
-                this.XAxis.GetValue(dataPoint.X), 
-                this.YAxis.Title ?? "Y", 
+                this.XAxis.GetValue(dataPoint.X),
+                this.YAxis.Title ?? "Y",
                 this.YAxis.GetValue(dataPoint.Y),
             };
 
@@ -208,39 +208,37 @@ namespace OxyPlot.Series
             IComparer<OxyRect> comparer;
             if (this.IsTransposed())
             {
-                comparer = ComparerHelper.CreateComparer<OxyRect>(
-                    (x, y) =>
-                        {
-                            if (x.Bottom < point.Y)
-                            {
-                                return 1;
-                            }
+                comparer = ComparerHelper.CreateComparer<OxyRect>((x, y) =>
+                {
+                    if (x.Bottom < point.Y)
+                    {
+                        return 1;
+                    }
 
-                            if (x.Top > point.Y)
-                            {
-                                return -1;
-                            }
+                    if (x.Top > point.Y)
+                    {
+                        return -1;
+                    }
 
-                            return 0;
-                        });
+                    return 0;
+                });
             }
             else
             {
-                comparer = ComparerHelper.CreateComparer<OxyRect>(
-                    (x, y) =>
-                        {
-                            if (x.Right < point.X)
-                            {
-                                return -1;
-                            }
+                comparer = ComparerHelper.CreateComparer<OxyRect>((x, y) =>
+                {
+                    if (x.Right < point.X)
+                    {
+                        return -1;
+                    }
 
-                            if (x.Left > point.X)
-                            {
-                                return 1;
-                            }
+                    if (x.Left > point.X)
+                    {
+                        return 1;
+                    }
 
-                            return 0;
-                        });
+                    return 0;
+                });
             }
 
             return this.rectangles.BinarySearch(0, this.rectangles.Count, new OxyRect(), comparer);
@@ -273,10 +271,10 @@ namespace OxyPlot.Series
                 var barColors = this.GetBarColors(actualPoint.Y);
 
                 rc.DrawRectangle(
-                    rectangle, 
-                    barColors.FillColor, 
-                    barColors.StrokeColor, 
-                    this.StrokeThickness, 
+                    rectangle,
+                    barColors.FillColor,
+                    barColors.StrokeColor,
+                    this.StrokeThickness,
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
             }
         }

--- a/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
@@ -46,7 +46,6 @@ namespace OxyPlot.Series
             // this.LabelFormatString = "{0}-{1},{2}-{3}"; // X0-X1,Y0-Y1
         }
 
-
         /// <summary>
         /// Gets or sets the default color of the interior of the rectangles.
         /// </summary>

--- a/Source/OxyPlot/Series/BoxPlotSeries.cs
+++ b/Source/OxyPlot/Series/BoxPlotSeries.cs
@@ -9,11 +9,9 @@
 
 namespace OxyPlot.Series
 {
-    using System;
+    using OxyPlot.Axes;
     using System.Collections.Generic;
     using System.Linq;
-
-    using OxyPlot.Axes;
 
     /// <summary>
     /// Represents a series for box plots.
@@ -289,7 +287,7 @@ namespace OxyPlot.Series
         public virtual bool IsValidPoint(BoxPlotItem item, Axis xaxis, Axis yaxis)
         {
             return !double.IsNaN(item.X) && !double.IsInfinity(item.X) && !item.Values.Any(double.IsNaN)
-                   && !item.Values.Any(double.IsInfinity) && (xaxis != null && xaxis.IsValidValue(item.X))
+                   && !item.Values.Any(double.IsInfinity) && (xaxis?.IsValidValue(item.X) == true)
                    && (yaxis != null && item.Values.All(yaxis.IsValidValue));
         }
 
@@ -371,10 +369,10 @@ namespace OxyPlot.Series
                     // Draw the box
                     var rect = this.GetBoxRect(item);
                     rc.DrawRectangle(
-                        rect, 
-                        fillColor, 
-                        strokeColor, 
-                        this.StrokeThickness, 
+                        rect,
+                        fillColor,
+                        strokeColor,
+                        this.StrokeThickness,
                         this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
                 }
 
@@ -468,49 +466,31 @@ namespace OxyPlot.Series
             var fillColor = this.GetSelectableFillColor(this.Fill);
 
             // render the legend with EdgeRenderingMode.PreferGeometricAccuracy, because otherwise the fine geometry can look 'weird'
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, ytop) },
-                strokeColor,
-                LegendStrokeThickness,
-                this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferGeometricAccuracy),
-                LineStyle.Solid.GetDashArray(),
-                LineJoin.Miter);
-
-            rc.DrawLine(
-                new[] { new ScreenPoint(xmid, ybottom), new ScreenPoint(xmid, legendBox.Bottom) },
-                strokeColor,
-                LegendStrokeThickness,
-                this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferGeometricAccuracy),
-                LineStyle.Solid.GetDashArray(),
-                LineJoin.Miter);
+            rc.DrawLineSegments(new[]
+            {
+                new ScreenPoint(xmid, legendBox.Top), new ScreenPoint(xmid, ytop),
+                new ScreenPoint(xmid, ybottom), new ScreenPoint(xmid, legendBox.Bottom)
+            },
+            strokeColor,
+            LegendStrokeThickness,
+            this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferGeometricAccuracy),
+            LineStyle.Solid.GetDashArray());
 
             if (this.WhiskerWidth > 0)
             {
-                // top whisker
-                rc.DrawLine(
-                    new[]
-                        {
-                            new ScreenPoint(xmid - halfWhiskerWidth, legendBox.Bottom),
-                            new ScreenPoint(xmid + halfWhiskerWidth, legendBox.Bottom)
-                        },
-                    strokeColor,
-                    LegendStrokeThickness,
-                    this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferGeometricAccuracy),
-                    LineStyle.Solid.GetDashArray(),
-                    LineJoin.Miter);
-
-                // bottom whisker
-                rc.DrawLine(
-                    new[]
-                        {
-                            new ScreenPoint(xmid - halfWhiskerWidth, legendBox.Top),
-                            new ScreenPoint(xmid + halfWhiskerWidth, legendBox.Top)
-                        },
-                    strokeColor,
-                    LegendStrokeThickness,
-                    this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferGeometricAccuracy),
-                    LineStyle.Solid.GetDashArray(),
-                    LineJoin.Miter);
+                rc.DrawLineSegments(new[]
+                {
+                    // top whisker
+                    new ScreenPoint(xmid - halfWhiskerWidth, legendBox.Bottom),
+                    new ScreenPoint(xmid + halfWhiskerWidth, legendBox.Bottom),
+                    // bottom whisker
+                    new ScreenPoint(xmid - halfWhiskerWidth, legendBox.Top),
+                    new ScreenPoint(xmid + halfWhiskerWidth, legendBox.Top)
+                },
+                strokeColor,
+                LegendStrokeThickness,
+                this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferGeometricAccuracy),
+                LineStyle.Solid.GetDashArray());
             }
 
             if (this.ShowBox)
@@ -556,8 +536,7 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var sourceAsListOfT = this.ItemsSource as IEnumerable<BoxPlotItem>;
-            if (sourceAsListOfT != null)
+            if (this.ItemsSource is IEnumerable<BoxPlotItem> sourceAsListOfT)
             {
                 this.itemsSourceItems = sourceAsListOfT.ToList();
                 this.ownsItemsSourceItems = false;

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -11,7 +11,6 @@ namespace OxyPlot.Series
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
 
     /// <summary>
@@ -166,7 +165,7 @@ namespace OxyPlot.Series
             double[] actualContourLevels = this.ContourLevels;
 
             this.segments = new List<ContourSegment>();
-            Conrec.RendererDelegate renderer = (startX, startY, endX, endY, contourLevel) =>
+            void renderer(double startX, double startY, double endX, double endY, double contourLevel) =>
                 this.segments.Add(new ContourSegment(new DataPoint(startX, startY), new DataPoint(endX, endY), contourLevel));
 
             if (actualContourLevels == null)
@@ -202,7 +201,7 @@ namespace OxyPlot.Series
 
             this.JoinContourSegments();
 
-            if (this.ContourColors != null && this.ContourColors.Length > 0)
+            if (this.ContourColors?.Length > 0)
             {
                 foreach (var c in this.contours)
                 {
@@ -211,7 +210,7 @@ namespace OxyPlot.Series
                     if (index >= 0)
                     {
                         // clamp the index to the range of the ContourColors array
-                        index = index % this.ContourColors.Length;
+                        index %= this.ContourColors.Length;
                         c.Color = this.ContourColors[index];
                     }
                 }
@@ -228,9 +227,9 @@ namespace OxyPlot.Series
         {
             TrackerHitResult result = null;
 
-            var xaxisTitle = this.XAxis.Title ?? "X";
-            var yaxisTitle = this.YAxis.Title ?? "Y";
-            var zaxisTitle = "Z";
+            string xaxisTitle = this.XAxis.Title ?? "X";
+            string yaxisTitle = this.YAxis.Title ?? "Y";
+            const string zaxisTitle = "Z";
 
             foreach (var c in this.contours)
             {
@@ -630,15 +629,14 @@ namespace OxyPlot.Series
             double y = cl.Position.Y;
 
             var bpts = new[]
-                           {
-                               new ScreenPoint(x - (size.Width * ux) - (size.Height * vx), y - (size.Width * uy) - (size.Height * vy)),
-                               new ScreenPoint(x + (size.Width * ux) - (size.Height * vx), y + (size.Width * uy) - (size.Height * vy)),
-                               new ScreenPoint(x + (size.Width * ux) + (size.Height * vx), y + (size.Width * uy) + (size.Height * vy)),
-                               new ScreenPoint(x - (size.Width * ux) + (size.Height * vx), y - (size.Width * uy) + (size.Height * vy))
-                           };
+            {
+                new ScreenPoint(x - (size.Width * ux) - (size.Height * vx), y - (size.Width * uy) - (size.Height * vy)),
+                new ScreenPoint(x + (size.Width * ux) - (size.Height * vx), y + (size.Width * uy) - (size.Height * vy)),
+                new ScreenPoint(x + (size.Width * ux) + (size.Height * vx), y + (size.Width * uy) + (size.Height * vy)),
+                new ScreenPoint(x - (size.Width * ux) + (size.Height * vx), y - (size.Width * uy) + (size.Height * vy))
+            };
             rc.DrawPolygon(bpts, this.LabelBackground, OxyColors.Undefined, 0, this.EdgeRenderingMode);
         }
-
 
         /// <summary>
         /// Represents one of the two points of a segment.

--- a/Source/OxyPlot/Series/DataPointSeries.cs
+++ b/Source/OxyPlot/Series/DataPointSeries.cs
@@ -107,7 +107,7 @@ namespace OxyPlot.Series
             if (result != null)
             {
                 result.Text = StringHelper.Format(
-                    this.ActualCulture, 
+                    this.ActualCulture,
                     this.TrackerFormatString,
                     result.Item,
                     this.Title,
@@ -192,8 +192,7 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var sourceAsListOfDataPoints = this.ItemsSource as List<DataPoint>;
-            if (sourceAsListOfDataPoints != null)
+            if (this.ItemsSource is List<DataPoint> sourceAsListOfDataPoints)
             {
                 this.itemsSourcePoints = sourceAsListOfDataPoints;
                 this.ownsItemsSourcePoints = false;
@@ -202,8 +201,7 @@ namespace OxyPlot.Series
 
             this.ClearItemsSourcePoints();
 
-            var sourceAsEnumerableDataPoints = this.ItemsSource as IEnumerable<DataPoint>;
-            if (sourceAsEnumerableDataPoints != null)
+            if (this.ItemsSource is IEnumerable<DataPoint> sourceAsEnumerableDataPoints)
             {
                 this.itemsSourcePoints.AddRange(sourceAsEnumerableDataPoints);
                 return;
@@ -216,14 +214,13 @@ namespace OxyPlot.Series
             {
                 foreach (var item in this.ItemsSource)
                 {
-                    if (item is DataPoint)
+                    if (item is DataPoint dataPoint)
                     {
-                        this.itemsSourcePoints.Add((DataPoint)item);
+                        this.itemsSourcePoints.Add(dataPoint);
                         continue;
                     }
 
-                    var idpp = item as IDataPointProvider;
-                    if (idpp == null)
+                    if (!(item is IDataPointProvider idpp))
                     {
                         continue;
                     }

--- a/Source/OxyPlot/Series/ExtrapolationLineSeries.cs
+++ b/Source/OxyPlot/Series/ExtrapolationLineSeries.cs
@@ -9,11 +9,10 @@
 
 namespace OxyPlot.Series
 {
+    using OxyPlot;
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using OxyPlot;
-    using OxyPlot.Series;
 
     /// <summary>
     /// Represents a series where the line can be rendered using a different style
@@ -162,7 +161,7 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal override void UpdateMaxMin()
         {
-            if (this.IgnoreExtraplotationForScaling && this.orderedIntervals.Any())
+            if (this.IgnoreExtraplotationForScaling && this.orderedIntervals.Count > 0)
             {
                 this.MinX = this.Points
                     .Where(p => !this.InAnyInterval(p.X))
@@ -223,8 +222,7 @@ namespace OxyPlot.Series
             {
                 var centerX = this.InverseTransform(rect.Center).X;
 
-                bool isInterval = this.orderedIntervals != null
-                    && this.orderedIntervals.Any(i => i.Contains(centerX));
+                bool isInterval = this.orderedIntervals?.Any(i => i.Contains(centerX)) == true;
 
                 using (rc.AutoResetClip(rect))
                 {
@@ -242,7 +240,7 @@ namespace OxyPlot.Series
         {
             var previous = minX;
 
-            if (this.orderedIntervals != null && this.orderedIntervals.Any())
+            if (this.orderedIntervals?.Count > 0)
             {
                 IEnumerable<double> flatLimits
                     = this.Flatten(this.orderedIntervals).Where(l => l >= minX && l <= maxX);

--- a/Source/OxyPlot/Series/FinancialSeries/HighLowItem.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/HighLowItem.cs
@@ -87,10 +87,22 @@ namespace OxyPlot.Series
         /// Returns C# code that generates this instance.
         /// </summary>
         /// <returns>The C# code.</returns>
-        public string ToCode()
+        public virtual string ToCode()
         {
             return CodeGenerator.FormatConstructor(
-                this.GetType(), "{0},{1},{2},{3},{4}", this.X, this.High, this.Low, this.Open, this.Close);
+                this.GetType(), "{0},{1},{2},{3},{4}",
+                this.X, this.High, this.Low, this.Open, this.Close);
+        }
+
+        /// <summary>
+        /// Indicate whether is valid for rendering or not
+        /// </summary>
+        /// <returns><c>true</c> if this instance is valid; otherwise, <c>false</c>.</returns>
+        public virtual bool IsValid()
+        {
+            return !double.IsNaN(this.X) && !double.IsNaN(this.Open) &&
+                   !double.IsNaN(this.High) && !double.IsNaN(this.Low) &&
+                   !double.IsNaN(this.Close);
         }
     }
 }

--- a/Source/OxyPlot/Series/FinancialSeries/OhlcvItem.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/OhlcvItem.cs
@@ -14,22 +14,22 @@ namespace OxyPlot.Series
     /// <summary>
     /// Represents an item in a <see cref="CandleStickAndVolumeSeries" />.
     /// </summary>
-    public class OhlcvItem
+    public class OhlcvItem : HighLowItem
     {
         /// <summary>
         /// The undefined.
         /// </summary>
-        public static readonly OhlcvItem Undefined = new OhlcvItem(double.NaN, double.NaN, double.NaN, double.NaN, double.NaN);
+        public static new readonly OhlcvItem Undefined = new OhlcvItem(double.NaN, double.NaN, double.NaN, double.NaN, double.NaN);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OhlcvItem" /> class.
         /// </summary>
         public OhlcvItem()
-        { 
+        {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OxyPlot.Series.OhlcvItem"/> class.
+        /// Initializes a new instance of the <see cref="OhlcvItem"/> class.
         /// </summary>
         /// <param name="x">The x coordinate / time.</param>
         /// <param name="open">Open value.</param>
@@ -39,54 +39,19 @@ namespace OxyPlot.Series
         /// <param name="buyvolume">Buy volume.</param>
         /// <param name="sellvolume">Sell volume.</param>
         public OhlcvItem(
-            double x, 
-            double open, 
-            double high, 
-            double low, 
+            double x,
+            double open,
+            double high,
+            double low,
             double close,
-            double buyvolume = 0, 
-            double sellvolume = 0)
+            double buyvolume = 0,
+            double sellvolume = 0) : base(x, high, low, open, close)
         {
-            this.X = x;
-            this.Open = open;
-            this.High = high;
-            this.Low = low;
-            this.Close = close;
             this.BuyVolume = buyvolume;
             this.SellVolume = sellvolume;
         }
 
         // Properties
-
-        /// <summary>
-        /// Gets or sets the X value (time).
-        /// </summary>
-        /// <value>The X value.</value>
-        public double X { get; set; }
-
-        /// <summary>
-        /// Gets or sets the open value.
-        /// </summary>
-        /// <value>The open value.</value>
-        public double Open { get; set; }
-
-        /// <summary>
-        /// Gets or sets the high value.
-        /// </summary>
-        /// <value>The high value.</value>
-        public double High { get; set; }
-
-        /// <summary>
-        /// Gets or sets the low value.
-        /// </summary>
-        /// <value>The low value.</value>
-        public double Low { get; set; }
-
-        /// <summary>
-        /// Gets or sets the close value.
-        /// </summary>
-        /// <value>The close value.</value>
-        public double Close { get; set; }
 
         /// <summary>
         /// Gets or sets the buy volume.
@@ -150,9 +115,9 @@ namespace OxyPlot.Series
                     }
                 }
                 else
-                { 
-                    start = guessIdx + 1; 
-                    lastguess = guessIdx; 
+                {
+                    start = guessIdx + 1;
+                    lastguess = guessIdx;
                 }
 
                 if (start >= end)
@@ -171,12 +136,14 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Indicate whether is valid for rendering or not
+        /// Returns C# code that generates this instance.
         /// </summary>
-        /// <returns><c>true</c> if this instance is valid; otherwise, <c>false</c>.</returns>
-        public bool IsValid()
+        /// <returns>The C# code.</returns>
+        public override string ToCode()
         {
-            return !double.IsNaN(this.X) && !double.IsNaN(this.Open) && !double.IsNaN(this.High) && !double.IsNaN(this.Low) && !double.IsNaN(this.Close);
+            return CodeGenerator.FormatConstructor(
+                this.GetType(), "{0},{1},{2},{3},{4},{5},{6}",
+                this.X, this.High, this.Low, this.Open, this.Close, this.BuyVolume, this.SellVolume);
         }
     }
 }

--- a/Source/OxyPlot/Series/FunctionSeries.cs
+++ b/Source/OxyPlot/Series/FunctionSeries.cs
@@ -14,7 +14,7 @@ namespace OxyPlot.Series
     /// <summary>
     /// Represents a line series that generates its dataset from a function.
     /// </summary>
-    /// <remarks>Define <code>f(x)</code> and make a plot on the range <code>[x0,x1]</code> or define <code>x(t)</code> and <code>y(t)</code> and make a plot on the range <code>[t0,t1]</code>.</remarks>
+    /// <remarks>Define <c>f(x)</c> and make a plot on the range <c>[x0,x1]</c> or define <c>x(t)</c> and <c>y(t)</c> and make a plot on the range <c>[t0,t1]</c>.</remarks>
     public class FunctionSeries : LineSeries
     {
         /// <summary>
@@ -25,9 +25,9 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using a function <code>f(x)</code>.
+        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using a function <c>f(x)</c>.
         /// </summary>
-        /// <param name="f">The function <code>f(x)</code>.</param>
+        /// <param name="f">The function <c>f(x)</c>.</param>
         /// <param name="x0">The start x value.</param>
         /// <param name="x1">The end x value.</param>
         /// <param name="dx">The increment in x.</param>
@@ -42,9 +42,9 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using a function <code>f(x)</code>.
+        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using a function <c>f(x)</c>.
         /// </summary>
-        /// <param name="f">The function <code>f(x)</code>.</param>
+        /// <param name="f">The function <c>f(x)</c>.</param>
         /// <param name="x0">The start x value.</param>
         /// <param name="x1">The end x value.</param>
         /// <param name="n">The number of points.</param>
@@ -55,10 +55,10 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using functions <code>x(t)</code> and <code>y(t)</code>.
+        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using functions <c>x(t)</c> and <c>y(t)</c>.
         /// </summary>
-        /// <param name="fx">The function <code>x(t)</code>.</param>
-        /// <param name="fy">The function <code>y(t)</code>.</param>
+        /// <param name="fx">The function <c>x(t)</c>.</param>
+        /// <param name="fy">The function <c>y(t)</c>.</param>
         /// <param name="t0">The start t parameter.</param>
         /// <param name="t1">The end t parameter.</param>
         /// <param name="dt">The increment in t.</param>
@@ -73,10 +73,10 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using functions <code>x(t)</code> and <code>y(t)</code>.
+        /// Initializes a new instance of the <see cref="FunctionSeries" /> class using functions <c>x(t)</c> and <c>y(t)</c>.
         /// </summary>
-        /// <param name="fx">The function <code>x(t)</code>.</param>
-        /// <param name="fy">The function <code>y(t)</code>.</param>
+        /// <param name="fx">The function <c>x(t)</c>.</param>
+        /// <param name="fy">The function <c>y(t)</c>.</param>
         /// <param name="t0">The start t parameter.</param>
         /// <param name="t1">The end t parameter.</param>
         /// <param name="n">The number of points.</param>

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -9,9 +9,8 @@
 
 namespace OxyPlot.Series
 {
-    using System;
-
     using OxyPlot.Axes;
+    using System;
 
     /// <summary>
     /// Specifies how the heat map coordinates are defined.
@@ -390,8 +389,7 @@ namespace OxyPlot.Series
             }
 
             var value = GetValue(this.Data, i, j);
-            var colorAxis = this.ColorAxis as Axis;
-            var colorAxisTitle = (colorAxis != null ? colorAxis.Title : null) ?? DefaultColorAxisTitle;
+            var colorAxisTitle = (this.ColorAxis is Axis colorAxis ? colorAxis.Title : null) ?? DefaultColorAxisTitle;
 
             return new TrackerHitResult
             {
@@ -489,8 +487,7 @@ namespace OxyPlot.Series
         protected internal override void UpdateAxisMaxMin()
         {
             base.UpdateAxisMaxMin();
-            var colorAxis = this.ColorAxis as Axis;
-            if (colorAxis != null)
+            if (this.ColorAxis is Axis colorAxis)
             {
                 colorAxis.Include(this.MinValue);
                 colorAxis.Include(this.MaxValue);

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -240,12 +240,12 @@ namespace OxyPlot.Series
         /// </summary>
         protected internal void UpdateMaxMinXY()
         {
-            if (this.ActualItems != null && this.ActualItems.Count > 0)
+            if (this.ActualItems?.Count > 0)
             {
                 this.MinX = Math.Min(this.ActualItems.Min(r => r.RangeStart), this.ActualItems.Min(r => r.RangeEnd));
                 this.MaxX = Math.Max(this.ActualItems.Max(r => r.RangeStart), this.ActualItems.Max(r => r.RangeEnd));
-                this.MinY = Math.Min(this.ActualItems.Min(r => 0), this.ActualItems.Min(r => r.Height));
-                this.MaxY = Math.Max(this.ActualItems.Max(r => 0), this.ActualItems.Max(r => r.Height));
+                this.MinY = Math.Min(0, this.ActualItems.Min(r => r.Height));
+                this.MaxY = Math.Max(0, this.ActualItems.Max(r => r.Height));
             }
         }
 
@@ -263,7 +263,7 @@ namespace OxyPlot.Series
 
             this.UpdateMaxMinXY();
 
-            if (this.ActualItems != null && this.ActualItems.Count > 0)
+            if (this.ActualItems?.Count > 0)
             {
                 this.MinValue = this.ActualItems.Min(r => r.Value);
                 this.MaxValue = this.ActualItems.Max(r => r.Value);
@@ -304,10 +304,10 @@ namespace OxyPlot.Series
                 var rectrect = new OxyRect(p1, p2);
 
                 rc.DrawRectangle(
-                    rectrect, 
-                    actualFillColor, 
-                    this.StrokeColor, 
-                    this.StrokeThickness, 
+                    rectrect,
+                    actualFillColor,
+                    this.StrokeColor,
+                    this.StrokeThickness,
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
 
                 if (this.LabelFormatString != null)

--- a/Source/OxyPlot/Series/ItemsSeries.cs
+++ b/Source/OxyPlot/Series/ItemsSeries.cs
@@ -38,8 +38,7 @@ namespace OxyPlot.Series
                 return null;
             }
 
-            var list = itemsSource as IList;
-            if (list != null)
+            if (itemsSource is IList list)
             {
                 if (index < list.Count && index >= 0)
                 {
@@ -50,7 +49,7 @@ namespace OxyPlot.Series
             }
 
             var i = 0;
-            return itemsSource.Cast<object>().FirstOrDefault(item => i++ == index);
+            return itemsSource.Cast<object>().FirstOrDefault(_ => i++ == index);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -514,12 +514,12 @@ namespace OxyPlot.Series
 	    /// Extracts a single contiguous line segment beginning with the element at the position of the enumerator when the method
 	    /// is called. Initial invalid data points are ignored.
 	    /// </summary>
+	    /// <param name="points">Points collection</param>
 	    /// <param name="pointIdx">Current point index</param>
 	    /// <param name="previousContiguousLineSegmentEndPoint">Initially set to null, but I will update I won't give a broken line if this is null</param>
 	    /// <param name="xmax">Maximum visible X value</param>
 	    /// <param name="broken">place to put broken segment</param>
 	    /// <param name="contiguous">place to put contiguous segment</param>
-	    /// <param name="points">Points collection</param>
 	    /// <returns>
 	    ///   <c>true</c> if line segments are extracted, <c>false</c> if reached end.
 	    /// </returns>
@@ -533,9 +533,9 @@ namespace OxyPlot.Series
             List<ScreenPoint> contiguous)
         // ReSharper restore SuggestBaseTypeForParameter
         {
-            DataPoint currentPoint = default(DataPoint);
+            DataPoint currentPoint = default;
 		    bool hasValidPoint = false;
-		    
+
             // Skip all undefined points
 		    for (; pointIdx < points.Count; pointIdx++)
 		    {
@@ -544,7 +544,7 @@ namespace OxyPlot.Series
 			    {
 				    return false;
 			    }
-			    
+
 				// ReSharper disable once AssignmentInConditionalExpression
 			    if (hasValidPoint = this.IsValidPoint(currentPoint))
 			    {
@@ -718,18 +718,18 @@ namespace OxyPlot.Series
 
             if (this.MarkerType != MarkerType.None)
             {
-                var markerBinOffset = this.MarkerResolution > 0 ? this.Transform(this.MinX, this.MinY) : default(ScreenPoint);
+                var markerBinOffset = this.MarkerResolution > 0 ? this.Transform(this.MinX, this.MinY) : default;
 
                 rc.DrawMarkers(
-                    pointsToRender, 
-                    this.MarkerType, 
-                    this.MarkerOutline, 
-                    new[] { this.MarkerSize }, 
-                    this.ActualMarkerFill, 
-                    this.MarkerStroke, 
-                    this.MarkerStrokeThickness, 
+                    pointsToRender,
+                    this.MarkerType,
+                    this.MarkerOutline,
+                    new[] { this.MarkerSize },
+                    this.ActualMarkerFill,
+                    this.MarkerStroke,
+                    this.MarkerStrokeThickness,
                     this.EdgeRenderingMode,
-                    this.MarkerResolution, 
+                    this.MarkerResolution,
                     markerBinOffset);
             }
         }
@@ -749,13 +749,13 @@ namespace OxyPlot.Series
             }
 
             rc.DrawReducedLine(
-                pointsToRender, 
-                this.MinimumSegmentLength * this.MinimumSegmentLength, 
-                this.GetSelectableColor(this.ActualColor), 
-                this.StrokeThickness, 
+                pointsToRender,
+                this.MinimumSegmentLength * this.MinimumSegmentLength,
+                this.GetSelectableColor(this.ActualColor),
+                this.StrokeThickness,
                 this.EdgeRenderingMode,
-                dashArray, 
-                this.LineJoin, 
+                dashArray,
+                this.LineJoin,
                 this.outputBuffer);
         }
 

--- a/Source/OxyPlot/Series/RectangleItem.cs
+++ b/Source/OxyPlot/Series/RectangleItem.cs
@@ -113,13 +113,11 @@ namespace OxyPlot.Series
         public bool IsDefined()
         {
             // check that x and y is not NaN (the code below is faster than double.IsNaN)
-#pragma warning disable 1718
             // ReSharper disable EqualExpressionComparison
             // ReSharper disable CompareOfFloatsByEqualityOperator
             return this.A.IsDefined() && this.B.IsDefined() && !double.IsNaN(this.Value);
             // ReSharper restore CompareOfFloatsByEqualityOperator
             // ReSharper restore EqualExpressionComparison
-#pragma warning restore 1718
         }
     }
 }

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -1,10 +1,9 @@
 ﻿namespace OxyPlot.Series
 {
+    using Axes;
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
-    using Axes;
 
     /// <summary>
     /// Represents a series that can be bound to a collection of <see cref="RectangleItem"/>.
@@ -173,8 +172,7 @@
                 return;
             }
 
-            var sourceAsListOfDataRects = this.ItemsSource as List<RectangleItem>;
-            if (sourceAsListOfDataRects != null)
+            if (this.ItemsSource is List<RectangleItem> sourceAsListOfDataRects)
             {
                 this.actualItems = sourceAsListOfDataRects;
                 this.ownsActualItems = false;
@@ -183,8 +181,7 @@
 
             this.ClearActualItems();
 
-            var sourceAsEnumerableDataRects = this.ItemsSource as IEnumerable<RectangleItem>;
-            if (sourceAsEnumerableDataRects != null)
+            if (this.ItemsSource is IEnumerable<RectangleItem> sourceAsEnumerableDataRects)
             {
                 this.actualItems.AddRange(sourceAsEnumerableDataRects);
             }
@@ -208,23 +205,23 @@
                 var rectrect = new OxyRect(p1, p2);
 
                 rc.DrawRectangle(
-                    rectrect, 
-                    rectcolor, 
+                    rectrect,
+                    rectcolor,
                     OxyColors.Undefined,
-                    0, 
+                    0,
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
 
                 if (this.LabelFontSize > 0)
                 {
                     rc.DrawText(
-                        rectrect.Center, 
-                        item.Value.ToString(this.LabelFormatString), 
-                        this.ActualTextColor, 
-                        this.ActualFont, 
-                        this.LabelFontSize, 
-                        this.ActualFontWeight, 
-                        0, 
-                        HorizontalAlignment.Center, 
+                        rectrect.Center,
+                        item.Value.ToString(this.LabelFormatString),
+                        this.ActualTextColor,
+                        this.ActualFont,
+                        this.LabelFontSize,
+                        this.ActualFontWeight,
+                        0,
+                        HorizontalAlignment.Center,
                         VerticalAlignment.Middle);
                 }
             }
@@ -298,7 +295,7 @@
         /// </summary>
         protected internal void UpdateMaxMinXY()
         {
-            if (this.ActualItems != null && this.ActualItems.Count > 0)
+            if (this.ActualItems?.Count > 0)
             {
                 this.MinX = Math.Min(this.ActualItems.Min(r => r.A.X), this.ActualItems.Min(r => r.B.X));
                 this.MaxX = Math.Max(this.ActualItems.Max(r => r.A.X), this.ActualItems.Max(r => r.B.X));
@@ -322,7 +319,7 @@
 
             this.UpdateMaxMinXY();
 
-            if (this.ActualItems != null && this.ActualItems.Count > 0)
+            if (this.ActualItems?.Count > 0)
             {
                 this.MinValue = this.ActualItems.Min(r => r.Value);
                 this.MaxValue = this.ActualItems.Max(r => r.Value);
@@ -335,8 +332,7 @@
         protected internal override void UpdateAxisMaxMin()
         {
             base.UpdateAxisMaxMin();
-            var colorAxis = this.ColorAxis as Axis;
-            if (colorAxis != null)
+            if (this.ColorAxis is Axis colorAxis)
             {
                 colorAxis.Include(this.MinValue);
                 colorAxis.Include(this.MaxValue);

--- a/Source/OxyPlot/Series/ScatterErrorSeries.cs
+++ b/Source/OxyPlot/Series/ScatterErrorSeries.cs
@@ -138,11 +138,11 @@ namespace OxyPlot.Series
             }
 
             rc.DrawLineSegments(
-                segments, 
-                this.GetSelectableColor(this.ErrorBarColor), 
-                this.ErrorBarStrokeThickness, 
+                segments,
+                this.GetSelectableColor(this.ErrorBarColor),
+                this.ErrorBarStrokeThickness,
                 this.EdgeRenderingMode,
-                null, 
+                null,
                 LineJoin.Bevel);
         }
 

--- a/Source/OxyPlot/Series/ScatterSeries.cs
+++ b/Source/OxyPlot/Series/ScatterSeries.cs
@@ -9,8 +9,6 @@
 
 namespace OxyPlot.Series
 {
-    using System;
-
     /// <summary>
     /// Represents a series for scatter plots.
     /// </summary>

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -9,10 +9,9 @@
 
 namespace OxyPlot.Series
 {
+    using OxyPlot.Axes;
     using System;
     using System.Collections.Generic;
-
-    using OxyPlot.Axes;
 
     /// <summary>
     /// Provides a base class for scatter series.
@@ -81,7 +80,7 @@ namespace OxyPlot.Series
         public Func<object, T> Mapping { get; set; }
 
         /// <summary>
-        /// Gets or sets the size of the 'binning' feature. 
+        /// Gets or sets the size of the 'binning' feature.
         /// If this number is greater than 1, bins of the specified is created for both x and y directions. Only one point will be drawn in each bin.
         /// </summary>
         /// <value>
@@ -93,7 +92,7 @@ namespace OxyPlot.Series
         /// Gets the actual color axis.
         /// </summary>
         /// <value>A <see cref="IColorAxis" />.</value>
-        /// <remarks>This is used to map scatter point values to colors. Use the <see cref="ColorAxisKey" /> to specify a color axis. 
+        /// <remarks>This is used to map scatter point values to colors. Use the <see cref="ColorAxisKey" /> to specify a color axis.
         /// If the <see cref="ColorAxisKey" /> is not specified, the first <see cref="IColorAxis" /> of the <see cref="PlotModel" /> will be used.</remarks>
         public IColorAxis ColorAxis { get; private set; }
 
@@ -101,7 +100,7 @@ namespace OxyPlot.Series
         /// Gets or sets the color axis key.
         /// </summary>
         /// <value>The color axis key. The default is <c>null</c>.</value>
-        /// <remarks>If set to <c>null</c>, the first <see cref="IColorAxis" /> of the <see cref="PlotModel" /> will be used. 
+        /// <remarks>If set to <c>null</c>, the first <see cref="IColorAxis" /> of the <see cref="PlotModel" /> will be used.
         /// Make sure that the points contains values.
         /// If your <see cref="PlotModel" /> contains a <see cref="IColorAxis" />, but you don't want to use a color axis, set the value to <c>string.Empty</c> or some other key that is not in use.</remarks>
         public string ColorAxisKey { get; set; }
@@ -170,7 +169,7 @@ namespace OxyPlot.Series
         public OxyColor MarkerStroke { get; set; }
 
         /// <summary>
-        /// Gets or sets thickness of the the marker strokes.
+        /// Gets or sets thickness of the marker strokes.
         /// </summary>
         /// <value>The thickness. The default is <c>1</c>.</value>
         public double MarkerStrokeThickness { get; set; }
@@ -724,8 +723,7 @@ namespace OxyPlot.Series
                 this.MaxValue = maxvalue;
             }
 
-            var colorAxis = this.ColorAxis as Axis;
-            if (colorAxis != null)
+            if (this.ColorAxis is Axis colorAxis)
             {
                 colorAxis.Include(this.MinValue);
                 colorAxis.Include(this.MaxValue);
@@ -764,8 +762,7 @@ namespace OxyPlot.Series
             this.MinValue = minvalue;
             this.MaxValue = maxvalue;
 
-            var colorAxis = this.ColorAxis as Axis;
-            if (colorAxis != null)
+            if (this.ColorAxis is Axis colorAxis)
             {
                 colorAxis.Include(this.MinValue);
                 colorAxis.Include(this.MaxValue);
@@ -811,8 +808,7 @@ namespace OxyPlot.Series
                 return;
             }
 
-            var sourceAsListOfScatterPoints = this.ItemsSource as List<T>;
-            if (sourceAsListOfScatterPoints != null)
+            if (this.ItemsSource is List<T> sourceAsListOfScatterPoints)
             {
                 this.ItemsSourcePoints = sourceAsListOfScatterPoints;
                 this.OwnsItemsSourcePoints = false;
@@ -821,8 +817,7 @@ namespace OxyPlot.Series
 
             this.ClearItemsSourcePoints();
 
-            var sourceAsEnumerableScatterPoints = this.ItemsSource as IEnumerable<T>;
-            if (sourceAsEnumerableScatterPoints != null)
+            if (this.ItemsSource is IEnumerable<T> sourceAsEnumerableScatterPoints)
             {
                 this.ItemsSourcePoints.AddRange(sourceAsEnumerableScatterPoints);
                 return;
@@ -833,14 +828,13 @@ namespace OxyPlot.Series
             {
                 foreach (var item in this.ItemsSource)
                 {
-                    if (item is T)
+                    if (item is T t)
                     {
-                        this.ItemsSourcePoints.Add((T)item);
+                        this.ItemsSourcePoints.Add(t);
                         continue;
                     }
 
-                    var idpp = item as IScatterPointProvider;
-                    if (idpp != null)
+                    if (item is IScatterPointProvider idpp)
                     {
                         this.ItemsSourcePoints.Add((T)idpp.GetScatterPoint());
                     }

--- a/Source/OxyPlot/Series/StairStepSeries.cs
+++ b/Source/OxyPlot/Series/StairStepSeries.cs
@@ -61,7 +61,7 @@ namespace OxyPlot.Series
             if (!interpolate && result != null && result.Position.DistanceToSquared(point) < minimumDistanceSquared)
             {
                 result.Text = StringHelper.Format(
-                    this.ActualCulture, 
+                    this.ActualCulture,
                     this.TrackerFormatString,
                     result.Item,
                     this.Title,
@@ -157,64 +157,64 @@ namespace OxyPlot.Series
 
             var actualColor = this.GetSelectableColor(this.ActualColor);
 
-            Action<IList<ScreenPoint>, IList<ScreenPoint>> renderPoints = (lpts, mpts) =>
+            void renderPoints(IList<ScreenPoint> lpts, IList<ScreenPoint> mpts)
+            {
+                // clip the line segments with the clipping rectangle
+                if (this.StrokeThickness > 0 && lineStyle != LineStyle.None)
                 {
-                    // clip the line segments with the clipping rectangle
-                    if (this.StrokeThickness > 0 && lineStyle != LineStyle.None)
+                    if (!verticalStrokeThickness.Equals(this.StrokeThickness) || this.VerticalLineStyle != lineStyle)
                     {
-                        if (!verticalStrokeThickness.Equals(this.StrokeThickness) || this.VerticalLineStyle != lineStyle)
+                        // TODO: change to array
+                        var hlpts = new List<ScreenPoint>();
+                        var vlpts = new List<ScreenPoint>();
+                        for (int i = 0; i + 2 < lpts.Count; i += 2)
                         {
-                            // TODO: change to array
-                            var hlpts = new List<ScreenPoint>();
-                            var vlpts = new List<ScreenPoint>();
-                            for (int i = 0; i + 2 < lpts.Count; i += 2)
-                            {
-                                hlpts.Add(lpts[i]);
-                                hlpts.Add(lpts[i + 1]);
-                                vlpts.Add(lpts[i + 1]);
-                                vlpts.Add(lpts[i + 2]);
-                            }
+                            hlpts.Add(lpts[i]);
+                            hlpts.Add(lpts[i + 1]);
+                            vlpts.Add(lpts[i + 1]);
+                            vlpts.Add(lpts[i + 2]);
+                        }
 
-                            rc.DrawLineSegments(
-                                hlpts,
-                                actualColor,
-                                this.StrokeThickness,
-                                this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
-                                dashArray,
-                                this.LineJoin);
-                            rc.DrawLineSegments(
-                                vlpts,
-                                actualColor,
-                                verticalStrokeThickness,
-                                this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
-                                verticalLineDashArray,
-                                this.LineJoin);
-                        }
-                        else
-                        {
-                            rc.DrawLine(
-                                lpts,
-                                actualColor,
-                                this.StrokeThickness,
-                                this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
-                                dashArray,
-                                this.LineJoin);
-                        }
+                        rc.DrawLineSegments(
+                            hlpts,
+                            actualColor,
+                            this.StrokeThickness,
+                            this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
+                            dashArray,
+                            this.LineJoin);
+                        rc.DrawLineSegments(
+                            vlpts,
+                            actualColor,
+                            verticalStrokeThickness,
+                            this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
+                            verticalLineDashArray,
+                            this.LineJoin);
                     }
-
-                    if (this.MarkerType != MarkerType.None)
+                    else
                     {
-                        rc.DrawMarkers(
-                            mpts,
-                            this.MarkerType,
-                            this.MarkerOutline,
-                            new[] { this.MarkerSize },
-                            this.ActualMarkerFill,
-                            this.MarkerStroke,
-                            this.MarkerStrokeThickness,
-                            this.EdgeRenderingMode);
+                        rc.DrawLine(
+                            lpts,
+                            actualColor,
+                            this.StrokeThickness,
+                            this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness),
+                            dashArray,
+                            this.LineJoin);
                     }
-                };
+                }
+
+                if (this.MarkerType != MarkerType.None)
+                {
+                    rc.DrawMarkers(
+                        mpts,
+                        this.MarkerType,
+                        this.MarkerOutline,
+                        new[] { this.MarkerSize },
+                        this.ActualMarkerFill,
+                        this.MarkerStroke,
+                        this.MarkerStrokeThickness,
+                        this.EdgeRenderingMode);
+                }
+            }
 
             // Transform all points to screen coordinates
             // Render the line when invalid points occur

--- a/Source/OxyPlot/Series/StemSeries.cs
+++ b/Source/OxyPlot/Series/StemSeries.cs
@@ -88,7 +88,7 @@ namespace OxyPlot.Series
                         Index = i,
                         Text =
                             StringHelper.Format(
-                                this.ActualCulture, 
+                                this.ActualCulture,
                                 this.TrackerFormatString,
                                 item,
                                 this.Title,
@@ -147,10 +147,7 @@ namespace OxyPlot.Series
                         this.LineJoin);
                 }
 
-                if (markerPoints != null)
-                {
-                    markerPoints.Add(points[1]);
-                }
+                markerPoints?.Add(points[1]);
             }
 
             if (this.MarkerType != MarkerType.None)

--- a/Source/OxyPlot/Series/TwoColorAreaSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorAreaSeries.cs
@@ -10,7 +10,6 @@
 namespace OxyPlot.Series
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Represents a two-color area series.
@@ -36,7 +35,7 @@ namespace OxyPlot.Series
         /// Start index of a visible rendering window for markers.
         /// </summary>
         private int markerStartIndex;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref = "TwoColorAreaSeries" /> class.
         /// </summary>
@@ -237,8 +236,8 @@ namespace OxyPlot.Series
                     aboveMarkers,
                     this.MarkerType,
                     null,
-                    markerSizes, 
-                    this.ActualMarkerFill, 
+                    markerSizes,
+                    this.ActualMarkerFill,
                     this.MarkerStroke,
                     this.MarkerStrokeThickness,
                     this.EdgeRenderingMode,
@@ -379,7 +378,7 @@ namespace OxyPlot.Series
         {
             var result = new List<ScreenPoint>();
 
-            if (double.IsNaN(baseline) || source.Count <= 0)
+            if (double.IsNaN(baseline) || source.Count == 0)
             {
                 return result;
             }

--- a/Source/OxyPlot/Series/TwoColorLineSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorLineSeries.cs
@@ -113,7 +113,7 @@ namespace OxyPlot.Series
             var clippingRect = this.GetClippingRect();
             var p1 = this.InverseTransform(clippingRect.BottomLeft);
             var p2 = this.InverseTransform(clippingRect.TopRight);
-            
+
             var clippingRectLo = new OxyRect(
                 this.Transform(p1.X, Math.Min(p1.Y, p2.Y)),
                 this.Transform(p2.X, this.Limit)).Clip(clippingRect);

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -9,11 +9,10 @@
 
 namespace OxyPlot.Series
 {
+    using OxyPlot.Axes;
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
-    using OxyPlot.Axes;
 
     /// <summary>
     /// Provides an abstract base class for series that are related to an X-axis and a Y-axis.
@@ -360,9 +359,8 @@ namespace OxyPlot.Series
         /// <returns><c>true</c> if the point is valid; otherwise, <c>false</c> .</returns>
         protected virtual bool IsValidPoint(DataPoint pt)
         {
-            return
-                this.XAxis != null && this.XAxis.IsValidValue(pt.X) &&
-                this.YAxis != null && this.YAxis.IsValidValue(pt.Y);
+            return this.XAxis?.IsValidValue(pt.X) == true &&
+                   this.YAxis?.IsValidValue(pt.Y) == true;
         }
 
         /// <summary>
@@ -373,9 +371,8 @@ namespace OxyPlot.Series
         /// <returns><c>true</c> if the point is valid; otherwise, <c>false</c> . </returns>
         protected bool IsValidPoint(double x, double y)
         {
-            return
-                this.XAxis != null && this.XAxis.IsValidValue(x) &&
-                this.YAxis != null && this.YAxis.IsValidValue(y);
+            return this.XAxis?.IsValidValue(x) == true &&
+                   this.YAxis?.IsValidValue(y) == true;
         }
 
         /// <summary>
@@ -386,7 +383,7 @@ namespace OxyPlot.Series
         {
             if (points == null)
             {
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
             }
 
             this.IsXMonotonic = true;
@@ -514,7 +511,7 @@ namespace OxyPlot.Series
         {
             if (items == null)
             {
-                throw new ArgumentNullException("items");
+                throw new ArgumentNullException(nameof(items));
             }
 
             this.IsXMonotonic = true;
@@ -624,7 +621,7 @@ namespace OxyPlot.Series
         {
             if (items == null)
             {
-                throw new ArgumentNullException("items");
+                throw new ArgumentNullException(nameof(items));
             }
 
             this.IsXMonotonic = true;
@@ -775,7 +772,10 @@ namespace OxyPlot.Series
             int start = 0;
             int nominalEnd = items.Count - 1;
             while (nominalEnd > 0 && double.IsNaN(xgetter(items[nominalEnd])))
-                nominalEnd -= 1;
+            {
+                nominalEnd--;
+            }
+
             int end = nominalEnd;
             int curGuess = Math.Max(0, Math.Min(end, initialGuess));
 
@@ -785,9 +785,13 @@ namespace OxyPlot.Series
                 {
                     double guessX = xgetter(items[index]);
                     if (double.IsNaN(guessX))
-                        index += 1;
+                    {
+                        index++;
+                    }
                     else
+                    {
                         return guessX;
+                    }
                 }
                 return xgetter(items[nominalEnd]);
             }
@@ -805,7 +809,7 @@ namespace OxyPlot.Series
                     end = curGuess - 1;
                 }
                 else
-                { 
+                {
                     start = curGuess;
                 }
 
@@ -818,13 +822,15 @@ namespace OxyPlot.Series
                 double startX = GetX(start);
 
                 var m = (end - start + 1) / (endX - startX);
-                
+
                 curGuess = start + (int)((targetX - startX) * m);
                 curGuess = Math.Max(start + 1, Math.Min(curGuess, end));
             }
 
             while (start > 0 && (xgetter(items[start]) > targetX))
-                start -= 1;
+            {
+                start--;
+            }
 
             return start;
         }


### PR DESCRIPTION
### Checklist

- [X] I have included examples or tests (no need, they already exist)
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Update `net40`/`net45` to `net452` cf #1835
- Tidy up and modernise code
- Tidy up `ContourSeries`, `DataPointSeries`, `ExtrapolationLineSeries`, `FunctionSeries`, `HeatMapSeries`, `HistogramSeries`, `ItemsSeries`, `LineSeries`, `RectangleSeries`, `ScatterErrorSeries`, `ScatterSeries`, `StairStepSeries`, `StemSeries`, `TwoColorAreaSeries`, `TwoColorLineSeries`, `XYAxisSeries`
- Improve render performance of `BoxPlotSeries` (legend only), `HighLowSeries` , `CandleStickAndVolumeSeries`, `CandleStickSeries`, `VolumeSeries`, `PieSeries` - instead of calling render every time in the loop, it's called only once

One element that would need a particular review is `Source/OxyPlot.Wpf/XpsExporter.cs` where I'm not sure that replacing `#if !NET40` by `#if !NETFRAMEWORK` is correct?

@VisualMelon 
