### PR TITLE
So far only LabelFormatString moved to the base class, I would provide GetFormattedLabel method as  a separate commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ## [2.1.0] - 2021-10-02
 
 ### Added
+- It should be possible to create a method string GetFormattedLabel(object item) in ItemsSeries (#236)
 - Made Legend Items clickable to toggle series visibility (#644)
 - Added properties LegendKey and SeriesGroupName to Series, allowing grouping series between multiple legends and/or within same legend (#644)
 - OxyPlot.ImageSharp (#1188)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,6 +75,7 @@ kc1212 <kc04bc@gmx.com>
 kenny_evoleap
 Kenny Nygaard
 Kevin Crowell <crowell@proteinmetrics.com>
+Koto <ouad.second@gmail.com>
 Kyle Pulvermacher
 LECO® Corporation
 Levi Botelho <levi_botelho@hotmail.com>

--- a/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/FlagSeries.cs
@@ -9,6 +9,7 @@
 
 namespace ExampleLibrary
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -231,6 +232,12 @@ namespace ExampleLibrary
         {
             this.MinimumX = this.Values.Min();
             this.MaximumX = this.Values.Max();
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            throw GetFormattedLabelNotSupported();
         }
     }
 }

--- a/Source/OxyPlot.Tests/Series/FormatLabelTests.cs
+++ b/Source/OxyPlot.Tests/Series/FormatLabelTests.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+using OxyPlot.Series;
+using System;
+using System.Threading;
+
+namespace OxyPlot.Tests.Series
+{
+    class BarSeriesForTest : BarSeries
+    {
+        public string GetFormattedLabel(BarItem item)
+        {
+            return base.GetFormattedLabel(item);
+        }
+    }
+
+    class HistogramSeriesForTest : HistogramSeries
+    {
+        public string GetFormattedLabel(HistogramItem item)
+        {
+            return base.GetFormattedLabel(item);
+        }
+    }
+
+    class IntervalBarSeriesForTest : IntervalBarSeries
+    {
+        public string GetFormattedLabel(IntervalBarItem item)
+        {
+            return base.GetFormattedLabel(item);
+        }
+    }
+    
+
+    /// <summary>
+    /// Contains the unit tests for formatting series label <see cref="ItemsSeries"/> struct.
+    /// </summary
+    [TestFixture]
+    internal class FormatLabelTests
+    {
+        [Test]
+        public void TestEmptyLabelForUnsetLabelFormat()
+        {
+            var bs = new BarSeriesForTest();
+            Assert.IsNull(bs.LabelFormatString);
+            Assert.AreEqual(bs.GetFormattedLabel(new BarItem(1.0)), "");
+        }
+
+        [Test]
+        [TestCase(1.0, "{0}", "1")]
+        [TestCase(1.0, "{0:0}", "1")]
+        public void TestBarItemLabelFormat(double value, string format, string expectedResult)
+        {
+            var bs = new BarSeriesForTest();
+            bs.LabelFormatString = format;
+            Assert.AreEqual(bs.GetFormattedLabel(new BarItem(value)), expectedResult);
+        }
+
+        [Test]
+        public void TestHistogramItemLabelFormat()
+        {
+            var hs = new HistogramSeriesForTest();
+            hs.LabelFormatString = "Start: {1:0.00}\nEnd: {2:0.00}\nValue: {0:0.00}\nArea: {3:0.00}\nCount: {4}";
+
+            char sep = Convert.ToChar(Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+            var expected = $"Start: 1{sep}00\nEnd: 2{sep}00\nValue: 4{sep}00\nArea: 4{sep}00\nCount: 4";
+            Assert.AreEqual(hs.GetFormattedLabel(new HistogramItem(1, 2, 4, 4)) , expected);
+        }
+
+        [Test]
+        public void TestIntervalBarItemLabelFormat()
+        {
+            var ibs = new IntervalBarSeriesForTest();
+            ibs.LabelFormatString = "{0} - {1}";
+            Assert.AreEqual(ibs.GetFormattedLabel(new IntervalBarItem(1.0, 5.0)), "1 - 5");
+        }
+
+        
+    }
+}

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -71,12 +71,6 @@ namespace OxyPlot.Series
         public bool OverlapsStack { get; set; }
 
         /// <summary>
-        /// Gets or sets the label format string.
-        /// </summary>
-        /// <value>The label format string.</value>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the label margins.
         /// </summary>
         public double LabelMargin { get; set; }

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -11,6 +11,7 @@ namespace OxyPlot.Series
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
 
     /// <summary>
@@ -300,7 +301,7 @@ namespace OxyPlot.Series
             double categoryValue,
             double categoryEndValue)
         {
-            var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, item.Value);
+            var s = GetFormattedLabel(item);
             HorizontalAlignment ha;
             ScreenPoint pt;
             var y = (categoryEndValue + categoryValue) / 2;
@@ -439,6 +440,17 @@ namespace OxyPlot.Series
                 args => new BarItem(Convert.ToDouble(args[0])) { Color = (OxyColor)args[1] });
 
             return true;
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            if (this.LabelFormatString == null)
+                return "";
+
+                return GetFormattedLabel<BarItem>(item, (BarItem barItem) => {
+                return StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, barItem.Value);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
@@ -76,11 +76,6 @@ namespace OxyPlot.Series
         public OxyColor LabelColor { get; set; }
 
         /// <summary>
-        /// Gets or sets the format string for the maximum labels.
-        /// </summary>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the label margins.
         /// </summary>
         public double LabelMargin { get; set; }

--- a/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
@@ -223,7 +223,7 @@ namespace OxyPlot.Series
 
                 if (this.LabelFormatString != null)
                 {
-                    var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, this.GetItem(i), item.Start, item.End, item.Title);
+                    var s = GetFormattedLabel(this.GetItem(i)); 
 
                     var pt = new ScreenPoint(
                         (rectangle.Left + rectangle.Right) / 2, (rectangle.Top + rectangle.Bottom) / 2);
@@ -260,6 +260,14 @@ namespace OxyPlot.Series
                 args => new IntervalBarItem(Convert.ToDouble(args[0]), Convert.ToDouble(args[1])) { Color = (OxyColor)args[2] });
 
             return true;
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            return GetFormattedLabel<IntervalBarItem>(item, (IntervalBarItem intervalBarItem) => {
+                return StringHelper.Format(this.ActualCulture, this.LabelFormatString, intervalBarItem, intervalBarItem.Start, intervalBarItem.End, intervalBarItem.Title);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
@@ -73,11 +73,6 @@ namespace OxyPlot.Series
         public OxyColor LabelColor { get; set; }
 
         /// <summary>
-        /// Gets or sets the format string for the labels.
-        /// </summary>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the color of the border around the rectangles.
         /// </summary>
         /// <value>The color of the stroke.</value>

--- a/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
@@ -190,15 +190,7 @@ namespace OxyPlot.Series
 
                 if (this.LabelFormatString != null)
                 {
-                    var s = StringHelper.Format(
-                        this.ActualCulture,
-                        this.LabelFormatString,
-                        this.GetItem(i),
-                        item.X0,
-                        item.X1,
-                        item.Y0,
-                        item.Y1,
-                        item.Title);
+                    var s = GetFormattedLabel(this.GetItem(i));
 
                     var pt = new ScreenPoint(
                         (rectangle.Left + rectangle.Right) / 2, (rectangle.Top + rectangle.Bottom) / 2);
@@ -325,6 +317,22 @@ namespace OxyPlot.Series
         protected virtual bool IsValid(double v)
         {
             return !double.IsNaN(v) && !double.IsInfinity(v);
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            return GetFormattedLabel<RectangleBarItem>(item, (RectangleBarItem rectangleBarItem) => {
+                return StringHelper.Format(
+                    this.ActualCulture,
+                    this.LabelFormatString,
+                    rectangleBarItem,
+                    rectangleBarItem.X0,
+                    rectangleBarItem.X1,
+                    rectangleBarItem.Y0,
+                    rectangleBarItem.Y1,
+                    rectangleBarItem.Title);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
@@ -362,12 +362,6 @@ namespace OxyPlot.Series
             return true;
         }
 
-        /// <inheritdoc/>
-        protected override string GetFormattedLabel(object item)
-        {
-            throw GetInvalidOverloadUsed();
-        }
-
         /// <summary>
         /// Returns formatted label
         /// </summary>

--- a/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
@@ -227,11 +227,7 @@ namespace OxyPlot.Series
 
                 if (this.MinimumLabelFormatString != null)
                 {
-                    var s = StringHelper.Format(
-                        this.ActualCulture,
-                        this.MinimumLabelFormatString,
-                        this.GetItem(this.ValidItemsIndexInversion[i]),
-                        item.Minimum);
+                    var s = GetFormattedLabel(this.GetItem(this.ValidItemsIndexInversion[i]), true);
 
                     var pt = this.Transform(item.Minimum, barMid) - marginVector;
                     var ha = HorizontalAlignment.Right;
@@ -252,12 +248,8 @@ namespace OxyPlot.Series
 
                 if (this.MaximumLabelFormatString != null)
                 {
-                    var s = StringHelper.Format(
-                        this.ActualCulture,
-                        this.MaximumLabelFormatString,
-                        this.GetItem(this.ValidItemsIndexInversion[i]),
-                        item.Maximum);
-
+                    var s = GetFormattedLabel(this.GetItem(this.ValidItemsIndexInversion[i]), false);
+                    
                     var pt = this.Transform(item.Maximum, barMid) + marginVector;
                     var ha = HorizontalAlignment.Left;
                     var va = VerticalAlignment.Middle;
@@ -368,6 +360,29 @@ namespace OxyPlot.Series
                 });
 
             return true;
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            throw GetInvalidOverloadUsed();
+        }
+
+        /// <summary>
+        /// Returns formatted label
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="minimum"></param>
+        /// <returns></returns>
+        string GetFormattedLabel(object item, bool minimum)
+        {
+            return GetFormattedLabel<TornadoBarItem>(item, (TornadoBarItem tornadoBarItem) => {
+                return StringHelper.Format(
+                      this.ActualCulture,
+                      minimum ? this.MinimumLabelFormatString : this.MaximumLabelFormatString,
+                      item,
+                      minimum ? tornadoBarItem.Minimum : tornadoBarItem.Maximum);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -113,12 +113,6 @@ namespace OxyPlot.Series
         public OxyColor LabelBackground { get; set; }
 
         /// <summary>
-        /// Gets or sets the format string for contour values.
-        /// </summary>
-        /// <value>The format string.</value>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the label spacing, which is the space between labels on the same contour. Not used if <see cref="MultiLabel"/>==<see langword="false"/>
         /// </summary>
         /// <value>The label spacing.</value>

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -448,8 +448,7 @@ namespace OxyPlot.Series
                 angle += 180;
             }
 
-            var formatString = string.Concat("{0:", this.LabelFormatString, "}");
-            var text = string.Format(this.ActualCulture, formatString, contour.ContourLevel);
+            var text = GetFormattedLabel(contour);
             contourLabels.Add(new ContourLabel { Position = pos, Angle = angle, Text = text });
         }
 
@@ -632,7 +631,17 @@ namespace OxyPlot.Series
                            };
             rc.DrawPolygon(bpts, this.LabelBackground, OxyColors.Undefined, 0, this.EdgeRenderingMode);
         }
-
+                
+        /// <summary>
+        /// Returns formatted label
+        /// </summary>
+        /// <param name="contour">The contour</param>
+        /// <returns></returns>
+        string GetFormattedLabel(Contour contour)
+        {
+            var formatString = string.Concat("{0:", this.LabelFormatString, "}");
+            return string.Format(this.ActualCulture, formatString, contour.ContourLevel);
+        }
 
         /// <summary>
         /// Represents one of the two points of a segment.

--- a/Source/OxyPlot/Series/FinancialSeries/HighLowSeries.cs
+++ b/Source/OxyPlot/Series/FinancialSeries/HighLowSeries.cs
@@ -320,7 +320,7 @@ namespace OxyPlot.Series
                     LineJoin.Miter);
             }
         }
-
+                
         /// <summary>
         /// Sets the default values.
         /// </summary>

--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -172,13 +172,6 @@ namespace OxyPlot.Series
         public HeatMapRenderMethod RenderMethod { get; set; }
 
         /// <summary>
-        /// Gets or sets the format string for the cell labels. The default value is <c>0.00</c>.
-        /// </summary>
-        /// <value>The format string.</value>
-        /// <remarks>The label format string is only used when <see cref="LabelFontSize" /> is greater than 0.</remarks>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the font size of the labels. The default value is <c>0</c> (labels not visible).
         /// </summary>
         /// <value>The font size relative to the cell height.</value>

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -87,12 +87,6 @@ namespace OxyPlot.Series
         public double MaxValue { get; private set; }
 
         /// <summary>
-        /// Gets or sets the format string for the cell labels. The default value is <c>0.00</c>.
-        /// </summary>
-        /// <value>The format string.</value>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the label margins.
         /// </summary>
         public double LabelMargin { get; set; }

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -47,7 +47,6 @@ namespace OxyPlot.Series
             this.StrokeColor = OxyColors.Black;
             this.StrokeThickness = 0;
             this.TrackerFormatString = DefaultTrackerFormatString;
-            this.LabelFormatString = null;
             this.LabelPlacement = LabelPlacement.Outside;
             this.ColorMapping = this.GetDefaultColor;
         }
@@ -329,7 +328,7 @@ namespace OxyPlot.Series
         /// <param name="item">The item.</param>
         protected void RenderLabel(IRenderContext rc, OxyRect rect, HistogramItem item)
         {
-            var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, item.Value, item.RangeStart, item.RangeEnd, item.Area, item.Count);
+            var s = GetFormattedLabel(item);
             DataPoint dp;
             VerticalAlignment va;
             var ha = HorizontalAlignment.Center;
@@ -447,6 +446,22 @@ namespace OxyPlot.Series
             {
                 this.actualItems.AddRange(sourceAsEnumerableHistogramItems);
             }
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            return GetFormattedLabel<HistogramItem>(item, (HistogramItem histogramItem) => {
+                return StringHelper.Format(
+                        this.ActualCulture,
+                        this.LabelFormatString,
+                        histogramItem,
+                        histogramItem.Value,
+                        histogramItem.RangeStart,
+                        histogramItem.RangeEnd,
+                        histogramItem.Area,
+                        histogramItem.Count);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/ItemsSeries.cs
+++ b/Source/OxyPlot/Series/ItemsSeries.cs
@@ -62,5 +62,14 @@ namespace OxyPlot.Series
         {
             return GetItem(this.ItemsSource, i);
         }
+
+        /// <summary>
+        /// Gets or sets the format string for the maximum labels.
+        /// </summary>
+        public string LabelFormatString 
+        { 
+            get; 
+            set; 
+        }
     }
 }

--- a/Source/OxyPlot/Series/ItemsSeries.cs
+++ b/Source/OxyPlot/Series/ItemsSeries.cs
@@ -108,11 +108,5 @@ namespace OxyPlot.Series
         /// </summary>
         /// <returns></returns>
         protected Exception GetInvalidItemType() { return new InvalidOperationException("Invalid item type"); }
-
-        /// <summary>
-        /// Returns exception to be thrown when not valid GetFormattedLabel method's overload is used.
-        /// </summary>
-        /// <returns></returns>
-        protected Exception GetInvalidOverloadUsed() { return new InvalidOperationException("Invalid overload of GetFormattedLabel used"); }
     }
 }

--- a/Source/OxyPlot/Series/ItemsSeries.cs
+++ b/Source/OxyPlot/Series/ItemsSeries.cs
@@ -62,5 +62,15 @@ namespace OxyPlot.Series
         {
             return GetItem(this.ItemsSource, i);
         }
+
+        /// <summary>
+        /// Gets or sets the format string for the item's label.
+        /// </summary>
+        public string LabelFormatString 
+        { 
+            get; 
+            set; 
+        }
+
     }
 }

--- a/Source/OxyPlot/Series/ItemsSeries.cs
+++ b/Source/OxyPlot/Series/ItemsSeries.cs
@@ -9,6 +9,7 @@
 
 namespace OxyPlot.Series
 {
+    using System;
     using System.Collections;
     using System.Linq;
 
@@ -72,5 +73,46 @@ namespace OxyPlot.Series
             set; 
         }
 
+        /// <summary>
+        /// Returns formatted label
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        protected abstract string GetFormattedLabel(object item);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="formatter">The code actually doing formatting</param>
+        /// <returns></returns>
+        protected string GetFormattedLabel<T>(object item, Func<T, string> formatter)
+        {
+            if (item == null)
+                return "";
+
+            if (item is T typedItem)
+                return formatter(typedItem);
+
+            throw GetInvalidItemType();
+        }
+
+        /// <summary>
+        /// Returns exception to be thrown when derived class is not supporting GetFormattedLabel method.
+        /// </summary>
+        /// <returns></returns>
+        protected Exception GetFormattedLabelNotSupported() { return new InvalidOperationException("GetFormattedLabel is not valid for this class"); }
+
+        /// <summary>
+        /// Returns exception to be thrown when item send to GetFormattedLabel method is not of the expected type.
+        /// </summary>
+        /// <returns></returns>
+        protected Exception GetInvalidItemType() { return new InvalidOperationException("Invalid item type"); }
+
+        /// <summary>
+        /// Returns exception to be thrown when not valid GetFormattedLabel method's overload is used.
+        /// </summary>
+        /// <returns></returns>
+        protected Exception GetInvalidOverloadUsed() { return new InvalidOperationException("Invalid overload of GetFormattedLabel used"); }
     }
 }

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -607,7 +607,7 @@ namespace OxyPlot.Series
                 var pt = this.Transform(point) + new ScreenVector(0, -this.LabelMargin);
 
                 var item = this.GetItem(index);
-                var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, point.X, point.Y);
+                var s = GetFormattedLabel(item, point);
 
 #if SUPPORTLABELPLACEMENT
                     switch (this.LabelPlacement)
@@ -760,6 +760,22 @@ namespace OxyPlot.Series
         {
             double tolerance = Math.Abs(Math.Max(this.MaxX - this.MinX, this.MaxY - this.MinY) / ToleranceDivisor);
             this.smoothedPoints = this.InterpolationAlgorithm.CreateSpline(this.ActualPoints, false, tolerance);
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            throw GetInvalidOverloadUsed();
+        }
+
+        /// <summary>
+        /// Gets or sets the format string for the item's label.
+        /// </summary>
+        protected string GetFormattedLabel(object item, DataPoint point)
+        {
+            return GetFormattedLabel<object>(item, (object barItem) => {
+                return StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, point.X, point.Y);
+            });
         }
 
         /// <summary>

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -762,11 +762,6 @@ namespace OxyPlot.Series
             this.smoothedPoints = this.InterpolationAlgorithm.CreateSpline(this.ActualPoints, false, tolerance);
         }
 
-        /// <inheritdoc/>
-        protected override string GetFormattedLabel(object item)
-        {
-            throw GetInvalidOverloadUsed();
-        }
 
         /// <summary>
         /// Gets or sets the format string for the item's label.

--- a/Source/OxyPlot/Series/LineSeries.cs
+++ b/Source/OxyPlot/Series/LineSeries.cs
@@ -123,12 +123,6 @@ namespace OxyPlot.Series
         public Action<List<ScreenPoint>, List<ScreenPoint>> Decimator { get; set; }
 
         /// <summary>
-        /// Gets or sets the label format string. The default is <c>null</c> (no labels).
-        /// </summary>
-        /// <value>The label format string.</value>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the label margins. The default is <c>6</c>.
         /// </summary>
         public double LabelMargin { get; set; }

--- a/Source/OxyPlot/Series/PieSeries.cs
+++ b/Source/OxyPlot/Series/PieSeries.cs
@@ -489,5 +489,11 @@ namespace OxyPlot.Series
         protected internal override void UpdateMaxMin()
         {
         }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            throw GetFormattedLabelNotSupported(); 
+        }
     }
 }

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -210,15 +210,15 @@
                 if (this.LabelFontSize > 0)
                 {
                     rc.DrawText(
-                        rectrect.Center, 
-                        item.Value.ToString(this.LabelFormatString), 
-                        this.ActualTextColor, 
-                        this.ActualFont, 
-                        this.LabelFontSize, 
-                        this.ActualFontWeight, 
-                        0, 
-                        HorizontalAlignment.Center, 
-                        VerticalAlignment.Middle);
+                        rectrect.Center,
+                        GetFormattedLabel(item),
+                        this.ActualTextColor,
+                        this.ActualFont,
+                        this.LabelFontSize,
+                        this.ActualFontWeight,
+                        0,
+                        HorizontalAlignment.Center,
+                        VerticalAlignment.Middle); ;
                 }
             }
         }
@@ -346,6 +346,14 @@
             this.UpdateMaxMinXY();
 
             return p.X >= this.MinX && p.X <= this.MaxX && p.Y >= this.MinY && p.Y <= this.MaxY;
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            return GetFormattedLabel<RectangleItem>(item, (RectangleItem rectangleItem) => {
+                return rectangleItem.Value.ToString(this.LabelFormatString);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/RectangleSeries.cs
+++ b/Source/OxyPlot/Series/RectangleSeries.cs
@@ -64,13 +64,6 @@
         public string ColorAxisKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the format string for the cell labels. The default value is <c>0.00</c>.
-        /// </summary>
-        /// <value>The format string.</value>
-        /// <remarks>The label format string is only used when <see cref="LabelFontSize" /> is greater than 0.</remarks>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the font size of the labels. The default value is <c>0</c> (labels not visible).
         /// </summary>
         /// <value>The font size relative to the cell height.</value>

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -62,12 +62,6 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
-        /// Gets or sets the label format string. The default is <c>null</c> (no labels).
-        /// </summary>
-        /// <value>The label format string.</value>
-        public string LabelFormatString { get; set; }
-
-        /// <summary>
         /// Gets or sets the label margins. The default is <c>6</c>.
         /// </summary>
         public double LabelMargin { get; set; }

--- a/Source/OxyPlot/Series/ScatterSeries{T}.cs
+++ b/Source/OxyPlot/Series/ScatterSeries{T}.cs
@@ -553,7 +553,8 @@ namespace OxyPlot.Series
                 }
 
                 var item = this.GetItem(index);
-                var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, point.X, point.Y);
+
+                var s = GetFormattedLabel(item, dataPoint);
 
 #if SUPPORTLABELPLACEMENT
                     switch (this.LabelPlacement)
@@ -845,6 +846,19 @@ namespace OxyPlot.Series
 
             // Use reflection to add scatter points
             this.UpdateFromDataFields();
+        }
+
+        /// <summary>
+        /// Returns formatted label
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="point">The point.</param>
+        /// <returns></returns>
+        protected string GetFormattedLabel(object item, DataPoint point)
+        {
+            return GetFormattedLabel<object>(item, (object barItem) => {
+                return StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, point.X, point.Y);
+            });
         }
     }
 }

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -828,5 +828,11 @@ namespace OxyPlot.Series
 
             return start;
         }
+
+        /// <inheritdoc/>
+        protected override string GetFormattedLabel(object item)
+        {
+            throw GetFormattedLabelNotSupported();
+        }
     }
 }


### PR DESCRIPTION
#236 Most series contains a LabelFormatString property. I think this property can be moved to ItemsSeries

Fixes # .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-

@oxyplot/admins
