### PR TITLE
Fix WPF Dpi Regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Odd behavior of zooming of Logarithmic axis in Cartesian plot (#1825)
 - SkiaSharp.WPF - OxyPlot doesn't render inside an ElementHost (#1800)
 - NullReference in SkiaSharp WPF renderer if UIElement has no PresentationSource  (#1798)
+- WPF DPI Regression (#1799)
 
 ## [2.1.0] - 2021-10-02
 

--- a/Source/OxyPlot.Wpf/PlotView.cs
+++ b/Source/OxyPlot.Wpf/PlotView.cs
@@ -127,6 +127,7 @@ namespace OxyPlot.Wpf
         protected override double UpdateDpi()
         {
             var scale = base.UpdateDpi();
+            this.RenderContext.DpiScale = scale;
             var ancestor = this.GetAncestorVisualFromVisualTree(this);
             this.RenderContext.VisualOffset = ancestor != null ? this.TransformToAncestor(ancestor).Transform(default) : default;
             return scale;


### PR DESCRIPTION
Fixes a regression for non-Skia WPF in #1799

### Checklist

- [ ] I have included examples or tests: see e.g. axes lines which should be sharp regardless of DPI
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Introduce assignment of `RenderContext.DpiScale` for WPF

@oxyplot/admins
