### PR TITLE
Make minimum segment lengths more consistent and configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add LineThickness property to TrackerControl (#1831)
+- Add properties for `MinimumSegmentLength` to series and annotations (#1853)
 
 ### Changed
 - Update net40 and net45 to net452 (#1835)
+- Change default `MinimumSegmentLength` to `2` and remove limits for series and annotations with simple geometry (#1853)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add LineThickness property to TrackerControl (#1831)
 - Add properties for `MinimumSegmentLength` to series and annotations (#1853)
+- Add fractal examples for PolygonAnnotation and PolylineAnnotations (#1853)
 
 ### Changed
 - Update net40 and net45 to net452 (#1835)

--- a/Source/Examples/ExampleLibrary/Annotations/PolygonAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/PolygonAnnotationExamples.cs
@@ -76,5 +76,83 @@ namespace ExampleLibrary
             model.Series.Add(new FunctionSeries(Math.Sin, -20, 30, 400));
             return model;
         }
+
+        [Example("Koch Snowflakes")]
+        public static PlotModel KockSnowflakes()
+        {
+            DataPoint[] triangle(DataPoint centre)
+            {
+                return new[]
+                {
+                    new DataPoint(centre.X, centre.Y + 1),
+                    new DataPoint(centre.X + Math.Sin(Math.PI * 2 / 3), centre.Y + Math.Cos(Math.PI * 2 / 3)),
+                    new DataPoint(centre.X + Math.Sin(Math.PI * 4 / 3), centre.Y + Math.Cos(Math.PI * 4 / 3)),
+                };
+            }
+
+            var model = new PlotModel { Title = "PolygonAnnotation", PlotType = PlotType.Cartesian };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -4, Maximum = 4 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -2, Maximum = 2 });
+
+            var a1 = new PolygonAnnotation { Text = "MSL = 4", MinimumSegmentLength = 4 };
+            a1.Points.AddRange(KochFractal(triangle(new DataPoint(-2, 0)), 8, true, true));
+            model.Annotations.Add(a1);
+
+            var a2 = new PolygonAnnotation { Text = "MSL = 2", MinimumSegmentLength = 2 };
+            a2.Points.AddRange(KochFractal(triangle(new DataPoint(0, 0)), 8, true, true));
+            model.Annotations.Add(a2);
+
+            var a3 = new PolygonAnnotation { Text = "MSL = 1", MinimumSegmentLength = 1 };
+            a3.Points.AddRange(KochFractal(triangle(new DataPoint(2, 0)), 8, true, true));
+            model.Annotations.Add(a3);
+
+            return model;
+        }
+
+        public static DataPoint[] KochFractal(DataPoint[] seed, int n, bool clockwise, bool closed)
+        {
+            var cos60 = Math.Cos(Math.PI / 3);
+            var sin60 = Math.Sin(Math.PI / 3);
+            var cur = seed;
+
+            for (int i = 0; i < n; i++)
+            {
+                var next = new DataPoint[closed ? cur.Length * 4 : cur.Length * 4 - 3];
+                for (int j = 0; j < (closed ? cur.Length : cur.Length - 1); j++)
+                {
+                    var p0 = cur[j];
+                    var p1 = cur[(j + 1) % cur.Length];
+
+                    var dx = (p1.X - p0.X) / 3;
+                    var dy = (p1.Y - p0.Y) / 3;
+
+                    double dx2, dy2;
+                    if (clockwise)
+                    {
+                        dx2 = cos60 * dx - sin60 * dy;
+                        dy2 = cos60 * dy + sin60 * dx;
+                    }
+                    else
+                    {
+                        dx2 = cos60 * dx - sin60 * dy;
+                        dy2 = cos60 * dy + sin60 * dx;
+                    }
+
+                    next[j * 4] = p0;
+                    next[j * 4 + 1] = new DataPoint(p0.X + dx, p0.Y + dy);
+                    next[j * 4 + 2] = new DataPoint(p0.X + dx + dx2, p0.Y + dy + dy2);
+                    next[j * 4 + 3] = new DataPoint(p0.X + dx * 2, p0.Y + dy * 2);
+                }
+
+                if (!closed)
+                {
+                    next[next.Length - 1] = cur[cur.Length - 1];
+                }
+
+                cur = next;
+            }
+
+            return cur;
+        }
     }
 }

--- a/Source/Examples/ExampleLibrary/Annotations/PolylineAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/PolylineAnnotationExamples.cs
@@ -31,5 +31,36 @@ namespace ExampleLibrary
             model.Annotations.Add(a2);
             return model;
         }
+
+        [Example("Koch Surfaces")]
+        public static PlotModel KochSurface()
+        {
+            DataPoint[] plane(DataPoint centre)
+            {
+                return new[]
+                {
+                    new DataPoint(centre.X - 1, centre.Y),
+                    new DataPoint(centre.X + 1, centre.Y),
+                };
+            }
+
+            var model = new PlotModel { Title = "PolygonAnnotation", PlotType = PlotType.Cartesian };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -2, Maximum = 2 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -2, Maximum = 2 });
+
+            var a1 = new PolylineAnnotation { Text = "MSL = 4", MinimumSegmentLength = 4, LineStyle = LineStyle.Solid, TextPosition = new DataPoint(0, 1) };
+            a1.Points.AddRange(PolygonAnnotationExamples.KochFractal(plane(new DataPoint(0, 1)), 8, true, false));
+            model.Annotations.Add(a1);
+
+            var a2 = new PolylineAnnotation { Text = "MSL = 2", MinimumSegmentLength = 2, LineStyle = LineStyle.Solid, TextPosition = new DataPoint(0, 0) };
+            a2.Points.AddRange(PolygonAnnotationExamples.KochFractal(plane(new DataPoint(0, 0)), 8, true, false));
+            model.Annotations.Add(a2);
+
+            var a3 = new PolylineAnnotation { Text = "MSL = 1", MinimumSegmentLength = 1, LineStyle = LineStyle.Solid, TextPosition = new DataPoint(0, -1) };
+            a3.Points.AddRange(PolygonAnnotationExamples.KochFractal(plane(new DataPoint(0, -1)), 8, true, false));
+            model.Annotations.Add(a3);
+
+            return model;
+        }
     }
 }

--- a/Source/Examples/ExampleLibrary/CustomSeries/ErrorSeries.cs
+++ b/Source/Examples/ExampleLibrary/CustomSeries/ErrorSeries.cs
@@ -114,7 +114,7 @@ namespace ExampleLibrary
             {
                 rc.DrawReducedLine(
                     new[] { segments[i], segments[i + 1] },
-                    2,
+                    0,
                     this.GetSelectableColor(this.Color),
                     this.StrokeThickness,
                     this.EdgeRenderingMode,

--- a/Source/OxyPlot/Annotations/ArrowAnnotation.cs
+++ b/Source/OxyPlot/Annotations/ArrowAnnotation.cs
@@ -122,7 +122,7 @@ namespace OxyPlot.Annotations
             var p3 = p1 - (n * this.HeadWidth * this.StrokeThickness);
             var p4 = p1 + (d * this.Veeness * this.StrokeThickness);
 
-            const double MinimumSegmentLength = 4;
+            const double MinimumSegmentLength = 0;
 
             var dashArray = this.LineStyle.GetDashArray();
 

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -42,6 +42,7 @@ namespace OxyPlot.Annotations
             this.TextMargin = 12;
             this.TextHorizontalAlignment = HorizontalAlignment.Right;
             this.TextVerticalAlignment = VerticalAlignment.Top;
+            this.MinimumSegmentLength = 2;
         }
 
         /// <summary>
@@ -115,6 +116,14 @@ namespace OxyPlot.Annotations
         public double TextLinePosition { get; set; }
 
         /// <summary>
+        /// Gets or sets the minimum length of the segment.
+        /// Increasing this number will increase performance,
+        /// but make curves less accurate. The default is <c>2</c>.
+        /// </summary>
+        /// <value>The minimum length of the segment.</value>
+        public double MinimumSegmentLength { get; set; }
+
+        /// <summary>
         /// Gets or sets the actual minimum value on the x axis.
         /// </summary>
         /// <value>The actual minimum value on the x axis.</value>
@@ -152,8 +161,6 @@ namespace OxyPlot.Annotations
 
             this.screenPoints = this.GetScreenPoints();
 
-            const double MinimumSegmentLength = 4;
-
             var clippedPoints = new List<ScreenPoint>();
             var dashArray = this.LineStyle.GetDashArray();
 
@@ -161,7 +168,7 @@ namespace OxyPlot.Annotations
             {
                 rc.DrawReducedLine(
                    this.screenPoints,
-                   MinimumSegmentLength * MinimumSegmentLength,
+                   this.MinimumSegmentLength * this.MinimumSegmentLength,
                    this.GetSelectableColor(this.Color),
                    this.StrokeThickness,
                    this.EdgeRenderingMode,

--- a/Source/OxyPlot/Annotations/PolyLineAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PolyLineAnnotation.cs
@@ -35,14 +35,6 @@ namespace OxyPlot.Annotations
         }
 
         /// <summary>
-        /// Gets or sets the minimum length of the segment.
-        /// Increasing this number will increase performance,
-        /// but make the curve less accurate.
-        /// </summary>
-        /// <value>The minimum length of the segment.</value>
-        public double MinimumSegmentLength { get; set; }
-
-        /// <summary>
         /// Gets or sets the interpolation algorithm.
         /// </summary>
         /// <value>An interpolation algorithm.</value>

--- a/Source/OxyPlot/Annotations/PolygonAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PolygonAnnotation.cs
@@ -30,6 +30,8 @@ namespace OxyPlot.Annotations
         {
             this.LineStyle = LineStyle.Solid;
             this.LineJoin = LineJoin.Miter;
+            this.MinimumSegmentLength = 2;
+
             this.Points = new List<DataPoint>();
         }
 
@@ -44,6 +46,14 @@ namespace OxyPlot.Annotations
         /// </summary>
         /// <value>The line style.</value>
         public LineStyle LineStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum length of the segment.
+        /// Increasing this number will increase performance,
+        /// but make the polygon less accurate. The default is <c>2</c>.
+        /// </summary>
+        /// <value>The minimum length of the segment.</value>
+        public double MinimumSegmentLength { get; set; }
 
         /// <summary>
         /// Gets the points.
@@ -67,11 +77,9 @@ namespace OxyPlot.Annotations
                 return;
             }
 
-            const double MinimumSegmentLength = 4;
-
             rc.DrawReducedPolygon(
                 this.screenPoints,
-                MinimumSegmentLength * MinimumSegmentLength,
+                this.MinimumSegmentLength * this.MinimumSegmentLength,
                 this.GetSelectableFillColor(this.Fill),
                 this.GetSelectableColor(this.Stroke),
                 this.StrokeThickness,

--- a/Source/OxyPlot/Series/ContourSeries.cs
+++ b/Source/OxyPlot/Series/ContourSeries.cs
@@ -54,6 +54,7 @@ namespace OxyPlot.Series
             this.Color = OxyColors.Automatic;
             this.StrokeThickness = 1.0;
             this.LineStyle = LineStyle.Solid;
+            this.MinimumSegmentLength = 2;
 
             this.TrackerFormatString = DefaultTrackerFormatString;
         }
@@ -152,6 +153,14 @@ namespace OxyPlot.Series
         /// </summary>
         /// <value>The stroke thickness.</value>
         public double StrokeThickness { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum length of the segment.
+        /// Increasing this number will increase performance,
+        /// but make the curve less accurate. The default is <c>2</c>.
+        /// </summary>
+        /// <value>The minimum length of the segment.</value>
+        public double MinimumSegmentLength { get; set; }
 
         /// <summary>
         /// Calculates the contours.
@@ -292,7 +301,7 @@ namespace OxyPlot.Series
 
                 rc.DrawReducedLine(
                     transformedPoints,
-                    4,
+                    this.MinimumSegmentLength * this.MinimumSegmentLength,
                     this.GetSelectableColor(strokeColor),
                     this.StrokeThickness,
                     this.EdgeRenderingMode,


### PR DESCRIPTION
Fixes #1853 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add properties for `MinimumSegmentLength` to series and annotations (#1853)
- Change default `MinimumSegmentLength` to `2` and remove limits for series and annotations with simple geometry (#1853)
- Add fractal examples for PolygonAnnotation and PolylineAnnotations (#1853)

### Detailed notes

 - `PolyLineAnnotation` appears to have previously defaulted to `0` (though not explicitly), now defaults to `2`, inheriting from `PathAnnotation`.
 - `ArrowAnnotation` used to have a hard-coded default of `4`; changed to be hard-coded to 0 since it only has simple geometry.
 - `ErrorSeries` used to have a hard-coded default of `sqrt(2)`; changed to be hard-coded to `0` since it only has simple geometry.
 - `PathAnnotation` and `PolygonAnnotation` changed from hard-coded as `4` to user-configurable with default `2`.
 - `ContourSeries` changed from hard-coded as `2` to user-configurable with default `2`.
 - Examples are fractals with many thousands of data-points, and show 3 different choices of `MinimumSegmentLength` to show their effect on geometry: `2` is drastic, `1` is noticeable, `0.5` is practically imperceptible.

@oxyplot/admins
