### PR TITLE
Ticket 1824

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - SkiaSharp.WPF - OxyPlot doesn't render inside an ElementHost (#1800)
 - NullReference in SkiaSharp WPF renderer if UIElement has no PresentationSource  (#1798)
 - WPF DPI Regression (#1799)
+- Code generation for escape sequences in strings (#1824)
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -90,6 +90,7 @@ Memphisch <memphis@machzwo.de>
 Mendel Monteiro-Beckerman
 Menno Deij - van Rijswijk <m.deij@marin.nl>
 methdotnet
+Michael Hieke <mghie@gmx.net>
 Mikant <a.mikant@gmail.com>
 mirolev <miroslav.levicky@gmail.com>
 Mitch-Connor <acm@htri.net>

--- a/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
+++ b/Source/OxyPlot.Tests/Foundation/CodeGeneratorTests.cs
@@ -39,5 +39,23 @@ namespace OxyPlot.Tests
                 CheckCode(ei.PlotModel);
             }
         }
+
+        /// <summary>
+        /// Test that code generation properly handles escapes sequences in strings
+        /// </summary>
+        [Test]
+        public void TestCodeGeneratorStringExtensions()
+        {
+            var plot = new PlotModel();
+
+            // a custom tracker format string that shows x axis values in seconds as "m:ss.ff"
+            var series = new Series.LineSeries()
+            {
+                TrackerFormatString = "{1}: {2:m\\:ss\\.ff}\n{3}: {4:0.##}",
+            };
+            plot.Series.Add(series);
+
+            StringAssert.Contains(@"{1}: {2:m\\:ss\\.ff}\n{3}: {4:0.##}", plot.ToCode());
+        }
     }
 }

--- a/Source/OxyPlot/Foundation/CodeGenerator/CodeGeneratorStringExtensions.cs
+++ b/Source/OxyPlot/Foundation/CodeGenerator/CodeGeneratorStringExtensions.cs
@@ -11,6 +11,7 @@ namespace OxyPlot
 {
     using System;
     using System.Globalization;
+    using System.Text;
 
     /// <summary>
     /// Provides extension methods for code generation.
@@ -24,11 +25,26 @@ namespace OxyPlot
         /// <returns>C# code.</returns>
         public static string ToCode(this string value)
         {
-            value = value.Replace("\"", "\\\"");
-            value = value.Replace("\r\n", "\\n");
-            value = value.Replace("\n", "\\n");
-            value = value.Replace("\t", "\\t");
-            return "\"" + value + "\"";
+            StringBuilder sb = new StringBuilder(value.Length + 2);
+            sb.Append("\"");
+            foreach (var c in value.Replace("\r\n", "\n"))
+            {
+                switch (c)
+                {
+                    case '\"':
+                        sb.Append("\\\""); break;
+                    case '\\':
+                        sb.Append(@"\\"); break;
+                    case '\n':
+                        sb.Append(@"\n"); break;
+                    case '\t':
+                        sb.Append(@"\t"); break;
+                    default:
+                        sb.Append(c); break;
+                }
+            }
+            sb.Append("\"");
+            return sb.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1824.

### Checklist

- [X] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- `CodeGeneratorStringExtensions.ToCode()` for strings is modified to properly handle escape sequences other than newlines, carriage returns, tabs and double quotes.

@oxyplot/admins
