### PR TITLE
SkiaSharp - Search for Fonts in EmbeddedResources

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -62,6 +62,7 @@ Ilya Skriblovsky <IlyaSkriblovsky@gmail.com>
 Iurii Gazin <archeg@gmail.com>
 Jānis Kiršteins <janis@janiskirsteins.org>
 jaykul
+Jens Krumsieck <j.krumsieck@outlook.de>
 Jeremy Koritzinsky
 Jeremie Magnette
 jezza323

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -11,11 +11,11 @@ namespace OxyPlot.SkiaSharp
     using System;
     using System.Collections.Generic;
     using System.Linq;
-using System.Reflection;
+    using System.Reflection;
 
-/// <summary>
-/// Implements <see cref="IRenderContext" /> based on SkiaSharp.
-/// </summary>
+    /// <summary>
+    /// Implements <see cref="IRenderContext" /> based on SkiaSharp.
+    /// </summary>
     public class SkiaRenderContext : IRenderContext, IDisposable
     {
         private readonly Dictionary<FontDescriptor, SKShaper> shaperCache = new Dictionary<FontDescriptor, SKShaper>();

--- a/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
+++ b/Source/OxyPlot.SkiaSharp/SkiaRenderContext.cs
@@ -10,6 +10,7 @@ namespace OxyPlot.SkiaSharp
     using global::SkiaSharp.HarfBuzz;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
 
@@ -866,6 +867,7 @@ namespace OxyPlot.SkiaSharp
             if (!this.typefaceCache.TryGetValue(fontDescriptor, out var typeface))
             {
                 typeface = SKTypeface.FromFamilyName(fontFamily, new SKFontStyle((int)fontWeight, (int)SKFontStyleWidth.Normal, SKFontStyleSlant.Upright));
+#if NETSTANDARD2_0_OR_GREATER
                 if (typeface.FamilyName != fontFamily) // requested font not found or is WASM
                 {
                     try
@@ -873,7 +875,7 @@ namespace OxyPlot.SkiaSharp
                         var assembly = Assembly.GetEntryAssembly(); // the executing program (the GUI Project (WPF, WASM, ...))
                         var weight = (_fontWeights.ContainsKey((int)fontWeight) ? _fontWeights[(int)fontWeight] : "Regular");
                         var filename = $"{fontFamily}-{weight}.ttf".ToLower();
-                        Console.WriteLine($"Load Font {filename}");
+                        Debug.WriteLine($"Load Font {filename}");
 
                         var matches = assembly!.GetManifestResourceNames().Where(item => item.ToLower().EndsWith(filename));
                         if (!matches.Any()) matches = assembly!.GetManifestResourceNames().Where(item => item.ToLower().EndsWith(fontFamily + ".ttf"));
@@ -885,9 +887,10 @@ namespace OxyPlot.SkiaSharp
                     }
                     catch
                     {
-                        Console.WriteLine($"Requested Font {fontFamily} could not be found, falling back to {typeface.FamilyName}");
+                        Debug.WriteLine($"Requested Font {fontFamily} could not be found, falling back to {typeface.FamilyName}");
                     }
                 }
+#endif
                 this.typefaceCache.Add(fontDescriptor, typeface);
             }
 


### PR DESCRIPTION
Adds EmbeddedResource based fonts to SkiaSharp Renderer as `SKTypeface.FromFamilyName` is not valid in e.g. WASM. 
Uses inspiration from https://www.blazorspread.net/blogview/82.
Tested with Blazor WASM but probably also Fixes #1735  .
Axis rendered with Montserrat Font in WASM
![montserrat](https://user-images.githubusercontent.com/4296194/155292122-c0aff914-00c6-4fda-96f6-384a367120d1.png)

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Added Dictionary for translating fontweights (int) to string as this is used for naming .ttf file when downloaded from e.g. GoogleFonts 
  ```csharp
  private readonly Dictionary<int, string> _fontWeights = new Dictionary<int, string>()
          {
              [100] = "Thin",
              [200] = "ExtraLight",
              [300] = "Light",
              [400] = "Regular",
              [500] = "Medium",
              [600] = "SemiBold",
              [700] = "Bold",
              [800] = "ExtraBold",
              [900] = "Black"
          };
  ```
- Search embedded resources if font ist not found by name
  ```csharp
  if (typeface.FamilyName != fontFamily) // requested font not found or is WASM
                  {
                      try
                      {
                          var assembly = Assembly.GetEntryAssembly(); // the executing program (the GUI Project (WPF, WASM, ...))
                          var weight = (_fontWeights.ContainsKey((int)fontWeight) ? _fontWeights[(int)fontWeight] : "Regular");
                          var filename = $"{fontFamily}-{weight}.ttf".ToLower();
                          Console.WriteLine($"Load Font {filename}");
  
                          var matches = assembly!.GetManifestResourceNames().Where(item => item.ToLower().EndsWith(filename));
                          if (!matches.Any()) matches = assembly!.GetManifestResourceNames().Where(item => item.ToLower().EndsWith(fontFamily + ".ttf"));
                          foreach (var item in matches)
                          {
                              var s = assembly.GetManifestResourceStream(item);
                              typeface = SKTypeface.FromStream(s);
                          }
                      }
                      catch
                      {
                          Console.WriteLine($"Requested Font {fontFamily} could not be found, falling back to {typeface.FamilyName}");
                      }
                  }
  ```
@oxyplot/admins
