### PR TITLE
Fix tracker label clipping 1863

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - WPF DPI Regression (#1799)
 - Code generation for escape sequences in strings (#1824)
 - Axes not always honoring AbsoluteMinimum/AbsoluteMaximum and/or MinimumRange/MaximumRange properties (#1812)
+- WindowsForms tracker no longer clipping outside PlotView boundaries (#1863)
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -90,6 +90,7 @@ Memphisch <memphis@machzwo.de>
 Mendel Monteiro-Beckerman
 Menno Deij - van Rijswijk <m.deij@marin.nl>
 methdotnet
+Michael Fox <16841316+foxmja@users.noreply.github.com>
 Michael Hieke <mghie@gmx.net>
 Mikant <a.mikant@gmail.com>
 mirolev <miroslav.levicky@gmail.com>

--- a/Source/OxyPlot.WindowsForms/PlotView.cs
+++ b/Source/OxyPlot.WindowsForms/PlotView.cs
@@ -318,8 +318,8 @@ namespace OxyPlot.WindowsForms
             }
 
             this.trackerLabel.Text = data.ToString();
-            this.trackerLabel.Top = (int)data.Position.Y - this.trackerLabel.Height;
-            this.trackerLabel.Left = (int)data.Position.X - (this.trackerLabel.Width / 2);
+            this.trackerLabel.Top = Math.Min(Math.Max(0, (int)data.Position.Y - this.trackerLabel.Height), this.Height - this.trackerLabel.Height);
+            this.trackerLabel.Left = Math.Min(Math.Max(0, (int)data.Position.X - (this.trackerLabel.Width / 2)), this.Width - this.trackerLabel.Width);
             this.trackerLabel.Visible = true;
             this.trackerLabel.UseMnemonic = false;
         }


### PR DESCRIPTION
Fixes #1863.  First time contributing (to any open source project); documentation helped a lot, hopefully I didn't miss anything.

### Checklist

- [NA] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Added some bounds checking to the WinForms PlotView trackerLabel control to keep it within the bounds of the parent control where it will remain visible.

@oxyplot/admins
