### PR TITLE
Improve StairStepSeries render performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Update net40 and net45 to net452 (#1835)
 - Change default `MinimumSegmentLength` to `2` and remove limits for series and annotations with simple geometry (#1853)
+- Improve performance of `StairStepSeries`, particularly when zoomed in and X is monotonic or when consecutive points have equal Y components
+- `StairStepSeries` renders a horizontal line when a point with a valid X component and invalid Y component follows a valid point
 
 ### Removed
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Brannon King
 Bryan Freeman
 Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
+Carl Reinke
 Carlos Anderson <carlosjanderson@gmail.com>
 Carlos Teixeira <karlmtc@gmail.com>
 Chase Long <chaselfromal@gmail.com>

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -8,3 +8,13 @@ end_of_line = crlf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.cs]
+
+#### .NET Coding Conventions ####
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_property = true:warning

--- a/Source/Examples/ExampleLibrary/Series/StairStepSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/StairStepSeriesExamples.cs
@@ -69,6 +69,85 @@ namespace ExampleLibrary
             });
         }
 
+        [Example("StairStepSeries with invalid points")]
+        public static PlotModel StairStepSeriesWithInvalidPoints()
+        {
+            var model = new PlotModel
+            {
+                Title = "StairStepSeries with invalid points",
+                Subtitle = "Horizontal lines do not continue",
+            };
+
+            PopulateInvalidPointExampleModel(model, x => DataPoint.Undefined);
+
+            return model;
+        }
+
+        [Example("StairStepSeries with invalid Y")]
+        public static PlotModel StairStepSeriesWithInvalidY()
+        {
+            var model = new PlotModel
+            {
+                Title = "StairStepSeries with invalid Y",
+                Subtitle = "Horizontal lines continue until X of point with invalid Y",
+            };
+
+            PopulateInvalidPointExampleModel(model, x => new DataPoint(x, double.NaN));
+
+            return model;
+        }
+
+        [Example("StairStepSeries with non-monotonic X")]
+        public static PlotModel StairStepSeriesWithNonmonotonicX()
+        {
+            var model = new PlotModel
+            {
+                Title = "StairStepSeries with non-monotonic X",
+                Subtitle = "Lines form a boxed I-beam",
+            };
+
+            var iBeamSeries = new StairStepSeries
+            {
+                MarkerType = MarkerType.Circle,
+                VerticalLineStyle = LineStyle.Dash,
+                VerticalStrokeThickness = 4,
+            };
+            iBeamSeries.Points.Add(new DataPoint(1, 1));
+            iBeamSeries.Points.Add(new DataPoint(3, 1));
+            iBeamSeries.Points.Add(new DataPoint(2, 3));
+            iBeamSeries.Points.Add(new DataPoint(1, 3));
+            iBeamSeries.Points.Add(new DataPoint(3, 3));
+            model.Series.Add(iBeamSeries);
+
+            var boxBRSeries = new StairStepSeries
+            {
+                MarkerType = MarkerType.Circle,
+                VerticalLineStyle = LineStyle.Dash,
+                VerticalStrokeThickness = 4,
+            };
+            boxBRSeries.Points.Add(new DataPoint(1, 0));
+            boxBRSeries.Points.Add(new DataPoint(2, 0));
+            boxBRSeries.Points.Add(new DataPoint(0, 0));
+            boxBRSeries.Points.Add(new DataPoint(4, 0));
+            boxBRSeries.Points.Add(new DataPoint(4, 4));
+            model.Series.Add(boxBRSeries);
+
+            var boxTLSeries = new StairStepSeries
+            {
+                MarkerType = MarkerType.Circle,
+                VerticalLineStyle = LineStyle.Dash,
+                VerticalStrokeThickness = 4,
+            };
+            boxTLSeries.Points.Add(new DataPoint(3, 4));
+            boxTLSeries.Points.Add(new DataPoint(2, 4));
+            boxTLSeries.Points.Add(new DataPoint(4, 4));
+            boxTLSeries.Points.Add(new DataPoint(0, 4));
+            boxTLSeries.Points.Add(new DataPoint(0, 0));
+            model.Series.Add(boxTLSeries);
+
+            return model;
+        }
+
         /// <summary>
         /// Creates an example model and fills the specified series with points.
         /// </summary>
@@ -92,6 +171,60 @@ namespace ExampleLibrary
 
             model.Series.Add(series);
             return model;
+        }
+
+        private static void PopulateInvalidPointExampleModel(PlotModel model, Func<double, DataPoint> getInvalidPoint)
+        {
+            model.Legends.Add(new Legend()
+            {
+                LegendOrientation = LegendOrientation.Horizontal,
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.BottomCenter,
+            });
+
+            var series1 = new StairStepSeries
+            {
+                Title = "Invalid First Point",
+                MarkerType = MarkerType.Circle,
+            };
+            series1.Points.Add(getInvalidPoint(0));
+            series1.Points.Add(new DataPoint(1, 3.5));
+            series1.Points.Add(new DataPoint(2, 4.0));
+            series1.Points.Add(new DataPoint(3, 4.5));
+            model.Series.Add(series1);
+
+            var series2 = new StairStepSeries
+            {
+                Title = "Invalid Second Point",
+                MarkerType = MarkerType.Circle,
+            };
+            series2.Points.Add(new DataPoint(0, 2.0));
+            series2.Points.Add(getInvalidPoint(1));
+            series2.Points.Add(new DataPoint(2, 3.0));
+            series2.Points.Add(new DataPoint(3, 3.5));
+            model.Series.Add(series2);
+
+            var series3 = new StairStepSeries
+            {
+                Title = "Invalid Penultimate Point",
+                MarkerType = MarkerType.Circle,
+            };
+            series3.Points.Add(new DataPoint(0, 1.0));
+            series3.Points.Add(new DataPoint(1, 1.5));
+            series3.Points.Add(getInvalidPoint(2));
+            series3.Points.Add(new DataPoint(3, 2.5));
+            model.Series.Add(series3);
+
+            var series4 = new StairStepSeries
+            {
+                Title = "Invalid Last Point",
+                MarkerType = MarkerType.Circle,
+            };
+            series4.Points.Add(new DataPoint(0, 0.0));
+            series4.Points.Add(new DataPoint(1, 0.5));
+            series4.Points.Add(new DataPoint(2, 1.0));
+            series4.Points.Add(getInvalidPoint(3));
+            model.Series.Add(series4);
         }
     }
 }

--- a/Source/OxyPlot.CI.sln
+++ b/Source/OxyPlot.CI.sln
@@ -33,6 +33,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleBrowser.WPF", "Examp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F1A82564-31B4-4901-9AD4-446F3EA8ACF3}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		..\appveyor.yml = ..\appveyor.yml
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\CHANGELOG.md = ..\CHANGELOG.md

--- a/Source/OxyPlot.Core.Drawing.sln
+++ b/Source/OxyPlot.Core.Drawing.sln
@@ -11,6 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Core.Drawing", "Oxy
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example1", "Examples\Core.Drawing\Example1\Example1.csproj", "{1119F71C-3189-4018-AE6C-C3E0D5984F10}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{36E82747-9070-42D7-B9B1-91270D5E0A7C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.ImageSharp.sln
+++ b/Source/OxyPlot.ImageSharp.sln
@@ -15,6 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.ImageSharp.Tests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleLibrary", "Examples\ExampleLibrary\ExampleLibrary.csproj", "{7A0250AF-11D4-4F15-9C5C-331E00580BE6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{20D2E8BC-6787-4AC5-B2DB-3E9027DDAF58}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.SkiaSharp.sln
+++ b/Source/OxyPlot.SkiaSharp.sln
@@ -34,6 +34,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp.Wpf", "Ox
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WPF", "WPF", "{FE67617D-7D0C-4083-9183-B08E64CB9FB9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{65B6A5EF-E7EF-41DB-B525-2F99D7CE594F}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.WPF.sln
+++ b/Source/OxyPlot.WPF.sln
@@ -50,6 +50,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Wpf.Shared", "OxyPl
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SkiaSharp", "SkiaSharp", "{261D16CE-42DB-4C0D-830D-AE31B39C9781}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9D560519-B6F2-4A92-A13D-DB79AEE683A1}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.WindowsForms.sln
+++ b/Source/OxyPlot.WindowsForms.sln
@@ -30,6 +30,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Tests", "OxyPlot.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleBrowser.WindowsForms", "Examples\WindowsForms\ExampleBrowser\ExampleBrowser.WindowsForms.csproj", "{EDD7672B-8D5D-459C-A7BE-DBF29F40E0D4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{092FAD3B-0F91-40FF-939C-C8E735333E43}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
1. Improve performance of `StairStepSeries`, particularly when zoomed in and X is monotonic or when consecutive points have equal Y components
2. `StairStepSeries` renders a horizontal line when a point with a valid X component and invalid Y component follows a valid point

Regarding 2, here is the behavior before the change:
<img src="https://user-images.githubusercontent.com/11667451/166046321-6e066d93-83f4-457d-be2a-0ceb11bb6d56.png" width="50%" height="50%">
And here is the behavior after:
<img src="https://user-images.githubusercontent.com/11667451/166046839-3f1d7b9d-3281-434a-89fa-6848600efe1b.png" width="50%" height="50%">

Note that this does not change how `DataPoint.Undefined` is rendered:
<img src="https://user-images.githubusercontent.com/11667451/166046142-f85a49bb-7c95-465b-bc05-bebca6510719.png" width="50%" height="50%">

@oxyplot/admins

