### PR TITLE
Add plot manipulator axis preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Add LineThickness property to TrackerControl (#1831)
 - Add properties for `MinimumSegmentLength` to series and annotations (#1853)
 - Add fractal examples for PolygonAnnotation and PolylineAnnotations (#1853)
+- Add `AxisPreference` to `PlotManipulator`
 
 ### Changed
 - Update net40 and net45 to net452 (#1835)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Brannon King
 Bryan Freeman
 Brian Lim <brian.lim.ca@gmail.com>
 Caleb Clarke <thealmightybob@users.noreply.github.com>
+Carl Reinke
 Carlos Anderson <carlosjanderson@gmail.com>
 Carlos Teixeira <karlmtc@gmail.com>
 Chase Long <chaselfromal@gmail.com>

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -8,3 +8,13 @@ end_of_line = crlf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.cs]
+
+#### .NET Coding Conventions ####
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_property = true:warning

--- a/Source/Examples/ExampleLibrary/Examples/PlotControllerExamples.cs
+++ b/Source/Examples/ExampleLibrary/Examples/PlotControllerExamples.cs
@@ -109,5 +109,37 @@ namespace ExampleLibrary
 
             return new Example(plotModel, controller);
         }
+
+        [Example("Preferring an axis for manipulation")]
+        public static Example PreferringAnAxisForManipulation()
+        {
+            var model = new PlotModel
+            {
+                Title = "Preferring an axis for manipulation",
+                Subtitle = "Mouse wheel over plot area prefers X axis",
+            };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+
+            model.Series.Add(new FunctionSeries(Math.Cos, -7, 7, 0.01));
+
+            var controller = new PlotController();
+            controller.UnbindAll();
+            controller.BindMouseWheel(new DelegatePlotCommand<OxyMouseWheelEventArgs>((view, _, args) => HandleZoomByWheel(view, args)));
+            controller.BindMouseWheel(OxyModifierKeys.Control, new DelegatePlotCommand<OxyMouseWheelEventArgs>((view, _, args) => HandleZoomByWheel(view, args, 0.1)));
+
+            return new Example(model, controller);
+
+            void HandleZoomByWheel(IPlotView view, OxyMouseWheelEventArgs args, double factor = 1)
+            {
+                var m = new ZoomStepManipulator(view)
+                {
+                    AxisPreference = AxisPreference.X,
+                    Step = args.Delta * 0.001 * factor,
+                    FineControl = args.IsControlDown,
+                };
+                m.Started(args);
+            }
+        }
     }
 }

--- a/Source/OxyPlot.CI.sln
+++ b/Source/OxyPlot.CI.sln
@@ -33,6 +33,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleBrowser.WPF", "Examp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F1A82564-31B4-4901-9AD4-446F3EA8ACF3}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		..\appveyor.yml = ..\appveyor.yml
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\CHANGELOG.md = ..\CHANGELOG.md

--- a/Source/OxyPlot.Core.Drawing.sln
+++ b/Source/OxyPlot.Core.Drawing.sln
@@ -11,6 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Core.Drawing", "Oxy
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example1", "Examples\Core.Drawing\Example1\Example1.csproj", "{1119F71C-3189-4018-AE6C-C3E0D5984F10}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{36E82747-9070-42D7-B9B1-91270D5E0A7C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.ImageSharp.sln
+++ b/Source/OxyPlot.ImageSharp.sln
@@ -15,6 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.ImageSharp.Tests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleLibrary", "Examples\ExampleLibrary\ExampleLibrary.csproj", "{7A0250AF-11D4-4F15-9C5C-331E00580BE6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{20D2E8BC-6787-4AC5-B2DB-3E9027DDAF58}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.SkiaSharp.sln
+++ b/Source/OxyPlot.SkiaSharp.sln
@@ -34,6 +34,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.SkiaSharp.Wpf", "Ox
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WPF", "WPF", "{FE67617D-7D0C-4083-9183-B08E64CB9FB9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{65B6A5EF-E7EF-41DB-B525-2F99D7CE594F}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.WPF.sln
+++ b/Source/OxyPlot.WPF.sln
@@ -50,6 +50,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Wpf.Shared", "OxyPl
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SkiaSharp", "SkiaSharp", "{261D16CE-42DB-4C0D-830D-AE31B39C9781}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9D560519-B6F2-4A92-A13D-DB79AEE683A1}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.WindowsForms.sln
+++ b/Source/OxyPlot.WindowsForms.sln
@@ -30,6 +30,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.Tests", "OxyPlot.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleBrowser.WindowsForms", "Examples\WindowsForms\ExampleBrowser\ExampleBrowser.WindowsForms.csproj", "{EDD7672B-8D5D-459C-A7BE-DBF29F40E0D4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{092FAD3B-0F91-40FF-939C-C8E735333E43}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot/PlotController/Manipulators/AxisPreference.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/AxisPreference.cs
@@ -1,0 +1,32 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="AxisPreference.cs" company="OxyPlot">
+//   Copyright (c) 2022 OxyPlot contributors
+// </copyright>
+// <summary>
+//   Specifies which axis a manipulator will prefer to operate on.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot
+{
+    /// <summary>
+    /// Specifies which axis a manipulator will prefer to operate on.
+    /// </summary>
+    public enum AxisPreference
+    {
+        /// <summary>
+        /// Manipulation will not prefer a particular axis.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Manipulation will prefer to operate on the X axis.
+        /// </summary>
+        X,
+
+        /// <summary>
+        /// Manipulation will prefer to operate on the Y axis.
+        /// </summary>
+        Y,
+    }
+}

--- a/Source/OxyPlot/PlotController/Manipulators/PlotManipulator.cs
+++ b/Source/OxyPlot/PlotController/Manipulators/PlotManipulator.cs
@@ -34,6 +34,13 @@ namespace OxyPlot
         public IPlotView PlotView { get; private set; }
 
         /// <summary>
+        /// Gets or sets the axis that the manipulator will prefer to operate on.  The default is
+        /// <see cref="AxisPreference.None"/>.
+        /// </summary>
+        /// <value>The axis preference.</value>
+        public AxisPreference AxisPreference { get; set; }
+
+        /// <summary>
         /// Gets or sets the X axis.
         /// </summary>
         /// <value>The X axis.</value>
@@ -77,6 +84,21 @@ namespace OxyPlot
             if (this.PlotView.ActualModel != null)
             {
                 this.PlotView.ActualModel.GetAxesFromPoint(position, out xaxis, out yaxis);
+
+                if (this.AxisPreference != AxisPreference.None &&
+                    this.PlotView.ActualModel.PlotArea.Contains(position))
+                {
+                    if (this.AxisPreference == AxisPreference.X)
+                    {
+                        if (xaxis != null)
+                            yaxis = null;
+                    }
+                    else if (this.AxisPreference == AxisPreference.Y)
+                    {
+                        if (yaxis != null)
+                            xaxis = null;
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- Add `AxisPreference` to `PlotManipulator`.  When set, if an action could apply to a preferred axis and also to another axis (such has an action performed in the plot area) then the manipulator operates on only the preferred axis.  If an action applies only to a non-preferred axis (such as an action performed in the axis area of a non-preferred axis) then the manipulator operates on that axis, as usual.

@oxyplot/admins
