### PR TITLE
Add demo for logarithmic histogram plotting and fix rendering (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Code generation for escape sequences in strings (#1824)
 - Axes not always honoring AbsoluteMinimum/AbsoluteMaximum and/or MinimumRange/MaximumRange properties (#1812)
 - WindowsForms tracker no longer clipping outside PlotView boundaries (#1863)
+- Histogram now rendering properly when using logarithmic Y axis (#740) 
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,6 +49,7 @@ Elia Herzog
 Elmar Strittmatter
 episage <tilosag@gmail.com>
 eric
+Fabian Nitsche <ifab@freenet.de>
 Federico Coppola <fede@silentman.it>
 Francois Botha <igitur@gmail.com>
 Frank Tore Sæther <frank.sather@gmail.com>

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -29,6 +29,13 @@ namespace ExampleLibrary
             return CreateExponentialDistribution();
         }
 
+        [Example("Exponential Distribution (logarithmic)")]
+        [DocumentationExample("Series/HistogramSeries")]
+        public static PlotModel ExponentialDistributionLogarithmicAxis()
+        {
+            return CreateExponentialDistribution(true);
+        }
+
         [Example("Label Placement")]
         public static PlotModel HistogramLabelPlacement()
         {
@@ -122,10 +129,13 @@ namespace ExampleLibrary
             public string Description { get; }
         }
 
-        public static PlotModel CreateExponentialDistribution(double mean = 1, int n = 10000)
+        public static PlotModel CreateExponentialDistribution(bool logarithmicYAxis = false, double mean = 1, int n = 10000)
         {
-            var model = new PlotModel { Title = "Exponential Distribution", Subtitle = "Uniformly distributed bins (" + n + " samples)" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Frequency" });
+            var model = new PlotModel { Title = logarithmicYAxis ? "Exponential Distribution (logarithmic)" : "Exponential Distribution", Subtitle = "Uniformly distributed bins (" + n + " samples)" };
+            model.Axes.Add(
+                logarithmicYAxis ? 
+                    (Axis)new LogarithmicAxis { Position = AxisPosition.Left, Title = "Frequency"} : 
+                    new LinearAxis { Position = AxisPosition.Left, Title = "Frequency" });
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "x" });
 
             Random rnd = new Random(1);

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -303,6 +303,11 @@ namespace OxyPlot.Series
         {
             foreach (var item in items)
             {
+                if (this.YAxis.IsLogarithmic() && !this.YAxis.IsValidValue(item.Height))
+                {
+                    continue;
+                }
+
                 var actualFillColor = this.GetItemFillColor(item);
 
                 // transform the data points to screen points

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -298,7 +298,7 @@ namespace OxyPlot.Series
                 var actualFillColor = this.GetItemFillColor(item);
 
                 // transform the data points to screen points
-                var p1 = this.Transform(item.RangeStart, 0);
+                var p1 = this.Transform(item.RangeStart, this.YAxis.IsLogarithmic() ? double.Epsilon : 0);
                 var p2 = this.Transform(item.RangeEnd, item.Height);
 
                 var rectrect = new OxyRect(p1, p2);

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -244,8 +244,16 @@ namespace OxyPlot.Series
             {
                 this.MinX = Math.Min(this.ActualItems.Min(r => r.RangeStart), this.ActualItems.Min(r => r.RangeEnd));
                 this.MaxX = Math.Max(this.ActualItems.Max(r => r.RangeStart), this.ActualItems.Max(r => r.RangeEnd));
-                this.MinY = Math.Min(this.ActualItems.Min(r => 0), this.ActualItems.Min(r => r.Height));
-                this.MaxY = Math.Max(this.ActualItems.Max(r => 0), this.ActualItems.Max(r => r.Height));
+                if (this.YAxis.IsLogarithmic())
+                {
+                    this.MinX = Math.Max(this.ActualItems.Min(r => r.Height), double.Epsilon);
+                    this.MaxY = Math.Max(this.ActualItems.Max(r => r.Height), double.Epsilon);
+                }
+                else
+                {
+                    this.MinY = Math.Min(this.ActualItems.Min(r => 0), this.ActualItems.Min(r => r.Height));
+                    this.MaxY = Math.Max(this.ActualItems.Max(r => 0), this.ActualItems.Max(r => r.Height));
+                }
             }
         }
 

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -246,7 +246,7 @@ namespace OxyPlot.Series
                 this.MaxX = Math.Max(this.ActualItems.Max(r => r.RangeStart), this.ActualItems.Max(r => r.RangeEnd));
                 if (this.YAxis.IsLogarithmic())
                 {
-                    this.MinX = Math.Max(this.ActualItems.Min(r => r.Height), double.Epsilon);
+                    this.MinY = Math.Max(this.ActualItems.Min(r => r.Height), double.Epsilon);
                     this.MaxY = Math.Max(this.ActualItems.Max(r => r.Height), double.Epsilon);
                 }
                 else


### PR DESCRIPTION
Fixes #740 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Added an example for inverted rendering of histogram with logarithmic Y-axis.
- Fixed rendering for rendering of histogram with logarithmic Y-axis.

@oxyplot/admins
