### PR TITLE
Fix example build errors in certain code pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Axes not always honoring AbsoluteMinimum/AbsoluteMaximum and/or MinimumRange/MaximumRange properties (#1812)
 - WindowsForms tracker no longer clipping outside PlotView boundaries (#1863)
 - Histogram now rendering properly when using logarithmic Y axis (#740) 
+- Fix ExampleLibrary build errors in certain code pages (#1890)
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,6 +102,7 @@ moes_leco
 moljac
 mroth
 mrtncls
+myd7349 <myd7349@gmail.com>
 Oleg Tarasov <oleg.v.tarasov@gmail.com>
 Oystein Bjorke <oystein.bjorke@gmail.com>
 Patrice Marin <patrice.marin@thomsonreuters.com>

--- a/Source/Examples/ExampleLibrary/Annotations/ArrowAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/ArrowAnnotationExamples.cs
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ArrowAnnotationExamples.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
@@ -85,7 +85,7 @@ namespace ExampleLibrary
                     new ArrowAnnotation
                         {
                             EndPoint = new DataPoint(i % 45, i / 45),
-                            Text = $"{i}�",
+                            Text = $"{i}°",
                             ArrowDirection = new ScreenVector(Math.Cos(rad), Math.Sin(rad)) * 25,
                             HeadLength = 5
                         });

--- a/Source/Examples/ExampleLibrary/Annotations/TextAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/TextAnnotationExamples.cs
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TextAnnotationExamples.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
@@ -74,7 +74,7 @@ namespace ExampleLibrary
                                           {
                                               TextRotation = i, 
                                               TextPosition = new DataPoint(i % 45, i / 45), 
-                                              Text = $"{i}�", 
+                                              Text = $"{i}°", 
                                               TextVerticalAlignment = VerticalAlignment.Middle, 
                                               TextHorizontalAlignment = HorizontalAlignment.Center
                                           });

--- a/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
+++ b/Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RenderingCapabilities.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
@@ -805,7 +805,7 @@ namespace ExampleLibrary
                     var dy = Math.Cos(halfAngle) * LINE_LENGTH;
 
                     var textP = new ScreenPoint(15, y);
-                    rc.DrawText(textP, angle.ToString() + "�", OxyColors.Black, fontSize: 12);
+                    rc.DrawText(textP, angle.ToString() + "°", OxyColors.Black, fontSize: 12);
 
                     foreach (LineJoin lineJoin in Enum.GetValues(typeof(LineJoin)))
                     {


### PR DESCRIPTION
Currently, these three files have an ANSI encoding:

- Source/Examples/ExampleLibrary/Annotations/ArrowAnnotationExamples.cs
- Source/Examples/ExampleLibrary/Annotations/TextAnnotationExamples.cs
- Source/Examples/ExampleLibrary/Examples/RenderingCapabilities.cs
![屏幕截图 2022-05-21 182136](https://user-images.githubusercontent.com/5435649/169649154-e323b3fd-89e7-4d2f-8722-76f11b2351ee.png)
![屏幕截图 2022-05-21 182234](https://user-images.githubusercontent.com/5435649/169649161-136e685c-458a-422f-a15a-2f4fcae28d10.png)

which will cause build errors in certain code pages.
![屏幕截图 2022-05-21 181221](https://user-images.githubusercontent.com/5435649/169649257-3800a25c-ab81-4c99-8416-4ef958e077c5.png)

![无标题](https://user-images.githubusercontent.com/5435649/169649267-dd88ed8c-bcbc-4222-97ad-42664a8b3565.png)

![屏幕截图 2022-05-21 181427](https://user-images.githubusercontent.com/5435649/169649333-fa90e022-c37b-4e3f-a5f5-9f3195b03f42.png)

![屏幕截图 2022-05-21 181459](https://user-images.githubusercontent.com/5435649/169649385-829abd63-54ec-4d02-ac65-b61b36fd2350.png)

![屏幕截图 2022-05-21 181633](https://user-images.githubusercontent.com/5435649/169649409-8bdfead3-f51c-49e8-bf5b-70cfb6b48ab2.png)


In iso-8859-1 and cp936, degree symbol is not the same:

```python
>>> '°'.encode('iso-8859-1')
b'\xb0'
>>> '°'.encode('cp936')
b'\xa1\xe3'
```

and when it comes to cp936, it can not understand '0xb0' correctly.

![屏幕截图 2022-05-21 182819](https://user-images.githubusercontent.com/5435649/169649529-bb986c62-354e-4954-8751-5e7e2e7adae9.png)

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change encoding of these three files from ANSI to UTF-8 with BOM.

@oxyplot/admins
