### PR TITLE
Update to .NET Framework 4.6.2

### DIFF
--- a/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
+++ b/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
       <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>

--- a/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
+++ b/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot ImageSharp unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
+++ b/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFramework>net462</TargetFramework>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot Pdf unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot SkiaSharp unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -9,13 +9,13 @@
         <Platforms>AnyCPU;x86;x64</Platforms>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|AnyCPU'">
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net462|AnyCPU'">
         <PlatformTarget>x86</PlatformTarget>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|x86'">
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net462|x86'">
         <PlatformTarget>x86</PlatformTarget>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net461|x64'">
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net462|x64'">
         <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>
     <ItemGroup>

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFramework>net462</TargetFramework>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
+++ b/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFramework>net462</TargetFramework>
         <UseWPF>true</UseWPF>
         <Description>OxyPlot WPF unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Fixes the failing github action.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Change all .NET Framework 4.6.1 projects to target 4.6.2

This only affects test and example projects; library projects are all 4.5.2 at the moment I think.

@oxyplot/admins
