### PR TITLE
Add PathAnnotation.TextBackground properties (#1900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Example of issue with AreaSeries tracker (#1982)
 - Example for CategoryAxis with custom MajorStep and uncentered ticks (#1971)
 - BarSeries.LabelAngle property (#1870)
+- Border properties on PathAnnotation to match functionality in TextAnnotation (#1900)
 
 ### Changed
 - Make consistent BaseValue and BaseLine across BarSeries, LinearBarSeries, and HistogramSeries
@@ -42,7 +43,6 @@ All notable changes to this project will be documented in this file.
 - Add `AxisPreference` to `PlotManipulator`
 - Add MinimumMajorIntervalCount and MaximumMajorIntervalCount Axis Properties (#24)
 - Add VisualStudioToolsManifest.xml to add components to the Visual Studio Designer toolbox (#1446)
-- Add TextBorder properties on PathAnnotation to match functionality in TextAnnotation (#1900)
 
 ### Changed
 - Change default `MinimumSegmentLength` to `2` and remove limits for series and annotations with simple geometry (#1853)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 - Add `AxisPreference` to `PlotManipulator`
 - Add MinimumMajorIntervalCount and MaximumMajorIntervalCount Axis Properties (#24)
 - Add VisualStudioToolsManifest.xml to add components to the Visual Studio Designer toolbox (#1446)
+- Add TextBorder properties on PathAnnotation to match functionality in TextAnnotation (#1900)
 
 ### Changed
 - Change default `MinimumSegmentLength` to `2` and remove limits for series and annotations with simple geometry (#1853)

--- a/Source/Examples/ExampleLibrary/Annotations/LineAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/LineAnnotationExamples.cs
@@ -25,8 +25,8 @@ namespace ExampleLibrary
                         Slope = 0.1,
                         Intercept = 1,
                         Text = "First",
-                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
-                        TextBackgroundPadding = new OxyThickness(5)
+                        BorderBackground = OxyColors.White.ChangeOpacity(0.75),
+                        BorderPadding = new OxyThickness(5)
                 });
             model.Annotations.Add(
                 new LineAnnotation
@@ -36,8 +36,8 @@ namespace ExampleLibrary
                         MaximumX = 40,
                         Color = OxyColors.Red,
                         Text = "Second",
-                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
-                        TextBackgroundPadding = new OxyThickness(5)
+                        BorderBackground = OxyColors.White.ChangeOpacity(0.75),
+                        BorderPadding = new OxyThickness(5)
                 });
             model.Annotations.Add(
                 new LineAnnotation
@@ -47,8 +47,8 @@ namespace ExampleLibrary
                         MaximumY = 10,
                         Color = OxyColors.Green,
                         Text = "Vertical",
-                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
-                        TextBackgroundPadding = new OxyThickness(5)
+                        BorderBackground = OxyColors.White.ChangeOpacity(0.75),
+                        BorderPadding = new OxyThickness(5)
                 });
             model.Annotations.Add(
                 new LineAnnotation
@@ -58,8 +58,8 @@ namespace ExampleLibrary
                         MaximumX = 4,
                         Color = OxyColors.Gold,
                         Text = "Horizontal",
-                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
-                        TextBackgroundPadding = new OxyThickness(5)
+                        BorderBackground = OxyColors.White.ChangeOpacity(0.75),
+                        BorderPadding = new OxyThickness(5)
                 });
             return model;
         }

--- a/Source/Examples/ExampleLibrary/Annotations/LineAnnotationExamples.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/LineAnnotationExamples.cs
@@ -19,9 +19,26 @@ namespace ExampleLibrary
             var model = new PlotModel { Title = "LineAnnotation on linear axes" };
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -20, Maximum = 80 });
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -10, Maximum = 10 });
-            model.Annotations.Add(new LineAnnotation { Slope = 0.1, Intercept = 1, Text = "First" });
             model.Annotations.Add(
-                new LineAnnotation { Slope = 0.3, Intercept = 2, MaximumX = 40, Color = OxyColors.Red, Text = "Second" });
+                new LineAnnotation
+                    {
+                        Slope = 0.1,
+                        Intercept = 1,
+                        Text = "First",
+                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
+                        TextBackgroundPadding = new OxyThickness(5)
+                });
+            model.Annotations.Add(
+                new LineAnnotation
+                    {
+                        Slope = 0.3,
+                        Intercept = 2,
+                        MaximumX = 40,
+                        Color = OxyColors.Red,
+                        Text = "Second",
+                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
+                        TextBackgroundPadding = new OxyThickness(5)
+                });
             model.Annotations.Add(
                 new LineAnnotation
                     {
@@ -29,8 +46,10 @@ namespace ExampleLibrary
                         X = 4,
                         MaximumY = 10,
                         Color = OxyColors.Green,
-                        Text = "Vertical"
-                    });
+                        Text = "Vertical",
+                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
+                        TextBackgroundPadding = new OxyThickness(5)
+                });
             model.Annotations.Add(
                 new LineAnnotation
                     {
@@ -38,8 +57,10 @@ namespace ExampleLibrary
                         Y = 2,
                         MaximumX = 4,
                         Color = OxyColors.Gold,
-                        Text = "Horizontal"
-                    });
+                        Text = "Horizontal",
+                        TextBackground = OxyColors.White.ChangeOpacity(0.75),
+                        TextBackgroundPadding = new OxyThickness(5)
+                });
             return model;
         }
 

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -103,28 +103,28 @@ namespace OxyPlot.Annotations
         public double TextPadding { get; set; }
 
         /// <summary>
-        /// Gets or sets the padding of the text border rectangle.
+        /// Gets or sets the padding of the border rectangle.
         /// </summary>
-        /// <value>The text border padding.</value>
-        public OxyThickness TextBorderPadding { get; set; }
+        /// <value>The border padding.</value>
+        public OxyThickness BorderPadding { get; set; }
 
         /// <summary>
-        /// Gets or sets the fill color of the text border rectangle.
+        /// Gets or sets the fill color of the border rectangle.
         /// </summary>
-        /// <value>The text border background color.</value>
-        public OxyColor TextBorderBackground { get; set; }
+        /// <value>The border background color.</value>
+        public OxyColor BorderBackground { get; set; }
 
         /// <summary>
-        /// Gets or sets the stroke color of the text border rectangle.
+        /// Gets or sets the stroke color of the border rectangle.
         /// </summary>
-        /// <value>The text border stroke color.</value>
-        public OxyColor TextBorderStroke { get; set; }
+        /// <value>The border stroke color.</value>
+        public OxyColor BorderStroke { get; set; }
 
         /// <summary>
-        /// Gets or sets the stroke thickness of the text border rectangle.
+        /// Gets or sets the stroke thickness of the border rectangle.
         /// </summary>
-        /// <value>The text border stroke thickness.</value>
-        public double TextBorderStrokeThickness { get; set; }
+        /// <value>The border stroke thickness.</value>
+        public double BorderStrokeThickness { get; set; }
 
         /// <summary>
         /// Gets or sets the text orientation.
@@ -280,16 +280,16 @@ namespace OxyPlot.Annotations
 
                     var textSize = rc.MeasureText(this.Text, this.ActualFont, this.ActualFontSize, this.ActualFontWeight);
 
-                    var textBounds = TextAnnotation.GetTextBounds(position, textSize, this.TextBackgroundPadding, angle, ha, va);
+                    var textBounds = TextAnnotation.GetTextBounds(position, textSize, this.BorderPadding, angle, ha, va);
 
                     if ((angle % 90).Equals(0))
                     {
                         var actualRect = new OxyRect(textBounds[0], textBounds[2]);
-                        rc.DrawRectangle(actualRect, this.TextBackground, this.TextBorderStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
+                        rc.DrawRectangle(actualRect, this.BorderBackground, this.BorderStroke, this.BorderStrokeThickness, this.EdgeRenderingMode);
                     }
                     else
                     {
-                        rc.DrawPolygon(textBounds, this.TextBackground, this.TextBorderStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
+                        rc.DrawPolygon(textBounds, this.BorderBackground, this.BorderStroke, this.BorderStrokeThickness, this.EdgeRenderingMode);
                     }
 
                     rc.DrawText(

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -103,16 +103,16 @@ namespace OxyPlot.Annotations
         public double TextPadding { get; set; }
 
         /// <summary>
-        /// Gets or sets the padding of the text background and border rectangle.
+        /// Gets or sets the padding of the text border rectangle.
         /// </summary>
-        /// <value>The text background and border padding.</value>
-        public OxyThickness TextBackgroundPadding { get; set; }
+        /// <value>The text border padding.</value>
+        public OxyThickness TextBorderPadding { get; set; }
 
         /// <summary>
-        /// Gets or sets the fill color of the text background rectangle.
+        /// Gets or sets the fill color of the text border rectangle.
         /// </summary>
-        /// <value>The text background color.</value>
-        public OxyColor TextBackground { get; set; }
+        /// <value>The text border background color.</value>
+        public OxyColor TextBorderBackground { get; set; }
 
         /// <summary>
         /// Gets or sets the stroke color of the text border rectangle.

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -103,6 +103,30 @@ namespace OxyPlot.Annotations
         public double TextPadding { get; set; }
 
         /// <summary>
+        /// Gets or sets the padding of the text background rectangle.
+        /// </summary>
+        /// <value>The text background padding.</value>
+        public OxyThickness TextBackgroundPadding { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fill color of the text background rectangle.
+        /// </summary>
+        /// <value>The text background color.</value>
+        public OxyColor TextBackground { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stroke color of the text background rectangle.
+        /// </summary>
+        /// <value>The text background stroke color.</value>
+        public OxyColor TextBackgroundStroke { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stroke thickness of the text background rectangle.
+        /// </summary>
+        /// <value>The text background stroke thickness.</value>
+        public double TextBackgroundStrokeThickness { get; set; }
+
+        /// <summary>
         /// Gets or sets the text orientation.
         /// </summary>
         /// <value>The text orientation.</value>
@@ -252,6 +276,20 @@ namespace OxyPlot.Annotations
                     if (this.TextPosition.IsDefined())
                     {
                         angle = this.TextRotation;
+                    }
+
+                    var textSize = rc.MeasureText(this.Text, this.ActualFont, this.ActualFontSize, this.ActualFontWeight);
+
+                    var textBounds = TextAnnotation.GetTextBounds(position, textSize, this.TextBackgroundPadding, angle, ha, va);
+
+                    if ((angle % 90).Equals(0))
+                    {
+                        var actualRect = new OxyRect(textBounds[0], textBounds[2]);
+                        rc.DrawRectangle(actualRect, this.TextBackground, this.TextBackgroundStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
+                    }
+                    else
+                    {
+                        rc.DrawPolygon(textBounds, this.TextBackground, this.TextBackgroundStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
                     }
 
                     rc.DrawText(

--- a/Source/OxyPlot/Annotations/PathAnnotation.cs
+++ b/Source/OxyPlot/Annotations/PathAnnotation.cs
@@ -103,9 +103,9 @@ namespace OxyPlot.Annotations
         public double TextPadding { get; set; }
 
         /// <summary>
-        /// Gets or sets the padding of the text background rectangle.
+        /// Gets or sets the padding of the text background and border rectangle.
         /// </summary>
-        /// <value>The text background padding.</value>
+        /// <value>The text background and border padding.</value>
         public OxyThickness TextBackgroundPadding { get; set; }
 
         /// <summary>
@@ -115,16 +115,16 @@ namespace OxyPlot.Annotations
         public OxyColor TextBackground { get; set; }
 
         /// <summary>
-        /// Gets or sets the stroke color of the text background rectangle.
+        /// Gets or sets the stroke color of the text border rectangle.
         /// </summary>
-        /// <value>The text background stroke color.</value>
-        public OxyColor TextBackgroundStroke { get; set; }
+        /// <value>The text border stroke color.</value>
+        public OxyColor TextBorderStroke { get; set; }
 
         /// <summary>
-        /// Gets or sets the stroke thickness of the text background rectangle.
+        /// Gets or sets the stroke thickness of the text border rectangle.
         /// </summary>
-        /// <value>The text background stroke thickness.</value>
-        public double TextBackgroundStrokeThickness { get; set; }
+        /// <value>The text border stroke thickness.</value>
+        public double TextBorderStrokeThickness { get; set; }
 
         /// <summary>
         /// Gets or sets the text orientation.
@@ -285,11 +285,11 @@ namespace OxyPlot.Annotations
                     if ((angle % 90).Equals(0))
                     {
                         var actualRect = new OxyRect(textBounds[0], textBounds[2]);
-                        rc.DrawRectangle(actualRect, this.TextBackground, this.TextBackgroundStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
+                        rc.DrawRectangle(actualRect, this.TextBackground, this.TextBorderStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
                     }
                     else
                     {
-                        rc.DrawPolygon(textBounds, this.TextBackground, this.TextBackgroundStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
+                        rc.DrawPolygon(textBounds, this.TextBackground, this.TextBorderStroke, this.TextBackgroundStrokeThickness, this.EdgeRenderingMode);
                     }
 
                     rc.DrawText(

--- a/Source/OxyPlot/Annotations/TextAnnotation.cs
+++ b/Source/OxyPlot/Annotations/TextAnnotation.cs
@@ -133,7 +133,7 @@ namespace OxyPlot.Annotations
         /// <param name="horizontalAlignment">The horizontal alignment.</param>
         /// <param name="verticalAlignment">The vertical alignment.</param>
         /// <returns>The background rectangle coordinates.</returns>
-        private static IList<ScreenPoint> GetTextBounds(
+        internal static IList<ScreenPoint> GetTextBounds(
             ScreenPoint position,
             OxySize size,
             OxyThickness padding,

--- a/Source/OxyPlot/Rendering/OxyColorExtensions.cs
+++ b/Source/OxyPlot/Rendering/OxyColorExtensions.cs
@@ -57,6 +57,17 @@ namespace OxyPlot
         }
 
         /// <summary>
+        /// Changes the opacity.
+        /// </summary>
+        /// <param name="color">The color.</param>
+        /// <param name="factor">The factor.</param>
+        /// <returns>A color with the new opacity.</returns>
+        public static OxyColor ChangeOpacity(this OxyColor color, double factor)
+        {
+            return OxyColor.FromAColor((byte)(color.A * factor), color);
+        }
+
+        /// <summary>
         /// Calculates the complementary color.
         /// </summary>
         /// <param name="color">The color to convert.</param>


### PR DESCRIPTION
Fixes #1900 by adding properties to `PathAnnotation` that match the functionality of `TextAnnotation`. Decided to not try to put everything in `TextualAnnotation` because there would be naming issues, as the same names are used in `PathAnnotation` and `TextAnnotation` already for different purposes.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add four new properties to `PathAnnotation`:
  - `TextBackground`
  - `TextBackgroundStroke`
  - `TextBackgroundStrokeThickness`
  - `TextBackgroundPadding`

@colejonson66 suggested `Border` for the stroke properties as an alternative to `Background`, which may be a better name.

@oxyplot/admins
