### PR TITLE
fix: Fixed binding and DataContext issue in WPF ExampleBrowser.

### DIFF
--- a/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml
@@ -1,18 +1,30 @@
-﻿<Window x:Class="ExampleBrowser.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:oxyWpf="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Wpf" 
-        xmlns:oxySkia="clr-namespace:OxyPlot.SkiaSharp.Wpf;assembly=OxyPlot.SkiaSharp.Wpf" 
-        xmlns:local="clr-namespace:ExampleBrowser" 
-        Title="OxyPlot.WPF Example Browser"
-        Height="720" Width="1280" Icon="OxyPlot_64.png">
+﻿<Window
+    x:Class="ExampleBrowser.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:ExampleBrowser"
+    xmlns:oxySkia="clr-namespace:OxyPlot.SkiaSharp.Wpf;assembly=OxyPlot.SkiaSharp.Wpf"
+    xmlns:oxyWpf="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Wpf"
+    Title="OxyPlot.WPF Example Browser"
+    Width="1280"
+    Height="720"
+    Icon="OxyPlot_64.png">
+    <Window.DataContext>
+        <local:MainWindowViewModel />
+    </Window.DataContext>
     <Window.Resources>
-        <SolidColorBrush x:Key="HotItemBackground" Color="#e6f3f7"/>
-        <SolidColorBrush x:Key="SelectedItemBorder" Color="#6dbdd1"/>
-        <SolidColorBrush x:Key="SelectedItemBackground" Color="#cbe6ef"/>
-        <SolidColorBrush x:Key="NormalItemBackground" Color="White"/>
+        <SolidColorBrush x:Key="HotItemBackground" Color="#e6f3f7" />
+        <SolidColorBrush x:Key="SelectedItemBorder" Color="#6dbdd1" />
+        <SolidColorBrush x:Key="SelectedItemBackground" Color="#cbe6ef" />
+        <SolidColorBrush x:Key="NormalItemBackground" Color="White" />
 
-        <DrawingBrush x:Key="CheckerBoard" TileMode="Tile" ViewboxUnits="Absolute" Viewbox="0,0,2,2" Viewport="0,0,10,10" ViewportUnits="Absolute">
+        <DrawingBrush
+            x:Key="CheckerBoard"
+            TileMode="Tile"
+            Viewbox="0,0,2,2"
+            ViewboxUnits="Absolute"
+            Viewport="0,0,10,10"
+            ViewportUnits="Absolute">
             <DrawingBrush.Drawing>
                 <DrawingGroup>
                     <GeometryDrawing Brush="White">
@@ -39,15 +51,20 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ListBoxItem}">
                         <Grid>
-                            <Rectangle Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" 
-                                       StrokeThickness="{TemplateBinding BorderThickness}" RadiusX="3" RadiusY="3" SnapsToDevicePixels="True"/>
+                            <Rectangle
+                                Fill="{TemplateBinding Background}"
+                                RadiusX="3"
+                                RadiusY="3"
+                                SnapsToDevicePixels="True"
+                                Stroke="{TemplateBinding BorderBrush}"
+                                StrokeThickness="{TemplateBinding BorderThickness}" />
                             <ContentPresenter Margin="8,5" />
                         </Grid>
                         <ControlTemplate.Triggers>
                             <MultiTrigger>
                                 <MultiTrigger.Conditions>
                                     <Condition Property="IsMouseOver" Value="True" />
-                                    <Condition Property="IsSelected" Value="False"/>
+                                    <Condition Property="IsSelected" Value="False" />
                                 </MultiTrigger.Conditions>
                                 <Setter Property="Background" Value="{StaticResource HotItemBackground}" />
                             </MultiTrigger>
@@ -64,12 +81,15 @@
     </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*"/>
-            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="1*" />
+            <ColumnDefinition Width="2*" />
         </Grid.ColumnDefinitions>
         <Grid Background="#20000000">
-            <ListBox ItemsSource="{Binding ExamplesView}" ItemContainerStyle="{DynamicResource ListboxItemStyle}" 
-                     SelectedItem="{Binding SelectedExample}" BorderThickness="0,0,0,1">
+            <ListBox
+                BorderThickness="0,0,0,1"
+                ItemContainerStyle="{DynamicResource ListboxItemStyle}"
+                ItemsSource="{Binding ExamplesView}"
+                SelectedItem="{Binding SelectedExample}">
                 <ListBox.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.ContainerStyle>
@@ -77,11 +97,14 @@
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate>
-                                            <Expander IsExpanded="False" ExpandDirection="Down">
+                                            <Expander ExpandDirection="Down" IsExpanded="False">
                                                 <Expander.Header>
                                                     <StackPanel Orientation="Horizontal">
-                                                        <TextBlock FontWeight="Bold" Text="{Binding Name}" Padding="0 0 8 0"/>
-                                                        <TextBlock Text="{Binding ItemCount, StringFormat='({0})'}"/>
+                                                        <TextBlock
+                                                            Padding="0,0,8,0"
+                                                            FontWeight="Bold"
+                                                            Text="{Binding Name}" />
+                                                        <TextBlock Text="{Binding ItemCount, StringFormat='({0})'}" />
                                                     </StackPanel>
                                                 </Expander.Header>
                                                 <ItemsPresenter />
@@ -98,11 +121,11 @@
         <Grid Grid.Column="1">
             <TabControl TabStripPlacement="Bottom">
                 <TabControl.Resources>
-                    <Style TargetType="{x:Type TextBox}" x:Key="CodeTextBox">
-                        <Setter Property="AcceptsReturn" Value="True"></Setter>
-                        <Setter Property="FontFamily" Value="Consolas"></Setter>
-                        <Setter Property="BorderThickness" Value="0"></Setter>
-                        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"></Setter>
+                    <Style x:Key="CodeTextBox" TargetType="{x:Type TextBox}">
+                        <Setter Property="AcceptsReturn" Value="True" />
+                        <Setter Property="FontFamily" Value="Consolas" />
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
                     </Style>
                 </TabControl.Resources>
                 <TabItem Header="Plot">
@@ -110,20 +133,46 @@
                         <Grid.Resources>
                             <local:NotNullVisibilityConverter x:Key="NotNullVisibilityConverter" />
                         </Grid.Resources>
-                        <oxySkia:PlotView Model="{Binding SkiaModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding SkiaModel, Converter={StaticResource NotNullVisibilityConverter}}" />
-                        <oxyWpf:PlotView Model="{Binding CanvasModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding CanvasModel, Converter={StaticResource NotNullVisibilityConverter}}" />
-                        <local:XamlPlotView Model="{Binding CanvasXamlModel}" Controller="{Binding SelectedExample.Controller}" Visibility="{Binding CanvasXamlModel, Converter={StaticResource NotNullVisibilityConverter}}" />
+                        <oxySkia:PlotView
+                            Controller="{Binding SelectedExample.PlotController}"
+                            Model="{Binding SkiaModel}"
+                            Visibility="{Binding SkiaModel, Converter={StaticResource NotNullVisibilityConverter}}" />
+                        <oxyWpf:PlotView
+                            Controller="{Binding SelectedExample.PlotController}"
+                            Model="{Binding CanvasModel}"
+                            Visibility="{Binding CanvasModel, Converter={StaticResource NotNullVisibilityConverter}}" />
+                        <local:XamlPlotView
+                            Controller="{Binding SelectedExample.PlotController}"
+                            Model="{Binding CanvasXamlModel}"
+                            Visibility="{Binding CanvasXamlModel, Converter={StaticResource NotNullVisibilityConverter}}" />
                     </Grid>
                 </TabItem>
                 <TabItem Header="Code">
-                    <TextBox Text="{Binding Code, Mode=OneWay}" Style="{StaticResource CodeTextBox}" />
+                    <TextBox Style="{StaticResource CodeTextBox}" Text="{Binding Code, Mode=OneWay}" />
                 </TabItem>
             </TabControl>
-            <StackPanel VerticalAlignment="Bottom" HorizontalAlignment="Right" Orientation="Horizontal">
-                <TextBlock Text="Renderer:" VerticalAlignment="Center" />
-                <ComboBox SelectedItem="{Binding Renderer}" ItemsSource="{Binding Renderers}" Margin="3,0,0,0" Width="80" />
-                <CheckBox IsChecked="{Binding Transposed}" Content="Transposed" VerticalAlignment="Center" Margin="10,0,5,0" IsEnabled="{Binding CanTranspose}" />
-                <CheckBox IsChecked="{Binding Reversed}" Content="Reversed" VerticalAlignment="Center" Margin="10,0,5,0" IsEnabled="{Binding CanReverse}" />
+            <StackPanel
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Text="Renderer:" />
+                <ComboBox
+                    Width="80"
+                    Margin="3,0,0,0"
+                    ItemsSource="{Binding Renderers}"
+                    SelectedItem="{Binding Renderer}" />
+                <CheckBox
+                    Margin="10,0,5,0"
+                    VerticalAlignment="Center"
+                    Content="Transposed"
+                    IsChecked="{Binding Transposed}"
+                    IsEnabled="{Binding CanTranspose}" />
+                <CheckBox
+                    Margin="10,0,5,0"
+                    VerticalAlignment="Center"
+                    Content="Reversed"
+                    IsChecked="{Binding Reversed}"
+                    IsEnabled="{Binding CanReverse}" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml.cs
@@ -18,23 +18,17 @@ namespace ExampleBrowser
     public partial class MainWindow : Window
     {
         /// <summary>
-        /// The vm.
-        /// </summary>
-        private readonly MainWindowViewModel vm = new MainWindowViewModel();
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="MainWindow" /> class.
         /// </summary>
         public MainWindow()
         {
             this.InitializeComponent();
-            this.DataContext = this.vm;
             SystemEvents.DisplaySettingsChanged += this.SystemEvents_DisplaySettingsChanged;
         }
 
         private void SystemEvents_DisplaySettingsChanged(object sender, System.EventArgs e)
         {
-            this.vm.ActiveModel?.PlotView?.InvalidatePlot(false);
+            (this.DataContext as MainWindowViewModel)?.ActiveModel?.PlotView?.InvalidatePlot(false);
         }
     }
 }


### PR DESCRIPTION
Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- I moved the initialization of the ViewModel into a xaml file, so the IDE's xaml parser is able to understand the DataContext type and issue warnings about incorrect bindings
- Accordingly, I corrected incorrect bindings. I have not checked other applications for this error.
- Sorry for the xaml formatting change, this is due to https://github.com/Xavalon/XamlStyler, I can submit a PR that will provide a configuration (https://github.com/Xavalon/XamlStyler/wiki/External-Configurations) for it according to your requirements.

@oxyplot/admins
