### PR TITLE
Bump CI and Tests to .NET 6.0

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.201
+        dotnet-version: 6.0.400
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/Source/Examples/ImageSharp/Example1/Example1.csproj
+++ b/Source/Examples/ImageSharp/Example1/Example1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
     <ItemGroup>

--- a/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
+++ b/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
@@ -13,8 +13,8 @@
         <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     </ItemGroup>
 </Project>

--- a/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
+++ b/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot ImageSharp unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -24,8 +24,8 @@
         <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     </ItemGroup>
 </Project>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot SkiaSharp unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 skip_branch_with_pr: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,6 @@ steps:
 - task: VSTest@2
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: 'net4*/*Tests.dll'
+    testAssemblyVer2: '**\net4*\*.Tests.dll'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,5 +31,7 @@ steps:
 
 - task: VSTest@2
   inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: 'net4*/*Tests.dll'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'


### PR DESCRIPTION
(Hopefully) fixes issues with Azure failing on Github.ImageSharp.Tests

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use VS 2022 for AppVeyor
- Use .NET 6 for GithubAction
- Use .NET 6 for Github.ImageSharp.Tests and Github.SkiaSharp.Tests

Not sure how to configure the Azure CI, but hopefully I can work that out if it's necessary.

@oxyplot/admins
