### PR TITLE
Replaced unsafe value < double.Epsilon expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - WindowsForms tracker no longer clipping outside PlotView boundaries (#1863)
 - Histogram now rendering properly when using logarithmic Y axis (#740) 
 - Fix ExampleLibrary build errors in certain code pages (#1890)
+- Fix for double.Epsilon zero check that fails on some architectures (#1924)
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -120,6 +120,7 @@ Scott W Harden <swharden@gmail.com>
 Shankar Mathiah Nanjundan <shankar.ooty@hotmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>
 Soarc <gor.rustamyan@gmail.com>
+Soren Holstebroe <sh@pantoinspect.com>
 Stefan Rado <oxyplot@sradonia.net>
 stefan-schweiger
 Steve Hoelzer <shoelzer@gmail.com>

--- a/Source/OxyPlot/Axes/Axis.cs
+++ b/Source/OxyPlot/Axes/Axis.cs
@@ -1449,7 +1449,7 @@ namespace OxyPlot.Axes
                 a1 -= this.MaximumDataMargin * marginSign;
             }
 
-            if (this.ActualMaximum - this.ActualMinimum < double.Epsilon)
+            if (this.ActualMaximum - this.ActualMinimum <= double.Epsilon)
             {
                 this.ActualMaximum = this.ActualMinimum + 1;
             }
@@ -1740,7 +1740,7 @@ namespace OxyPlot.Axes
             var actualMaximum = this.DataMaximum;
             double range = this.DataMaximum - this.DataMinimum;
 
-            if (range < double.Epsilon)
+            if (range <= double.Epsilon)
             {
                 double zeroRange = this.DataMaximum > 0 ? this.DataMaximum : 1;
                 actualMaximum += zeroRange * 0.5;
@@ -1769,7 +1769,7 @@ namespace OxyPlot.Axes
             var actualMinimum = this.DataMinimum;
             double range = this.DataMaximum - this.DataMinimum;
 
-            if (range < double.Epsilon)
+            if (range <= double.Epsilon)
             {
                 double zeroRange = this.DataMaximum > 0 ? this.DataMaximum : 1;
                 actualMinimum -= zeroRange * 0.5;
@@ -1824,12 +1824,12 @@ namespace OxyPlot.Axes
                 return maxIntervalSize;
             }
 
-            if (Math.Abs(maxIntervalSize) < double.Epsilon)
+            if (Math.Abs(maxIntervalSize) <= double.Epsilon)
             {
                 throw new ArgumentException("Maximum interval size cannot be zero.", "maxIntervalSize");
             }
 
-            if (Math.Abs(range) < double.Epsilon)
+            if (Math.Abs(range) <= double.Epsilon)
             {
                 throw new ArgumentException("Range cannot be zero.", "range");
             }

--- a/Source/OxyPlot/Axes/LogarithmicAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicAxis.cs
@@ -161,7 +161,7 @@ namespace OxyPlot.Axes
             var x0 = this.InverseTransform(isHorizontal ? ppt.X : ppt.Y);
             var x1 = this.InverseTransform(isHorizontal ? cpt.X : cpt.Y);
 
-            if (Math.Abs(x1) < double.Epsilon)
+            if (Math.Abs(x1) <= double.Epsilon)
             {
                 return;
             }

--- a/Source/OxyPlot/Axes/MagnitudeAxis.cs
+++ b/Source/OxyPlot/Axes/MagnitudeAxis.cs
@@ -147,7 +147,7 @@ namespace OxyPlot.Axes
                 a1 -= this.MaximumDataMargin * marginSign;
             }
 
-            if (this.ActualMaximum - this.ActualMinimum < double.Epsilon)
+            if (this.ActualMaximum - this.ActualMinimum <= double.Epsilon)
             {
                 this.ActualMaximum = this.ActualMinimum + 1;
             }

--- a/Source/OxyPlot/Axes/MagnitudeAxisFullPlotArea.cs
+++ b/Source/OxyPlot/Axes/MagnitudeAxisFullPlotArea.cs
@@ -131,7 +131,7 @@ namespace OxyPlot.Axes
                 a1 -= this.MaximumDataMargin * marginSign;
             }
 
-            if (this.ActualMaximum - this.ActualMinimum < double.Epsilon)
+            if (this.ActualMaximum - this.ActualMinimum <= double.Epsilon)
             {
                 this.ActualMaximum = this.ActualMinimum + 1;
             }

--- a/Source/OxyPlot/Rendering/OxyPen.cs
+++ b/Source/OxyPlot/Rendering/OxyPen.cs
@@ -92,7 +92,7 @@ namespace OxyPlot
             LineStyle lineStyle = LineStyle.Solid,
             LineJoin lineJoin = LineJoin.Miter)
         {
-            if (color.IsInvisible() || lineStyle == LineStyle.None || Math.Abs(thickness) < double.Epsilon)
+            if (color.IsInvisible() || lineStyle == LineStyle.None || Math.Abs(thickness) <= double.Epsilon)
             {
                 return null;
             }

--- a/Source/OxyPlot/Series/PieSeries.cs
+++ b/Source/OxyPlot/Series/PieSeries.cs
@@ -259,7 +259,7 @@ namespace OxyPlot.Series
             }
 
             this.total = this.slices.Sum(slice => slice.Value);
-            if (Math.Abs(this.total) < double.Epsilon)
+            if (Math.Abs(this.total) <= double.Epsilon)
             {
                 return;
             }

--- a/Source/OxyPlot/Series/StairStepSeries.cs
+++ b/Source/OxyPlot/Series/StairStepSeries.cs
@@ -96,7 +96,7 @@ namespace OxyPlot.Series
                     u2 = 1;
                 }
 
-                if (Math.Abs(u2) < double.Epsilon)
+                if (Math.Abs(u2) <= double.Epsilon)
                 {
                     continue; // P1 && P2 coincident
                 }


### PR DESCRIPTION
Fixes #1924.

### Changes proposed in this pull request:
All `Math.Abs(value) < double.Epsilon` checks replaced with `<=` since `0 < double.Epsilon` cannot be trusted to evaluate true on all architectures.
