### PR TITLE
DataPointSeries.GetItem is using cached items source points.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - WindowsForms tracker no longer clipping outside PlotView boundaries (#1863)
 - Histogram now rendering properly when using logarithmic Y axis (#740) 
 - Fix ExampleLibrary build errors in certain code pages (#1890)
+- DataPointSeries.GetItem uses cached items source points if available.
 
 ## [2.1.0] - 2021-10-02
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -120,6 +120,7 @@ Scott W Harden <swharden@gmail.com>
 Shankar Mathiah Nanjundan <shankar.ooty@hotmail.com>
 Shun-ichi Goto <shunichi.goto@gmail.com>
 Soarc <gor.rustamyan@gmail.com>
+Soren Holstebroe <sh@pantoinspect.com>
 Stefan Rado <oxyplot@sradonia.net>
 stefan-schweiger
 Steve Hoelzer <shoelzer@gmail.com>

--- a/Source/OxyPlot.Tests/Series/DataPointSeriesTest.cs
+++ b/Source/OxyPlot.Tests/Series/DataPointSeriesTest.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace OxyPlot.Tests
+{
+    using System.Collections;
+
+    using NUnit.Framework;
+
+    using OxyPlot.Series;
+
+    [TestFixture]
+    public class DataPointSeriesTest
+    {
+        [Test]
+        public void CachedItemsSourcePointsAreUsedByGetItem()
+        {
+            var itemsSource = new MockItemsSource();
+            var series = new TestDataPointSeries { ItemsSource = itemsSource };
+            series.TestUpdateData();
+            var itemA = (DataPoint) series.TestGetItem(2);
+            var itemB = (DataPoint) series.TestGetItem(2);
+
+            Assert.That(itemA.X, Is.EqualTo(2));
+            Assert.That(itemB.X, Is.EqualTo(2));
+            Assert.That(itemsSource.IterationCount, Is.EqualTo(1));
+        }
+
+        class MockItemsSource : IEnumerable<DataPoint>
+        {
+            public int IterationCount;
+
+            public IEnumerator<DataPoint> GetEnumerator()
+            {
+                ++this.IterationCount;
+
+                return Enumerable.Range(0, 5).Select(x => new DataPoint(x, x)).GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+        }
+
+        class TestDataPointSeries : DataPointSeries
+        {
+            public override void Render(IRenderContext rc)
+            {
+                // Do nothing
+            }
+
+            public object TestGetItem(int i)
+            {
+                return this.GetItem(i);
+            }
+            public void TestUpdateData()
+            {
+                this.UpdateData();
+            }
+        }
+    }
+}

--- a/Source/OxyPlot/Series/DataPointSeries.cs
+++ b/Source/OxyPlot/Series/DataPointSeries.cs
@@ -150,7 +150,7 @@ namespace OxyPlot.Series
         protected override object GetItem(int i)
         {
             var actualPoints = this.ActualPoints;
-            if (this.ItemsSource == null && actualPoints != null && i < actualPoints.Count)
+            if (actualPoints != null && i < actualPoints.Count)
             {
                 return actualPoints[i];
             }


### PR DESCRIPTION
Removed items source null check in DataPointSeries.GetItem since it prevented the use of cached items source points resulting in a huge performance penalty for large or slow items source data sets.

Fixes #1926 .

### Changes proposed in this pull request:
Null check for items source removed since it is already checked for in ActualPoints, but ActualPoints also returns cached points if available.