### PR TITLE
Bump msbuild tool version for github actions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -5,11 +5,13 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
-    
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: | 
+          3.1.x
+          6.0.x
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
     - master
+    - develop
   pull_request:
     branches:
     - master
+    - develop
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 3.1.x
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,7 +18,7 @@ jobs:
       run: dotnet test Source/OxyPlot.CI.sln --configuration Release
     
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     
     - name: MSBuild
       run: msbuild Source\OxyPlot.CI.sln -p:Configuration=Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.201
+        dotnet-version: 6.0.9
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.9
+        dotnet-version: 6.0.x
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,5 +1,11 @@
 name: Build on Windows
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Hopefully this will magically fix the CI failure now that we use reproducible builds

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Bump msbuild tool version for github actions to 1.1

@oxyplot/admins
