### PR TITLE
Fix placement of BarSeries labels when stacked (#1979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Example of BarSeries stacked and with labels (#1979)
 
 ### Changed
 
 ### Removed
 
 ### Fixed
+- Placement of BarSeries labels when stacked (#1979)
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -963,6 +963,46 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Stacked (labels)")]
+        public static PlotModel StackedLabels()
+        {
+            var model = new PlotModel { Title = "Stacked with Labels" };
+
+            int i = 0;
+            foreach (var placement in new[] { LabelPlacement.Base, LabelPlacement.Inside, LabelPlacement.Middle, LabelPlacement.Outside })
+            {
+                var categoryAxis = new CategoryAxis
+                {
+                    Title = "Category",
+                    Position = AxisPosition.Left,
+                    StartPosition = 1 - i * 0.25,
+                    EndPosition = 0.75 - i * 0.25,
+                    Key = $"C{i}",
+                };
+
+                var bs1 = new BarSeries { Title = placement.ToString(), LabelPlacement = placement, LabelFormatString = "{0:0}", IsStacked = true, YAxisKey = categoryAxis.Key };
+                bs1.Items.Add(new BarItem { Value = 5 });
+                bs1.Items.Add(new BarItem { Value = 10 });
+                bs1.Items.Add(new BarItem { Value = 15 });
+                model.Series.Add(bs1);
+
+                var bs2 = new BarSeries { Title = placement.ToString(), LabelPlacement = placement, LabelFormatString = "{0:0}", IsStacked = true, YAxisKey = categoryAxis.Key };
+                bs2.Items.Add(new BarItem { Value = 15 });
+                bs2.Items.Add(new BarItem { Value = 10 });
+                bs2.Items.Add(new BarItem { Value = 5 });
+                model.Series.Add(bs2);
+
+                categoryAxis.Labels.AddRange(new[] { "A", "B", "C" });
+                model.Axes.Add(categoryAxis);
+
+                i++;
+            }
+
+            model.Legends.Add(new Legend());
+
+            return model;
+        }
+
         [Example("GapWidth 0%")]
         public static PlotModel GapWidth0()
         {

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -310,7 +310,7 @@ namespace OxyPlot.Series
             HorizontalAlignment ha;
             ScreenPoint pt;
             var y = (categoryEndValue + categoryValue) / 2;
-            var sign = Math.Sign(item.Value - baseValue);
+            var sign = Math.Sign(topValue - baseValue);
             var marginVector = new ScreenVector(this.LabelMargin, 0) * sign;
 
             switch (this.LabelPlacement)


### PR DESCRIPTION
Fixes #1979 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- Adds an example of a stacked bar chart with labels
- Compute 'sign' of label based on top value, rather than item value

@oxyplot/admins
