### PR TITLE
Issue1982

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Example of BarSeries stacked and with labels (#1979)
+- Example of issue with AreaSeries tracker (#1982)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Placement of BarSeries labels when stacked (#1979)
+- Issue with tracking AreaSeries with monotonic data points (#1982)
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -2510,6 +2510,32 @@ namespace ExampleLibrary
             return plot;
         }
 
+        [Example("#1982: Area series GetNearestPoint Issue")]
+        public static PlotModel Issue1982AreaSeriesGetNearestPoint()
+        {
+            var plotModel1 = new PlotModel()
+            {
+                Subtitle = "AreaSeries.GetNearestPoint returns nonsense indexes, and doesn't snap to the nearest point."
+            };
+
+            AreaSeries areaSeries = new AreaSeries();
+            areaSeries.TrackerFormatString = "Y: {4:0.#####}\nX: {2:0.#####}\nZ: {Z}";
+
+            CustomDataPoint[] CdpTest = new CustomDataPoint[1000];
+            for (int i = 0; i < 1000; i++)
+            {
+                // Z corresponds to the item index
+                CdpTest[i] = new CustomDataPoint(x: i, (i - 500) * (i - 500), i);
+            }
+
+            areaSeries.ItemsSource = CdpTest;
+            plotModel1.Series.Add(areaSeries);
+
+            areaSeries.CanTrackerInterpolatePoints = false;
+
+            return plotModel1;
+        }
+
         private class TimeSpanPoint
         {
             public TimeSpan X { get; set; }
@@ -2521,6 +2547,26 @@ namespace ExampleLibrary
             public DateTime X { get; set; }
             public DateTime Y { get; set; }
         }
+
+        public class CustomDataPoint : IDataPointProvider
+        {
+            public double X { get; }
+            public double Y { get; }
+            public int Z { get; }
+
+            public CustomDataPoint(double x, double y, int z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+
+            public DataPoint GetDataPoint()
+            {
+                return new DataPoint(X, Y);
+            }
+        }
+
         /* NEW ISSUE TEMPLATE
            [Example("#123: Issue Description")]
            public static PlotModel IssueDescription()

--- a/Source/OxyPlot/Series/AreaSeries.cs
+++ b/Source/OxyPlot/Series/AreaSeries.cs
@@ -155,10 +155,10 @@ namespace OxyPlot.Series
             var xy = this.InverseTransform(point);
             var targetX = xy.X;
             int startIdx = this.IsXMonotonic 
-                ? this.FindWindowStartIndex(this.ActualPoints, p => p.x, targetX, this.WindowStartIndex)
+                ? this.WindowStartIndex
                 : 0;
             int startIdx2 = this.IsXMonotonic
-                ? this.FindWindowStartIndex(this.ActualPoints2, p => p.x, targetX, this.WindowStartIndex2)
+                ? this.WindowStartIndex2
                 : 0;
 
             TrackerHitResult result1, result2;

--- a/Source/OxyPlot/Series/XYAxisSeries.cs
+++ b/Source/OxyPlot/Series/XYAxisSeries.cs
@@ -314,7 +314,7 @@ namespace OxyPlot.Series
             double index = -1;
 
             double minimumDistance = double.MaxValue;
-            int i = 0;
+            int i = startIdx;
             foreach (var p in points.Skip(startIdx))
             {
                 if (!this.IsValidPoint(p))


### PR DESCRIPTION
Fixes #1982

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds an example for Issue 1982, indicating problems with tracking on `AreaSeries`
- Don't excessively constraint search for points on `AreaSeries` when Monotonic
- Fix bug in `XYSeries.GetNearestPointInternal` when `startIdx` not equal to zero

@oxyplot/admins
