### PR TITLE
Add BarSeries.LabelAngle property (#1870)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Example to Show/Hide Legend (#1470)
 - Example of BarSeries stacked and with labels (#1979)
 - Example of issue with AreaSeries tracker (#1982)
+- BarSeries.LabelAngle property (#1870)
 
 ### Changed
 

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -63,6 +63,19 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("With labels (at an angle)")]
+        public static PlotModel WithLabelsAtAnAngle()
+        {
+            var model = WithLabels();
+
+            foreach (BarSeries b in model.Series)
+            {
+                b.LabelAngle = -45;
+            }
+
+            return model;
+        }
+
         [Example("With labels (Value Axis reversed)")]
         public static PlotModel WithLabelsXAxisReversed()
         {

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
@@ -87,7 +87,7 @@ namespace OxyPlot.Axes
             //Text rendering
             foreach (var value in this.MajorLabelValues.Take(majorTickCount))
             {
-                ScreenPoint pt = TransformToClientRectangle(magnitudeAxis.ClipMaximum, value, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint);
+                ScreenPoint pt = this.TransformToClientRectangle(magnitudeAxis.ClipMaximum, value, axis, this.Plot.PlotArea, magnitudeAxis.MidPoint);
 
                 var angle = Math.Atan2(pt.y - magnitudeAxis.MidPoint.y, pt.x - magnitudeAxis.MidPoint.x);
 

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -37,6 +37,7 @@ namespace OxyPlot.Series
             this.NegativeFillColor = OxyColors.Undefined;
             this.TrackerFormatString = DefaultTrackerFormatString;
             this.LabelMargin = 2;
+            this.LabelAngle = 0;
             this.StackGroup = string.Empty;
             this.StrokeThickness = 0;
         }
@@ -77,9 +78,14 @@ namespace OxyPlot.Series
         public string LabelFormatString { get; set; }
 
         /// <summary>
-        /// Gets or sets the label margins.
+        /// Gets or sets the label margins. Default value is 2.
         /// </summary>
         public double LabelMargin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the label angle in degrees. Default value is 0.
+        /// </summary>
+        public double LabelAngle { get; set; }
 
         /// <summary>
         /// Gets or sets label placements.
@@ -307,40 +313,43 @@ namespace OxyPlot.Series
             double categoryEndValue)
         {
             var s = StringHelper.Format(this.ActualCulture, this.LabelFormatString, item, item.Value);
-            HorizontalAlignment ha;
             ScreenPoint pt;
             var y = (categoryEndValue + categoryValue) / 2;
             var sign = Math.Sign(topValue - baseValue);
             var marginVector = new ScreenVector(this.LabelMargin, 0) * sign;
+            var centreVector = new ScreenVector(0, 0);
+
+            var size = rc.MeasureText(
+                s,
+                this.ActualFont,
+                this.ActualFontSize,
+                this.ActualFontWeight,
+                this.LabelAngle);
 
             switch (this.LabelPlacement)
             {
                 case LabelPlacement.Inside:
                     pt = this.Transform(topValue, y);
                     marginVector = -marginVector;
-                    ha = (HorizontalAlignment)sign;
+                    centreVector = new ScreenVector(-sign * size.Width / 2, 0);
                     break;
                 case LabelPlacement.Outside:
                     pt = this.Transform(topValue, y);
-                    ha = (HorizontalAlignment)(-sign);
+                    centreVector = new ScreenVector(sign * size.Width / 2, 0);
                     break;
                 case LabelPlacement.Middle:
                     pt = this.Transform((topValue + baseValue) / 2, y);
                     marginVector = new ScreenVector(0, 0);
-                    ha = HorizontalAlignment.Center;
                     break;
                 case LabelPlacement.Base:
                     pt = this.Transform(baseValue, y);
-                    ha = (HorizontalAlignment)(-sign);
+                    centreVector = new ScreenVector(sign * size.Width / 2, 0);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
 
-            var va = VerticalAlignment.Middle;
-            this.Orientate(ref ha, ref va);
-
-            pt += this.Orientate(marginVector);
+            pt += this.Orientate(marginVector) + this.Orientate(centreVector);
 
             rc.DrawText(
                 pt,
@@ -349,9 +358,9 @@ namespace OxyPlot.Series
                 this.ActualFont,
                 this.ActualFontSize,
                 this.ActualFontWeight,
-                0,
-                ha,
-                va);
+                this.LabelAngle,
+                HorizontalAlignment.Center,
+                VerticalAlignment.Middle);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes #1870, may partially address #1995 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds `BarSeries.LabelAngle` property to control the angle at which labels are drawn. Labels are aligned with the middle of bar, and offset by the `LabelMargin` from their baseline. Default behaviour (when `LabelAngle = 0`) should be unchanged.

@oxyplot/admins
