### PR TITLE
Fix HitTest when IsLegendVisible is false (#1975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Placement of BarSeries labels when stacked (#1979)
 - SystemInvalidException in LineSeries when only Double.Nan values are added (#1991)
 - Issue with tracking AreaSeries with monotonic data points (#1982)
+- HitTest when IsLegendVisible is false (#1975)
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/OxyPlot/Legends/Legend.cs
+++ b/Source/OxyPlot/Legends/Legend.cs
@@ -73,10 +73,15 @@ namespace OxyPlot.Legends
         /// <summary>
         /// Override for legend hit test.
         /// </summary>
-        /// <param name="args">Arguments passe to the hit test</param>
+        /// <param name="args">Arguments passed to the hit test</param>
         /// <returns>The hit test results.</returns>
         protected override HitTestResult LegendHitTest(HitTestArguments args)
         {
+            if (!this.IsLegendVisible || !this.PlotModel.IsLegendVisible)
+            {
+                return null;
+            }
+
             ScreenPoint point = args.Point;
             if (this.IsPointInLegend(point))
             {


### PR DESCRIPTION
Fixes #1975 .

### Checklist

- [ ] I have included examples or tests
   -> newly added example for showing hiding legends is an adequate test
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

@oxyplot/admins
