### PR TITLE
Add example and fix for incorrect final tick on category axis (#1971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Example to Show/Hide Legend (#1470)
 - Example of BarSeries stacked and with labels (#1979)
 - Example of issue with AreaSeries tracker (#1982)
+- Add example for CategoryAxis with custom MajorStep and uncentered ticks (#1971)
 
 ### Changed
 

--- a/Source/Examples/ExampleLibrary/Axes/CategoryAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/CategoryAxisExamples.cs
@@ -55,6 +55,18 @@ namespace ExampleLibrary
         [Example("MajorStep")]
         public static PlotModel MajorStepCategoryAxis()
         {
+            var plotModel1 = new PlotModel { Title = "Major Step = 4, IsTickCentered = false" };
+            var catAxis = new CategoryAxis { IsTickCentered = false, MajorStep = 4 };
+            catAxis.Labels.AddRange(new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" });
+            plotModel1.Axes.Add(catAxis);
+            var linearAxis = new LinearAxis { Position = AxisPosition.Left };
+            plotModel1.Axes.Add(linearAxis);
+            return plotModel1;
+        }
+
+        [Example("MajorStep, TickCentered")]
+        public static PlotModel MajorStepCategoryTickCenteredAxis()
+        {
             var plotModel1 = new PlotModel { Title = "Major Step = 4, IsTickCentered = true" };
             var catAxis = new CategoryAxis { IsTickCentered = true, MajorStep = 4 };
             catAxis.Labels.AddRange(new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" });

--- a/Source/OxyPlot/Axes/CategoryAxis.cs
+++ b/Source/OxyPlot/Axes/CategoryAxis.cs
@@ -111,7 +111,7 @@ namespace OxyPlot.Axes
 
                 if (mv.Count > 0)
                 {
-                    var lastTick = mv[mv.Count - 1] + 1;
+                    var lastTick = mv[mv.Count - 1] + this.MajorStep;
                     if (lastTick < this.ClipMaximum + epsilon)
                     {
                         mv.Add(lastTick);


### PR DESCRIPTION
Fixes #1971 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix the final tick that is added to ensure it is offset by the MajorStep rather than always 1

@oxyplot/admins
