### PR TITLE
 Make consistent BaseValue and BaseLine across BarSeries, LinearBarSeries, and HistogramSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - BarSeries.LabelAngle property (#1870)
 
 ### Changed
+- Make consistent BaseValue and BaseLine across BarSeries, LinearBarSeries, and HistogramSeries
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -389,8 +389,8 @@ namespace ExampleLibrary
             return model;
         }
 
-        [Example("Logarithmic axis")]
-        public static PlotModel LogAxis()
+        [Example("Logarithmic axis (Base Value)")]
+        public static PlotModel LogAxisBaseValue()
         {
             var model = new PlotModel
             {
@@ -423,8 +423,42 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("Logarithmic axis (Base Line)")]
+        public static PlotModel LogAxisBaseLine()
+        {
+            var model = new PlotModel
+            {
+                Title = "Logarithmic axis"
+            };
+
+            var l = new Legend
+            {
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.BottomCenter,
+                LegendOrientation = LegendOrientation.Horizontal,
+                LegendBorderThickness = 0
+            };
+
+            model.Legends.Add(l);
+            var s1 = new BarSeries { Title = "Series 1", BaseLine = 0.1, StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+            s1.Items.Add(new BarItem { Value = 25 });
+            s1.Items.Add(new BarItem { Value = 37 });
+            s1.Items.Add(new BarItem { Value = 18 });
+            s1.Items.Add(new BarItem { Value = 40 });
+
+            var categoryAxis = new CategoryAxis { Position = AxisPosition.Left };
+            categoryAxis.Labels.Add("Category A");
+            categoryAxis.Labels.Add("Category B");
+            categoryAxis.Labels.Add("Category C");
+            categoryAxis.Labels.Add("Category D");
+            model.Series.Add(s1);
+            model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, MinimumPadding = 0, AbsoluteMinimum = 0 });
+            return model;
+        }
+
         [Example("Logarithmic axis (not stacked)")]
-        public static PlotModel LogAxis2()
+        public static PlotModel LogAxisNotStacked()
         {
             var model = new PlotModel { Title = "Logarithmic axis" };
             var l = new Legend
@@ -440,9 +474,9 @@ namespace ExampleLibrary
                                 new Item {Label = "Bananas", Value1 = 23, Value2 = 2, Value3 = 29}
                             };
 
-            model.Series.Add(new BarSeries { Title = "2009", BaseValue = 0.1, ItemsSource = items, ValueField = "Value1" });
-            model.Series.Add(new BarSeries { Title = "2010", BaseValue = 0.1, ItemsSource = items, ValueField = "Value2" });
-            model.Series.Add(new BarSeries { Title = "2011", BaseValue = 0.1, ItemsSource = items, ValueField = "Value3" });
+            model.Series.Add(new BarSeries { Title = "2009", ItemsSource = items, ValueField = "Value1" });
+            model.Series.Add(new BarSeries { Title = "2010", ItemsSource = items, ValueField = "Value2" });
+            model.Series.Add(new BarSeries { Title = "2011", ItemsSource = items, ValueField = "Value3" });
 
             model.Axes.Add(new CategoryAxis { Position = AxisPosition.Left, ItemsSource = items, LabelField = "Label" });
             model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, Minimum = 1 });
@@ -450,9 +484,9 @@ namespace ExampleLibrary
         }
 
         [Example("Logarithmic axis (stacked series)")]
-        public static PlotModel LogAxis3()
+        public static PlotModel LogAxisStacked()
         {
-            var model = LogAxis2();
+            var model = LogAxisNotStacked();
             foreach (var s in model.Series.OfType<BarSeries>())
             {
                 s.IsStacked = true;

--- a/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HistogramSeriesExamples.cs
@@ -36,6 +36,13 @@ namespace ExampleLibrary
             return CreateExponentialDistribution(true);
         }
 
+        [Example("Exponential Distribution (logarithmic,with BaseValue)")]
+        [DocumentationExample("Series/HistogramSeries")]
+        public static PlotModel ExponentialDistributionLogarithmicAxisWithBaseValue()
+        {
+            return CreateExponentialDistribution(true, baseValue: 0.1);
+        }
+
         [Example("Label Placement")]
         public static PlotModel HistogramLabelPlacement()
         {
@@ -129,7 +136,7 @@ namespace ExampleLibrary
             public string Description { get; }
         }
 
-        public static PlotModel CreateExponentialDistribution(bool logarithmicYAxis = false, double mean = 1, int n = 10000)
+        public static PlotModel CreateExponentialDistribution(bool logarithmicYAxis = false, double mean = 1, int n = 10000, double baseValue = 0)
         {
             var model = new PlotModel { Title = logarithmicYAxis ? "Exponential Distribution (logarithmic)" : "Exponential Distribution", Subtitle = "Uniformly distributed bins (" + n + " samples)" };
             model.Axes.Add(
@@ -146,6 +153,8 @@ namespace ExampleLibrary
             var binBreaks = HistogramHelpers.CreateUniformBins(0, 5, 15);
             chs.Items.AddRange(HistogramHelpers.Collect(SampleExps(rnd, mean, n), binBreaks, binningOptions));
             chs.StrokeThickness = 1;
+            chs.BaseValue = baseValue;
+            chs.NegativeFillColor = OxyColors.Red;
             model.Series.Add(chs);
 
             return model;

--- a/Source/Examples/ExampleLibrary/Series/LinearBarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/LinearBarSeriesExamples.cs
@@ -50,10 +50,22 @@
         [Example("With negative colors (logaritmic)")]
         public static PlotModel WithNegativeColorsLogarithmic()
         {
-            return CreateWithNegativeColors(true);
+            return CreateWithNegativeColors(logarithmic: true);
         }
 
-        public static PlotModel CreateWithNegativeColors(bool logarithmic = false)
+        [Example("With BaseValue")]
+        public static PlotModel WithBaseValue()
+        {
+            return CreateWithNegativeColors(baseValue: 50);
+        }
+
+        [Example("With BaseValue (Logarithmic)")]
+        public static PlotModel WithBaseValueLogarithmic()
+        {
+            return CreateWithNegativeColors(logarithmic: true, baseValue: 50);
+        }
+
+        public static PlotModel CreateWithNegativeColors(bool logarithmic = false, double baseValue = 0)
         {
             var model = new PlotModel { Title = logarithmic ? "LinearBarSeries with stroke (logarithmic)" : "LinearBarSeries with stroke" };
             model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
@@ -65,6 +77,7 @@
             linearBarSeries.NegativeFillColor = OxyColor.Parse("#45BF360C");
             linearBarSeries.NegativeStrokeColor = OxyColor.Parse("#BF360C");
             linearBarSeries.StrokeThickness = 1;
+            linearBarSeries.BaseValue = baseValue;
             model.Series.Add(linearBarSeries);
 
             return model;

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -467,8 +467,8 @@ namespace OxyPlot.Series
                     this.Manager.SetCurrentBaseValue(stackIndex, categoryIndex, value < 0, topValue);
                 }
 
-                var clampBase = this.YAxis.IsLogarithmic() && !this.YAxis.IsValidValue(baseValue);
-                var p1 = this.Transform(clampBase ? this.YAxis.ClipMinimum : baseValue, categoryValue);
+                var clampBase = this.XAxis.IsLogarithmic() && !this.XAxis.IsValidValue(baseValue);
+                var p1 = this.Transform(clampBase ? this.XAxis.ClipMinimum : baseValue, categoryValue);
                 var p2 = this.Transform(topValue, categoryValue + actualBarWidth);
 
                 var rectangle = new OxyRect(p1, p2);

--- a/Source/OxyPlot/Series/BarSeries/BarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/BarSeries.cs
@@ -41,19 +41,34 @@ namespace OxyPlot.Series
             this.LabelAngle = 0;
             this.StackGroup = string.Empty;
             this.StrokeThickness = 0;
+            this.BaseValue = 0;
+            this.BaseLine = double.NaN;
+            this.ActualBaseLine = double.NaN;
         }
+
+        /// <summary>
+        /// Gets or sets the base value. Default value is 0.
+        /// </summary>
+        /// <value>The base value.</value>
+        public double BaseValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base value.
+        /// </summary>
+        /// <value>The base value.</value>
+        public double BaseLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actual base line.
+        /// </summary>
+        /// <returns>The actual base line.</returns>
+        public double ActualBaseLine { get; protected set; }
 
         /// <summary>
         /// Gets the actual fill color.
         /// </summary>
         /// <value>The actual color.</value>
         public OxyColor ActualFillColor => this.FillColor.GetActualColor(this.defaultFillColor);
-        
-        /// <summary>
-        /// Gets or sets the base value.
-        /// </summary>
-        /// <value>The base value.</value>
-        public double BaseValue { get; set; }
 
         /// <summary>
         /// Gets or sets the color field.
@@ -171,6 +186,40 @@ namespace OxyPlot.Series
             if (this.FillColor.IsAutomatic())
             {
                 this.defaultFillColor = this.PlotModel.GetDefaultColor();
+            }
+        }
+
+        /// <summary>
+        /// Updates the axes to include the max and min of this series.
+        /// </summary>
+        protected internal override void UpdateAxisMaxMin()
+        {
+            base.UpdateAxisMaxMin();
+
+            this.ComputeActualBaseLine();
+            this.XAxis.Include(this.ActualBaseLine);
+        }
+
+        /// <summary>
+        /// Computes the actual base value..
+        /// </summary>
+        protected void ComputeActualBaseLine()
+        {
+            if (double.IsNaN(this.BaseLine))
+            {
+                if (this.XAxis.IsLogarithmic())
+                {
+                    var lowestPositiveValue = this.ActualItems == null ? 1 : this.ActualItems.Select(p => p.Value).Where(v => v > 0).MinOrDefault(1);
+                    this.ActualBaseLine = Math.Max(lowestPositiveValue / 10.0, this.BaseValue);
+                }
+                else
+                {
+                    this.ActualBaseLine = 0;
+                }
+            }
+            else
+            {
+                this.ActualBaseLine = this.BaseLine;
             }
         }
 
@@ -418,16 +467,15 @@ namespace OxyPlot.Series
                     this.Manager.SetCurrentBaseValue(stackIndex, categoryIndex, value < 0, topValue);
                 }
 
-                if (this.YAxis.IsLogarithmic() && !this.YAxis.IsValidValue(baseValue))
-                {
-                    baseValue = LogarithmicAxis.LowestValidRoundtripValue;
-                }
+                var clampBase = this.YAxis.IsLogarithmic() && !this.YAxis.IsValidValue(baseValue);
+                var p1 = this.Transform(clampBase ? this.YAxis.ClipMinimum : baseValue, categoryValue);
+                var p2 = this.Transform(topValue, categoryValue + actualBarWidth);
 
-                var rect = new OxyRect(this.Transform(baseValue, categoryValue), this.Transform(topValue, categoryValue + actualBarWidth));
+                var rectangle = new OxyRect(p1, p2);
 
-                this.ActualBarRectangles.Add(rect);
+                this.ActualBarRectangles.Add(rectangle);
 
-                this.RenderItem(rc, topValue, categoryValue, actualBarWidth, item, rect);
+                this.RenderItem(rc, topValue, categoryValue, actualBarWidth, item, rectangle);
 
                 if (this.LabelFormatString != null)
                 {

--- a/Source/OxyPlot/Series/HistogramSeries.cs
+++ b/Source/OxyPlot/Series/HistogramSeries.cs
@@ -50,7 +50,30 @@ namespace OxyPlot.Series
             this.LabelFormatString = null;
             this.LabelPlacement = LabelPlacement.Outside;
             this.ColorMapping = this.GetDefaultColor;
+            this.NegativeFillColor = OxyColors.Undefined;
+            this.NegativeStrokeColor = OxyColors.Undefined;
+            this.BaseValue = 0;
+            this.BaseLine = double.NaN;
+            this.ActualBaseLine = double.NaN;
         }
+
+        /// <summary>
+        /// Gets or sets the base value. Default value is 0.
+        /// </summary>
+        /// <value>The base value.</value>
+        public double BaseValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base value.
+        /// </summary>
+        /// <value>The base value.</value>
+        public double BaseLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actual base line.
+        /// </summary>
+        /// <returns>The actual base line.</returns>
+        public double ActualBaseLine{ get; protected set; }
 
         /// <summary>
         /// Gets or sets the color of the interior of the bars.
@@ -69,6 +92,18 @@ namespace OxyPlot.Series
         /// </summary>
         /// <value>The color of the stroke.</value>
         public OxyColor StrokeColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the interior of the bars when the value is negative.
+        /// </summary>
+        /// <value>The color.</value>
+        public OxyColor NegativeFillColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the border around the bars when the value is negative.
+        /// </summary>
+        /// <value>The color of the stroke.</value>
+        public OxyColor NegativeStrokeColor { get; set; }
 
         /// <summary>
         /// Gets or sets the thickness of the bar border strokes.
@@ -236,6 +271,41 @@ namespace OxyPlot.Series
         }
 
         /// <summary>
+        /// Updates the axes to include the max and min of this series.
+        /// </summary>
+        protected internal override void UpdateAxisMaxMin()
+        {
+            base.UpdateAxisMaxMin();
+
+            this.ComputeActualBaseLine();
+            this.YAxis.Include(this.ActualBaseLine);
+        }
+
+        /// <summary>
+        /// Computes the base line.
+        /// </summary>
+        /// <returns>The baseline for the plot.</returns>
+        protected void ComputeActualBaseLine()
+        {
+            if (double.IsNaN(this.BaseLine))
+            {
+                if (this.YAxis.IsLogarithmic())
+                {
+                    var lowestPositiveValue = this.ActualItems == null ? 1 : this.ActualItems.Select(p => p.Value).Where(v => v > 0).MinOrDefault(1);
+                    this.ActualBaseLine = Math.Max(lowestPositiveValue / 10.0, this.BaseValue);
+                }
+                else
+                {
+                    this.ActualBaseLine = 0;
+                }
+            }
+            else
+            {
+                this.ActualBaseLine = this.BaseLine;
+            }
+        }
+
+        /// <summary>
         /// Updates the maximum and minimum values of the series for the x and y dimensions only.
         /// </summary>
         protected internal void UpdateMaxMinXY()
@@ -301,6 +371,8 @@ namespace OxyPlot.Series
         /// <param name="items">The Items to render.</param>
         protected void RenderBins(IRenderContext rc, ICollection<HistogramItem> items)
         {
+            bool clampBase = this.YAxis.IsLogarithmic() && !this.YAxis.IsValidValue(this.BaseValue);
+
             foreach (var item in items)
             {
                 if (this.YAxis.IsLogarithmic() && !this.YAxis.IsValidValue(item.Height))
@@ -309,23 +381,24 @@ namespace OxyPlot.Series
                 }
 
                 var actualFillColor = this.GetItemFillColor(item);
+                var actualStrokeColor = this.GetItemStrokeColor(item);
 
                 // transform the data points to screen points
-                var p1 = this.Transform(item.RangeStart, this.YAxis.IsLogarithmic() ? double.Epsilon : 0);
+                var p1 = this.Transform(item.RangeStart, clampBase ? this.YAxis.ClipMinimum : this.BaseValue);
                 var p2 = this.Transform(item.RangeEnd, item.Height);
 
-                var rectrect = new OxyRect(p1, p2);
+                var rectangle = new OxyRect(p1, p2);
 
                 rc.DrawRectangle(
-                    rectrect, 
-                    actualFillColor, 
-                    this.StrokeColor, 
+                    rectangle, 
+                    actualFillColor,
+                    actualStrokeColor, 
                     this.StrokeThickness, 
                     this.EdgeRenderingMode.GetActual(EdgeRenderingMode.PreferSharpness));
 
                 if (this.LabelFormatString != null)
                 {
-                    this.RenderLabel(rc, rectrect, item);
+                    this.RenderLabel(rc, rectangle, item);
                 }
             }
         }
@@ -338,6 +411,23 @@ namespace OxyPlot.Series
         protected OxyColor GetItemFillColor(HistogramItem item)
         {
             return item.Color.IsAutomatic() ? this.ColorMapping(item) : item.Color;
+        }
+
+        /// <summary>
+        /// Gets the stroke color of the given <see cref="HistogramItem"/>.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns>The stroke color of the item.</returns>
+        protected OxyColor GetItemStrokeColor(HistogramItem item)
+        {
+            if (this.NegativeStrokeColor.IsUndefined() || item.Height >= this.BaseValue)
+            {
+                return this.StrokeColor;
+            }
+            else
+            {
+                return this.NegativeStrokeColor;
+            }
         }
 
         /// <summary>
@@ -433,7 +523,14 @@ namespace OxyPlot.Series
         /// <returns>The default color.</returns>
         private OxyColor GetDefaultColor(HistogramItem item)
         {
-            return this.ActualFillColor;
+            if (this.NegativeFillColor.IsUndefined() || item.Value >= this.BaseValue)
+            {
+                return this.ActualFillColor;
+            }
+            else
+            {
+                return this.NegativeFillColor;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Having merged #1942 (from which all of this work is derived), this makes the BaseValue and BaseLine consistent across all the 'bar-type' series, and exposes the `ActualBaseLine` as a `{ public get; protected set; }` property.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes
 - All 3 series have consistent support for negative values, determined by a `BaseValue` that defaults to zero.
 - Fixes issues with rendering against log axes by explicit detection and use of `YAxis.ClipMinimum` to clamp to end of plot
 - All 3 series have consistent support for a `BaseLine` which is included in the Y-axis: important for log-axes which extend to infinity that they have a sensisble 'reference' baseline. When `NaN`, actual value is derived for log-axes by dividing the smallest value by 10 (to give some padding to log plots: better ideas welcome (e.g. depend on range of values and base of axis?): computed values is exposed as `ActualBaseLine`

@oxyplot/admins
