### PR TITLE
Fix incorrect coloring of TwoColorLineSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Placement of BarSeries labels when stacked (#1979)
 - SystemInvalidException in LineSeries when only Double.Nan values are added (#1991)
 - Issue with tracking AreaSeries with monotonic data points (#1982)
+- Incorrect coloring of TwoColorLineSeries
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/OxyPlot/Series/TwoColorLineSeries.cs
+++ b/Source/OxyPlot/Series/TwoColorLineSeries.cs
@@ -141,12 +141,12 @@ namespace OxyPlot.Series
 
             using (rc.AutoResetClip(clippingRectLo))
             {
-                RenderLine(this.ActualColor);
+                RenderLine(this.ActualColor2);
             }
 
             using (rc.AutoResetClip(clippingRectHi))
             {
-                RenderLine(this.ActualColor2);
+                RenderLine(this.ActualColor);
             }
         }
     }


### PR DESCRIPTION
Fixes TwoColorLineSeries swapping the colors around: `Color2` is reported to be the color below the limit, and the existing examples reflect that.

### Checklist

- [ ] I have included examples or tests (existing example suffice)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Swap colors around in `TwoColorLineSeries`: other multi-color series seem to be fine.

@oxyplot/admins
