### PR TITLE
Fix font weight not being applied in ImageSharp. Issue #2006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Placement of BarSeries labels when stacked (#1979)
 - SystemInvalidException in LineSeries when only Double.Nan values are added (#1991)
 - Issue with tracking AreaSeries with monotonic data points (#1982)
+- Font weight not being applied in ImageSharp (#2006)
 
 ## [2.1.2] - 2022-12-03
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -63,6 +63,7 @@ Iain Nicol <git@iainnicol.com>
 Ilja Nosik <ilja.nosik@outlook.com>
 Ilya Skriblovsky <IlyaSkriblovsky@gmail.com>
 Iurii Gazin <archeg@gmail.com>
+IzStriker <IzStriker@users.noreply.github.com>
 Jānis Kiršteins <janis@janiskirsteins.org>
 jaykul
 Jens Krumsieck <j.krumsieck@outlook.de>

--- a/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
+++ b/Source/OxyPlot.ImageSharp/ImageRenderContext.cs
@@ -548,11 +548,11 @@ namespace OxyPlot.ImageSharp
             }
         }
 
-        private Font GetFontOrThrow(string fontFamily, double fontSize, FontStyle regular, bool allowFallback = true)
+        private Font GetFontOrThrow(string fontFamily, double fontSize, FontStyle fontWeight, bool allowFallback = true)
         {
             var family = this.GetFamilyOrFallbackOrThrow(fontFamily, allowFallback);
             var actualFontSize = this.NominalFontSizeToPoints(fontSize);
-            return new Font(family, (float)actualFontSize, FontStyle.Regular);
+            return new Font(family, (float)actualFontSize, fontWeight);
         }
 
         private FontFamily GetFamilyOrFallbackOrThrow(string fontFamily = null, bool allowFallback = true)


### PR DESCRIPTION
Fixes #2006 where provided font weight wasn't applied when generating graphs and always defaulted to `FontWeights.Normal`.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Apply appropriate font-weight in ImageSharp as already done with other platforms.


@oxyplot/admins
