### PR TITLE
Update SkiaSharp to v2.88.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Move example projects to .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Run tests on both .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Add support for .NET 7.0 (#1937)
+- Update SkiaSharp to Version 2.88.3
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)
@@ -30,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - HitTest when IsLegendVisible is false (#1975)
 - Font weight not being applied in ImageSharp (#2006)
 - SkiaSharp - Fix use of obsolete functions (#1937)
+- Dashed lines are solid when exporting via SkiaSharp.SvgExporter (#1674)
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
@@ -11,7 +11,7 @@
     <AssemblyOriginatorKeyFile>OxyPlot.SkiaSharp.Wpf.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="1.68.3" />
+    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.88.3" />
     <None Include="OxyPlot.SkiaSharp.Wpf.snk" />
     <None Include="VisualStudioToolsManifest.xml" Pack="true" PackagePath="tools" />
   </ItemGroup>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -13,8 +13,8 @@
     <AssemblyOriginatorKeyFile>OxyPlot.SkiaSharp.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="1.68.3" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="1.68.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="OxyPlot.SkiaSharp.snk" />


### PR DESCRIPTION
Fixes #1674.
Also probably generally a good idea to stay up to date.

### Checklist

- [ ] I have included examples or tests (existing samples are sufficient)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Update SkiaSharp to 2.88.3. This is trivial since #1937 is merged.

@oxyplot/admins
