### PR TITLE
Remove unused LabelColor property (#2030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)
+- Unused LabelColor property from TornadoBarSeries, IntervalBarSeries, and RectangleBarSeries (#2030)
 
 ### Fixed
 - Placement of BarSeries labels when stacked (#1979)

--- a/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/IntervalBarSeries.cs
@@ -32,7 +32,6 @@ namespace OxyPlot.Series
         /// </summary>
         public IntervalBarSeries()
         {
-            this.LabelColor = OxyColors.Automatic;
             this.FillColor = OxyColors.Automatic;
             this.StrokeThickness = 1;
 

--- a/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/RectangleBarSeries.cs
@@ -35,7 +35,6 @@ namespace OxyPlot.Series
             this.Items = new List<RectangleBarItem>();
 
             this.FillColor = OxyColors.Automatic;
-            this.LabelColor = OxyColors.Automatic;
             this.StrokeColor = OxyColors.Black;
             this.StrokeThickness = 1;
 
@@ -66,11 +65,6 @@ namespace OxyPlot.Series
         /// Gets the rectangle bar items.
         /// </summary>
         public IList<RectangleBarItem> Items { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the label color.
-        /// </summary>
-        public OxyColor LabelColor { get; set; }
 
         /// <summary>
         /// Gets or sets the format string for the labels.

--- a/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
+++ b/Source/OxyPlot/Series/BarSeries/TornadoBarSeries.cs
@@ -41,7 +41,6 @@ namespace OxyPlot.Series
             this.MaximumFillColor = OxyColor.FromRgb(216, 82, 85);
             this.MinimumFillColor = OxyColor.FromRgb(84, 138, 209);
 
-            this.LabelColor = OxyColors.Automatic;
             this.StrokeColor = OxyColors.Black;
             this.StrokeThickness = 1;
 


### PR DESCRIPTION
Fixes #2030 .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove Unused LabelColor property from TornadoBarSeries, IntervalBarSeries, and RectangleBarSeries 

This is a breaking change. Users expecting this property should use the `TextColor`.

@oxyplot/admins
