### PR TITLE
Fix TileMapAnnotation example

### DIFF
--- a/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotation.cs
+++ b/Source/Examples/ExampleLibrary/Annotations/TileMapAnnotation.cs
@@ -317,7 +317,7 @@ namespace ExampleLibrary
             var request = (HttpWebRequest)WebRequest.Create(uri);
             request.Method = "GET";
 
-#if NET45
+#if NETFRAMEWORK
             // unavailable in NET Standard 1.0
             request.UserAgent = this.UserAgent;
 #else


### PR DESCRIPTION
Fixes TileMapAnnotation under .NET 4.6.2

Missed this when we bumped all the net framework versions. I don't see any other dodgy #ifs

### Checklist

- [x] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
