### PR TITLE
Implement LogarithmicColorAxis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 - Run tests on both .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Add support for .NET 7.0 (#1937)
 - Update SkiaSharp to Version 2.88.6
-- AxisRenderBase is now generic
+- AxisRendererBase is now generic
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Border properties on PathAnnotation to match functionality in TextAnnotation (#1900)
 - Expanded `IntervalBarSeries` and `TornadoBarSeries` to allow for varied label positions and angles (#2027)
 - VectorSeries (#107)
+- LogarithmicColorAxis (#92)
 
 ### Changed
 - Make consistent BaseValue and BaseLine across BarSeries, LinearBarSeries, and HistogramSeries
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Run tests on both .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Add support for .NET 7.0 (#1937)
 - Update SkiaSharp to Version 2.88.6
+- AxisRenderBase is now generic
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)

--- a/Source/Examples/ExampleLibrary/Axes/LinearColorAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/LinearColorAxisExamples.cs
@@ -8,231 +8,57 @@ namespace ExampleLibrary
 {
     using OxyPlot;
     using OxyPlot.Axes;
+    using System.Linq;
 
     [Examples("LinearColorAxis"), Tags("Axes")]
     public class LinearColorAxisExamples
     {
-        [Example("Default palette")]
-        public static PlotModel DefaultPalette()
+        private static PlotModel EnableRenderAsImage(PlotModel plotModel)
         {
-            var model = HeatMapSeriesExamples.CreatePeaks(null, false);
-            model.Axes.Clear();
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right });
-            return model;
+            var axis = plotModel.Axes.OfType<LinearColorAxis>().Single();
+            axis.RenderAsImage = true;
+            plotModel.Title += " - RenderAsImage";
+            return plotModel;
         }
 
-        [Example("Jet (200 colors) palette")]
-        public static PlotModel Jet200()
+        [Example("Peaks")]
+        public static PlotModel Peaks()
         {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(200), false);
+            return HeatMapSeriesExamples.CreatePeaks(null, false);
         }
 
-        [Example("Jet (20 colors) palette")]
-        public static PlotModel Jet20()
+        [Example("Peaks - RenderAsImage")]
+        public static PlotModel PeaksRenderAsImage()
         {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(20), false);
+            return EnableRenderAsImage(Peaks());
         }
 
-        [Example("Hue (400 colors) palette")]
-        public static PlotModel Hue400()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hue(400), false);
-        }
-
-        [Example("Hue distinct (200 colors) palette")]
-        public static PlotModel HueDistinct200()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.HueDistinct(200), false);
-        }
-
-        [Example("Hue distinct reversed (200 colors) palette")]
-        public static PlotModel HueDistinctReverse200()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.HueDistinct(200).Reverse(), false);
-        }
-
-        [Example("Hot (200 colors) palette")]
-        public static PlotModel Hot200()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hot(200), false);
-        }
-
-        [Example("Hot (64 colors) palette")]
-        public static PlotModel Hot64()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hot64, false);
-        }
-
-        [Example("Hot (30 colors) palette")]
-        public static PlotModel Hot30()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hot(30), false);
-        }
-
-        [Example("Blue-white-red (200 colors) palette")]
-        public static PlotModel BlueWhiteRed200()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlueWhiteRed(200), false);
-        }
-
-        [Example("Blue-white-red (40 colors) palette")]
-        public static PlotModel BlueWhiteRed40()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlueWhiteRed(40), false);
-        }
-
-        [Example("Black-white-red (500 colors) palette")]
-        public static PlotModel BlackWhiteRed500()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlackWhiteRed(500), false);
-        }
-
-        [Example("Black-white-red (3 colors) palette")]
-        public static PlotModel BlackWhiteRed3()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlackWhiteRed(3), false);
-        }
-
-        [Example("Cool (200 colors) palette")]
-        public static PlotModel Cool200()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Cool(200), false);
-        }
-
-        [Example("Rainbow (200 colors) palette")]
-        public static PlotModel Rainbow200()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Rainbow(200), false);
-        }
-
-        [Example("Viridis palette")]
-        public static PlotModel Viridis()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Viridis(), false);
-        }
-
-        [Example("Plasma palette")]
-        public static PlotModel Plasma()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Plasma(), false);
-        }
-
-        [Example("Magma palette")]
-        public static PlotModel Magma()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Magma(), false);
-        }
-
-        [Example("Inferno palette")]
-        public static PlotModel Inferno()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Inferno(), false);
-        }
-
-        [Example("Cividis palette")]
-        public static PlotModel Cividis()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Cividis(), false);
-        }
-
-        [Example("Viridis (10 colors) palette")]
-        public static PlotModel Viridis10()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Viridis(10), false);
-        }
-
-        [Example("Rainbow (7 colors) palette")]
-        public static PlotModel Rainbow7()
-        {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Rainbow(7), false);
-        }
-
-        [Example("Vertical (6 colors)")]
-        public static PlotModel Vertical_6()
+        [Example("6 Colors")]
+        public static PlotModel Horizontal6()
         {
             return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(6), false);
         }
 
-        [Example("Vertical reverse (6 colors)")]
-        public static PlotModel Vertical_Reverse_6()
+        [Example("6 Colors - RenderAsImage")]
+        public static PlotModel Horizontal6RenderAsImage()
         {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(6), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.StartPosition = 1;
-            colorAxis.EndPosition = 0;
-            return model;
+            return EnableRenderAsImage(Horizontal6());
         }
 
-        [Example("Horizontal (6 colors)")]
-        public static PlotModel Horizontal_6()
-        {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(6), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.Position = AxisPosition.Top;
-            return model;
-        }
-
-        [Example("Horizontal reverse (6 colors)")]
-        public static PlotModel Horizontal_Reverse_6()
-        {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(6), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.Position = AxisPosition.Top;
-            colorAxis.StartPosition = 1;
-            colorAxis.EndPosition = 0;
-            return model;
-        }
-
-        [Example("RenderAsImage (horizontal)")]
-        public static PlotModel RenderAsImage_Horizontal()
-        {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(1000), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.RenderAsImage = true;
-            colorAxis.Position = AxisPosition.Top;
-            return model;
-        }
-
-        [Example("RenderAsImage (horizontal reversed)")]
-        public static PlotModel RenderAsImage_Horizontal_Reversed()
-        {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(1000), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.RenderAsImage = true;
-            colorAxis.Position = AxisPosition.Top;
-            colorAxis.StartPosition = 1;
-            colorAxis.EndPosition = 0;
-            return model;
-        }
-
-        [Example("RenderAsImage (vertical)")]
-        public static PlotModel RenderAsImage_Vertical()
-        {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(1000), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.RenderAsImage = true;
-            return model;
-        }
-
-        [Example("RenderAsImage (vertical reversed)")]
-        public static PlotModel RenderAsImage_Vertical_Reversed()
-        {
-            var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(1000), false);
-            var colorAxis = (LinearColorAxis)model.Axes[0];
-            colorAxis.RenderAsImage = true;
-            colorAxis.StartPosition = 1;
-            colorAxis.EndPosition = 0;
-            return model;
-        }
-
-        [Example("Short vertical")]
-        public static PlotModel Vertical_Short()
+        [Example("Short")]
+        public static PlotModel Short()
         {
             var model = HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(600), false);
             var colorAxis = (LinearColorAxis)model.Axes[0];
             colorAxis.StartPosition = 0.02;
             colorAxis.EndPosition = 0.5;
             return model;
+        }
+
+        [Example("Short - RenderAsImage")]
+        public static PlotModel ShortRenderAsImage()
+        {
+            return EnableRenderAsImage(Short());
         }
 
         [Example("Position None")]

--- a/Source/Examples/ExampleLibrary/Axes/LogarithmicColorAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/LogarithmicColorAxisExamples.cs
@@ -1,0 +1,85 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LinearColorAxisExamples.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ExampleLibrary
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
+    using System.Linq;
+
+    [Examples("LogarithmicColorAxis"), Tags("Axes")]
+    public class LogarithmicColorAxisExamples
+    {
+        private static PlotModel ConvertToLogarithmic(PlotModel model)
+        {
+            var linearAxis = model.Axes.OfType<LinearColorAxis>().Single();
+            model.Axes.Remove(linearAxis);
+            var logarithmicAxis = new LogarithmicColorAxis() 
+            { 
+                Position = linearAxis.Position,
+                Palette = linearAxis.Palette,
+                StartPosition = linearAxis.StartPosition,
+                EndPosition = linearAxis.EndPosition,
+                HighColor = linearAxis.HighColor,
+                LowColor = linearAxis.LowColor,
+                InvalidNumberColor = linearAxis.InvalidNumberColor,
+            };
+
+            var series = model.Series.OfType<HeatMapSeries>().Single();
+            for (int x = 0; x < series.Data.GetLength(0); x++)
+            for (int y = 0; y < series.Data.GetLength(1); y++)
+            {
+                series.Data[x, y] += 6.6;
+            }
+
+            model.Axes.Add(logarithmicAxis);
+            return model;
+        }
+
+        [Example("Peaks")]
+        public static PlotModel Peaks()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.Peaks());
+        }
+
+        [Example("Peaks - RenderAsImage")]
+        public static PlotModel PeaksRenderAsImage()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.PeaksRenderAsImage());
+        }
+
+        [Example("6 colors")]
+        public static PlotModel Horizontal6()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.Horizontal6());
+        }
+
+        [Example("6 colors - RenderAsImage")]
+        public static PlotModel Horizontal6RenderAsImage()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.Horizontal6RenderAsImage());
+        }
+
+        [Example("Short")]
+        public static PlotModel Short()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.Short());
+        }
+
+        [Example("Short - RenderAsImage")]
+        public static PlotModel ShortRenderAsImage()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.ShortRenderAsImage());
+        }
+
+        [Example("Position None")]
+        public static PlotModel Position_None()
+        {
+            return ConvertToLogarithmic(LinearColorAxisExamples.Position_None());
+        }
+    }
+}

--- a/Source/Examples/ExampleLibrary/Axes/LogarithmicColorAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/LogarithmicColorAxisExamples.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="LinearColorAxisExamples.cs" company="OxyPlot">
+// <copyright file="LogarithmicColorAxisExamples.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
@@ -5,6 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Example models for OxyPlot.</Description>
     <PackageTags>plotting plot charting chart</PackageTags>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Resources\DodgyContourData.tsv" />

--- a/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="LinearColorAxisExamples.cs" company="OxyPlot">
+// <copyright file="PaletteExamples.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
@@ -1,0 +1,146 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LinearColorAxisExamples.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ExampleLibrary
+{
+    using OxyPlot;
+
+    [Examples("Palettes")]
+    public class PaletteExamples
+    {
+        [Example("Default palette")]
+        public static PlotModel DefaultPalette()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(null, false);
+        }
+
+        [Example("Jet (200 colors) palette")]
+        public static PlotModel Jet200()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(200), false);
+        }
+
+        [Example("Jet (20 colors) palette")]
+        public static PlotModel Jet20()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(20), false);
+        }
+
+        [Example("Hue (400 colors) palette")]
+        public static PlotModel Hue400()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hue(400), false);
+        }
+
+        [Example("Hue distinct (200 colors) palette")]
+        public static PlotModel HueDistinct200()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.HueDistinct(200), false);
+        }
+
+        [Example("Hot (200 colors) palette")]
+        public static PlotModel Hot200()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hot(200), false);
+        }
+
+        [Example("Hot (64 colors) palette")]
+        public static PlotModel Hot64()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hot64, false);
+        }
+
+        [Example("Hot (30 colors) palette")]
+        public static PlotModel Hot30()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Hot(30), false);
+        }
+
+        [Example("Blue-white-red (200 colors) palette")]
+        public static PlotModel BlueWhiteRed200()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlueWhiteRed(200), false);
+        }
+
+        [Example("Blue-white-red (40 colors) palette")]
+        public static PlotModel BlueWhiteRed40()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlueWhiteRed(40), false);
+        }
+
+        [Example("Black-white-red (500 colors) palette")]
+        public static PlotModel BlackWhiteRed500()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlackWhiteRed(500), false);
+        }
+
+        [Example("Black-white-red (3 colors) palette")]
+        public static PlotModel BlackWhiteRed3()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.BlackWhiteRed(3), false);
+        }
+
+        [Example("Cool (200 colors) palette")]
+        public static PlotModel Cool200()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Cool(200), false);
+        }
+
+        [Example("Rainbow (200 colors) palette")]
+        public static PlotModel Rainbow200()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Rainbow(200), false);
+        }
+
+        [Example("Viridis palette")]
+        public static PlotModel Viridis()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Viridis(), false);
+        }
+
+        [Example("Plasma palette")]
+        public static PlotModel Plasma()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Plasma(), false);
+        }
+
+        [Example("Magma palette")]
+        public static PlotModel Magma()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Magma(), false);
+        }
+
+        [Example("Inferno palette")]
+        public static PlotModel Inferno()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Inferno(), false);
+        }
+
+        [Example("Cividis palette")]
+        public static PlotModel Cividis()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Cividis(), false);
+        }
+
+        [Example("Viridis (10 colors) palette")]
+        public static PlotModel Viridis10()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Viridis(10), false);
+        }
+
+        [Example("Rainbow (7 colors) palette")]
+        public static PlotModel Rainbow7()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Rainbow(7), false);
+        }
+
+        [Example("Jet (6 colors) palette")]
+        public static PlotModel Vertical_6()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(6), false);
+        }
+    }
+}

--- a/Source/Examples/ExampleLibrary/Series/HeatMapSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/HeatMapSeriesExamples.cs
@@ -37,7 +37,13 @@ namespace ExampleLibrary
             var peaksData = ArrayBuilder.Evaluate(peaks, xvalues, yvalues);
 
             var model = new PlotModel { Title = "Peaks" };
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = palette ?? OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
+            var colorAxis = new LinearColorAxis { Position = AxisPosition.Right, HighColor = OxyColors.Gray, LowColor = OxyColors.Black };
+            if (palette is not null)
+            {
+                colorAxis.Palette = palette;
+            }
+
+            model.Axes.Add(colorAxis);
 
             var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
             model.Series.Add(hms);

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot unit tests</Description>
+        <LangVersion>9</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn);CS0618</NoWarn>
     </PropertyGroup>

--- a/Source/OxyPlot.Tests/Utilities/HelpersTests.cs
+++ b/Source/OxyPlot.Tests/Utilities/HelpersTests.cs
@@ -21,7 +21,7 @@ namespace OxyPlot.Tests
         private readonly struct LinearInterpolationTestCase
         {
 
-            public LinearInterpolationTestCase(double x0, double x1, double y0, double y1, double x, double y) : this()
+            public LinearInterpolationTestCase(double x0, double y0, double x1, double y1, double x, double y) : this()
             {
                 this.X0 = x0;
                 this.X1 = x1;

--- a/Source/OxyPlot.Tests/Utilities/HelpersTests.cs
+++ b/Source/OxyPlot.Tests/Utilities/HelpersTests.cs
@@ -1,0 +1,68 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HelpersTests.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+
+    using NUnit.Framework;
+    using OxyPlot.Utilities;
+
+    // ReSharper disable InconsistentNaming
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Reviewed. Suppression is OK here.")]
+    [TestFixture]
+    public class HelpersTests
+    {
+        private readonly struct LinearInterpolationTestCase
+        {
+
+            public LinearInterpolationTestCase(double x0, double x1, double y0, double y1, double x, double y) : this()
+            {
+                this.X0 = x0;
+                this.X1 = x1;
+                this.Y0 = y0;
+                this.Y1 = y1;
+                this.X = x;
+                this.Y = y;
+            }
+
+            public double X0 { get; }
+            public double X1 { get; }
+            public double Y0 { get; }
+            public double Y1 { get; }
+            public double X { get; }
+            public double Y { get; }
+        }
+
+        [Test]
+        public void LinearInterpolation()
+        {
+            var testCases = new LinearInterpolationTestCase[]
+            {
+                //   x0   y0   x1   y1    x      y
+                new(  0,   0,   1,   1,   0.5,   0.5),
+                new(  0,   0,   1,   1,   0  ,   0  ),
+                new(  0,   0,   1,   1,   1  ,   1  ),
+                new(  0,   0,   1,   1,   0.1,   0.1),
+                new(  0,   0,   1,   1,   0.9,   0.9),
+                new(  0, -10,   1,  10,   0  , -10  ),
+                new(  0, -10,   1,  10,   0.5,   0  ),
+                new(  0, -10,   1,  10,   1  ,  10  ),
+                new(-10,   0,  10,   1, -10  ,   0  ),
+                new(-10,   0,  10,   1,   0  ,   0.5),
+                new(-10,   0,  10,   1,  10  ,   1  ),
+            };
+
+            foreach (var tc in testCases)
+            {
+                var result = Helpers.LinearInterpolation(tc.X0, tc.Y0, tc.X1, tc.Y1, tc.X);
+                Assert.AreEqual(tc.Y, result);
+            }
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/CategoryColorAxis.cs
+++ b/Source/OxyPlot/Axes/CategoryColorAxis.cs
@@ -9,7 +9,7 @@
 
 namespace OxyPlot.Axes
 {
-    using System;
+    using OxyPlot.Axes.Rendering;
     using System.Collections.Generic;
 
     /// <summary>
@@ -68,89 +68,11 @@ namespace OxyPlot.Axes
             return (int)value;
         }
 
-        /// <summary>
-        /// Renders the axis on the specified render context.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
-        /// <param name="pass">The pass.</param>
+        /// <inheritdoc />
         public override void Render(IRenderContext rc, int pass)
         {
-            if (this.Position == AxisPosition.None)
-            {
-                return;
-            }
-
-            if (pass == 0)
-            {
-                double left = this.PlotModel.PlotArea.Left;
-                double top = this.PlotModel.PlotArea.Top;
-                double width = this.MajorTickSize - 2;
-                double height = this.MajorTickSize - 2;
-
-                switch (this.Position)
-                {
-                    case AxisPosition.Left:
-                        left = this.PlotModel.PlotArea.Left - this.PositionTierMinShift - width;
-                        top = this.PlotModel.PlotArea.Top;
-                        break;
-                    case AxisPosition.Right:
-                        left = this.PlotModel.PlotArea.Right + this.PositionTierMinShift;
-                        top = this.PlotModel.PlotArea.Top;
-                        break;
-                    case AxisPosition.Top:
-                        left = this.PlotModel.PlotArea.Left;
-                        top = this.PlotModel.PlotArea.Top - this.PositionTierMinShift - height;
-                        break;
-                    case AxisPosition.Bottom:
-                        left = this.PlotModel.PlotArea.Left;
-                        top = this.PlotModel.PlotArea.Bottom + this.PositionTierMinShift;
-                        break;
-                }
-
-                Action<double, double, OxyColor> drawColorRect = (ylow, yhigh, color) =>
-                {
-                    double ymin = Math.Min(ylow, yhigh);
-                    double ymax = Math.Max(ylow, yhigh);
-                    rc.DrawRectangle(
-                        this.IsHorizontal()
-                            ? new OxyRect(ymin, top, ymax - ymin, height)
-                            : new OxyRect(left, ymin, width, ymax - ymin),
-                        color,
-                        OxyColors.Undefined,
-                        0,
-                        this.EdgeRenderingMode);
-                };
-
-                IList<double> majorLabelValues;
-                IList<double> majorTickValues;
-                IList<double> minorTickValues;
-                this.GetTickValues(out majorLabelValues, out majorTickValues, out minorTickValues);
-
-                int n = this.Palette.Colors.Count;
-                for (int i = 0; i < n; i++)
-                {
-                    double low = this.Transform(this.GetLowValue(i, majorLabelValues));
-                    double high = this.Transform(this.GetHighValue(i, majorLabelValues));
-                    drawColorRect(low, high, this.Palette.Colors[i]);
-                }
-            }
-
-            base.Render(rc, pass);
-        }
-
-        /// <summary>
-        /// Gets the high value of the specified palette index.
-        /// </summary>
-        /// <param name="paletteIndex">Index of the palette.</param>
-        /// <returns>The value.</returns>
-        protected double GetHighValue(int paletteIndex)
-        {
-            IList<double> majorLabelValues;
-            IList<double> majorTickValues;
-            IList<double> minorTickValues;
-            this.GetTickValues(out majorLabelValues, out majorTickValues, out minorTickValues);
-            var highValue = this.GetHighValue(paletteIndex, majorLabelValues);
-            return highValue;
+            var renderer = new CategoryColorAxisRenderer(rc, this.PlotModel);
+            renderer.Render(this, pass);
         }
 
         /// <summary>
@@ -159,7 +81,7 @@ namespace OxyPlot.Axes
         /// <param name="paletteIndex">Index of the palette.</param>
         /// <param name="majorLabelValues">The major label values.</param>
         /// <returns>The value.</returns>
-        private double GetHighValue(int paletteIndex, IList<double> majorLabelValues)
+        protected internal double GetHighValue(int paletteIndex, IList<double> majorLabelValues)
         {
             double highValue = paletteIndex >= this.Palette.Colors.Count - 1
                                    ? this.ClipMaximum
@@ -173,7 +95,7 @@ namespace OxyPlot.Axes
         /// <param name="paletteIndex">Index of the palette.</param>
         /// <param name="majorLabelValues">The major label values.</param>
         /// <returns>The value.</returns>
-        private double GetLowValue(int paletteIndex, IList<double> majorLabelValues)
+        protected internal double GetLowValue(int paletteIndex, IList<double> majorLabelValues)
         {
             double lowValue = paletteIndex == 0
                                   ? this.ClipMinimum

--- a/Source/OxyPlot/Axes/ColorAxisExtensions.cs
+++ b/Source/OxyPlot/Axes/ColorAxisExtensions.cs
@@ -24,5 +24,53 @@ namespace OxyPlot.Axes
         {
             return axis.GetColor(axis.GetPaletteIndex(value));
         }
+
+        /// <summary>
+        /// Gets the high value of the specified palette index.
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="paletteIndex">Index of the palette.</param>
+        /// <returns>The value.</returns>
+        public static double GetHighValue<T>(this T axis, int paletteIndex) where T: Axis, INumericColorAxis
+        {
+            return axis.GetLowValue(paletteIndex + 1);
+        }
+
+        /// <summary>
+        /// Gets the low value of the specified palette index.
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="paletteIndex">Index of the palette.</param>
+        /// <returns>The value.</returns>
+        public static double GetLowValue<T>(this T axis, int paletteIndex) where T : Axis, INumericColorAxis
+        {
+            return (double)paletteIndex / axis.Palette.Colors.Count * (axis.ClipMaximum - axis.ClipMinimum) + axis.ClipMinimum;
+        }
+
+        /// <summary>
+        /// Gets the color.
+        /// </summary>
+        /// <param name="axis">The axis.</param>
+        /// <param name="paletteIndex">The color map index (less than NumberOfEntries).</param>
+        /// <returns>The color.</returns>
+        public static OxyColor GetColor<T>(this T axis, int paletteIndex) where T : Axis, INumericColorAxis
+        {
+            if (paletteIndex == int.MinValue)
+            {
+                return axis.InvalidNumberColor;
+            }
+
+            if (paletteIndex == 0)
+            {
+                return axis.LowColor;
+            }
+
+            if (paletteIndex == axis.Palette.Colors.Count + 1)
+            {
+                return axis.HighColor;
+            }
+
+            return axis.Palette.Colors[paletteIndex - 1];
+        }
     }
 }

--- a/Source/OxyPlot/Axes/IColorAxis.cs
+++ b/Source/OxyPlot/Axes/IColorAxis.cs
@@ -30,3 +30,4 @@ namespace OxyPlot.Axes
         int GetPaletteIndex(double value);
     }
 }
+

--- a/Source/OxyPlot/Axes/INumericColorAxis.cs
+++ b/Source/OxyPlot/Axes/INumericColorAxis.cs
@@ -1,0 +1,44 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="INumericColorAxis.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes
+{
+    /// <summary>
+    /// Specifies functionality for numeric color axes.
+    /// </summary>
+    public interface INumericColorAxis : IColorAxis
+    {
+        /// <summary>
+        /// Gets or sets the palette.
+        /// </summary>
+        /// <value>The palette.</value>
+        OxyPalette Palette { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of values above the maximum value.
+        /// </summary>
+        /// <value>The color of the high values.</value>
+        OxyColor HighColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of values below the minimum value.
+        /// </summary>
+        /// <value>The color of the low values.</value>
+        OxyColor LowColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color used to represent NaN values.
+        /// </summary>
+        /// <value>A <see cref="OxyColor" /> that defines the color. The default value is <c>OxyColors.Gray</c>.</value>
+        OxyColor InvalidNumberColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to render the colors as an image.
+        /// </summary>
+        /// <value><c>true</c> if the rendering should use an image; otherwise, <c>false</c>.</value>
+        bool RenderAsImage { get; set; }
+    }
+}

--- a/Source/OxyPlot/Axes/LogarithmicAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicAxis.cs
@@ -207,8 +207,7 @@ namespace OxyPlot.Axes
         /// <returns>The value.</returns>
         public override double InverseTransform(double sx)
         {
-            // Inline the <see cref="PostInverseTransform" /> method here.
-            return Math.Exp((sx / this.Scale) + this.Offset);
+            return this.PostInverseTransform((sx / this.Scale) + this.Offset);
         }
 
         /// <summary>
@@ -223,8 +222,7 @@ namespace OxyPlot.Axes
                 return -1;
             }
 
-            // Inline the <see cref="PreTransform" /> method here.
-            return (Math.Log(x) - this.Offset) * this.Scale;
+            return (this.PreTransform(x) - this.Offset) * this.Scale;
         }
 
         /// <summary>
@@ -589,10 +587,10 @@ namespace OxyPlot.Axes
         /// <inheritdoc />
         protected override void ActualMaximumAndMinimumChangedOverride()
         {
-            this.LogActualMinimum = Math.Log(this.ActualMinimum, this.Base);
-            this.LogActualMaximum = Math.Log(this.ActualMaximum, this.Base);
-            this.LogClipMinimum = Math.Log(this.ClipMinimum, this.Base);
-            this.LogClipMaximum = Math.Log(this.ClipMaximum, this.Base);
+            this.LogActualMinimum = this.PreTransform(this.ActualMinimum);
+            this.LogActualMaximum = this.PreTransform(this.ActualMaximum);
+            this.LogClipMinimum = this.PreTransform(this.ClipMinimum);
+            this.LogClipMaximum = this.PreTransform(this.ClipMaximum);
         }
 
         /// <summary>
@@ -602,7 +600,7 @@ namespace OxyPlot.Axes
         /// <returns>The transformed value.</returns>
         protected override double PostInverseTransform(double x)
         {
-            return Math.Exp(x);
+            return Math.Pow(this.Base, x);
         }
 
         /// <summary>
@@ -614,7 +612,7 @@ namespace OxyPlot.Axes
         {
             Debug.Assert(x > 0, "Value should be positive.");
 
-            return x <= 0 ? 0 : Math.Log(x);
+            return x <= 0 ? 0 : Math.Log(x, this.Base);
         }
 
         /// <summary>

--- a/Source/OxyPlot/Axes/LogarithmicColorAxis.cs
+++ b/Source/OxyPlot/Axes/LogarithmicColorAxis.cs
@@ -1,25 +1,23 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="LinearColorAxis.cs" company="OxyPlot">
+// <copyright file="LogarithmicColorAxis.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
-// <summary>
-//   Represents a linear color axis.
-// </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace OxyPlot.Axes
 {
     using OxyPlot.Axes.Rendering;
+    using System;
 
     /// <summary>
-    /// Represents a linear color axis.
+    /// Represents a logarithmic color axis.
     /// </summary>
-    public class LinearColorAxis : LinearAxis, INumericColorAxis
+    public class LogarithmicColorAxis : LogarithmicAxis, INumericColorAxis
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LinearColorAxis" /> class.
         /// </summary>
-        public LinearColorAxis()
+        public LogarithmicColorAxis()
         {
             this.Position = AxisPosition.None;
             this.AxisDistance = 20;
@@ -57,7 +55,7 @@ namespace OxyPlot.Axes
         /// <inheritdoc />
         public override void Render(IRenderContext rc, int pass)
         {
-            var renderer = new NumericColorAxisRenderer<LinearColorAxis>(rc, this.PlotModel);
+            var renderer = new NumericColorAxisRenderer<LogarithmicColorAxis>(rc, this.PlotModel);
             renderer.Render(this, pass);
         }
 
@@ -84,7 +82,9 @@ namespace OxyPlot.Axes
                 return this.Palette.Colors.Count + 1;
             }
 
-            int index = 1 + (int)((value - this.ClipMinimum) / (this.ClipMaximum - this.ClipMinimum) * this.Palette.Colors.Count);
+            var logValue = this.PreTransform(value);
+
+            int index = 1 + (int)((logValue - this.LogClipMinimum) / (this.LogClipMaximum - this.LogClipMinimum) * this.Palette.Colors.Count);
 
             if (index < 1)
             {

--- a/Source/OxyPlot/Axes/RangeColorAxis.cs
+++ b/Source/OxyPlot/Axes/RangeColorAxis.cs
@@ -9,7 +9,7 @@
 
 namespace OxyPlot.Axes
 {
-    using System;
+    using OxyPlot.Axes.Rendering;
     using System.Collections.Generic;
 
     /// <summary>
@@ -20,7 +20,7 @@ namespace OxyPlot.Axes
         /// <summary>
         /// The ranges
         /// </summary>
-        private readonly List<ColorRange> ranges = new List<ColorRange>();
+        internal readonly List<ColorRange> ranges = new List<ColorRange>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RangeColorAxis" /> class.
@@ -131,126 +131,17 @@ namespace OxyPlot.Axes
             return this.ranges[paletteIndex].Color;
         }
 
-        /// <summary>
-        /// Renders the axis on the specified render context.
-        /// </summary>
-        /// <param name="rc">The render context.</param>
-        /// <param name="pass">The render pass.</param>
+        /// <inheritdoc />
         public override void Render(IRenderContext rc, int pass)
         {
-            if (this.Position == AxisPosition.None)
-            {
-                return;
-            }
-
-            if (pass == 0)
-            {
-                double distance = this.AxisDistance;
-                double left = this.PlotModel.PlotArea.Left;
-                double top = this.PlotModel.PlotArea.Top;
-                double width = this.MajorTickSize - 2;
-                double height = this.MajorTickSize - 2;
-
-                const int TierShift = 0;
-
-                switch (this.Position)
-                {
-                    case AxisPosition.Left:
-                        left = this.PlotModel.PlotArea.Left - TierShift - width - distance;
-                        top = this.PlotModel.PlotArea.Top;
-                        break;
-                    case AxisPosition.Right:
-                        left = this.PlotModel.PlotArea.Right + TierShift + distance;
-                        top = this.PlotModel.PlotArea.Top;
-                        break;
-                    case AxisPosition.Top:
-                        left = this.PlotModel.PlotArea.Left;
-                        top = this.PlotModel.PlotArea.Top - TierShift - height - distance;
-                        break;
-                    case AxisPosition.Bottom:
-                        left = this.PlotModel.PlotArea.Left;
-                        top = this.PlotModel.PlotArea.Bottom + TierShift + distance;
-                        break;
-                }
-
-                Action<double, double, OxyColor> drawColorRect = (ylow, yhigh, color) =>
-                {
-                    double ymin = Math.Min(ylow, yhigh);
-                    double ymax = Math.Max(ylow, yhigh);
-                    rc.DrawRectangle(
-                        this.IsHorizontal()
-                            ? new OxyRect(ymin, top, ymax - ymin, height)
-                            : new OxyRect(left, ymin, width, ymax - ymin),
-                        color,
-                        OxyColors.Undefined,
-                        0,
-                        this.EdgeRenderingMode);
-                };
-
-                // if the axis is reversed then the min and max values need to be swapped.
-                double effectiveMaxY = this.Transform(this.IsReversed ? this.ActualMinimum : this.ActualMaximum);
-                double effectiveMinY = this.Transform(this.IsReversed ? this.ActualMaximum : this.ActualMinimum);
-
-                foreach (ColorRange range in this.ranges)
-                {
-                    double ylow = this.Transform(range.LowerBound);
-                    double yhigh = this.Transform(range.UpperBound);
-
-                    if (this.IsHorizontal())
-                    {
-                        if (ylow < effectiveMinY)
-                        {
-                            ylow = effectiveMinY;
-                        }
-
-                        if (yhigh > effectiveMaxY)
-                        {
-                            yhigh = effectiveMaxY;
-                        }
-                    }
-                    else
-                    {
-                        if (ylow > effectiveMinY)
-                        {
-                            ylow = effectiveMinY;
-                        }
-
-                        if (yhigh < effectiveMaxY)
-                        {
-                            yhigh = effectiveMaxY;
-                        }
-                    }
-
-                    drawColorRect(ylow, yhigh, range.Color);
-                }
-
-                double highLowLength = 10;
-                if (this.IsHorizontal())
-                {
-                    highLowLength *= -1;
-                }
-
-                if (!this.LowColor.IsUndefined())
-                {
-                    double ylow = this.Transform(this.ActualMinimum);
-                    drawColorRect(ylow, ylow + highLowLength, this.LowColor);
-                }
-
-                if (!this.HighColor.IsUndefined())
-                {
-                    double yhigh = this.Transform(this.ActualMaximum);
-                    drawColorRect(yhigh, yhigh - highLowLength, this.HighColor);
-                }
-            }
-
-            var r = new HorizontalAndVerticalAxisRenderer(rc, this.PlotModel);
-            r.Render(this, pass);
+            var renderer = new RangeColorAxisRenderer(rc, this.PlotModel);
+            renderer.Render(this, pass);
         }
 
         /// <summary>
         /// Defines a range.
         /// </summary>
-        private class ColorRange
+        internal class ColorRange
         {
             /// <summary>
             /// Gets or sets the color.

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisFullPlotAreaRenderer.cs
@@ -15,7 +15,7 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Provides functionality to render <see cref="AngleAxis" /> using the full plot area.
     /// </summary>
-    public class AngleAxisFullPlotAreaRenderer : AxisRendererBase
+    public class AngleAxisFullPlotAreaRenderer : AxisRendererBase<AngleAxisFullPlotArea>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AngleAxisFullPlotAreaRenderer" /> class.
@@ -33,10 +33,8 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="pass">The render pass.</param>
         /// <exception cref="System.InvalidOperationException">Magnitude axis not defined.</exception>
-        public override void Render(Axis axis, int pass)
+        public override void Render(AngleAxisFullPlotArea axis, int pass)
         {
-            var angleAxis = (AngleAxis)axis;
-
             base.Render(axis, pass);
 
             var magnitudeAxis = this.Plot.DefaultMagnitudeAxis;
@@ -46,8 +44,8 @@ namespace OxyPlot.Axes
                 throw new InvalidOperationException("Magnitude axis not defined.");
             }
 
-            var scaledStartAngle = angleAxis.StartAngle / angleAxis.Scale;
-            var scaledEndAngle = angleAxis.EndAngle / angleAxis.Scale;
+            var scaledStartAngle = axis.StartAngle / axis.Scale;
+            var scaledEndAngle = axis.EndAngle / axis.Scale;
 
             var axisLength = Math.Abs(scaledEndAngle - scaledStartAngle);
             var eps = axis.MinorStep * 1e-3;
@@ -65,7 +63,7 @@ namespace OxyPlot.Axes
                 }
             }
 
-            var isFullCircle = Math.Abs(Math.Abs(Math.Max(angleAxis.EndAngle, angleAxis.StartAngle) - Math.Min(angleAxis.StartAngle, angleAxis.EndAngle)) - 360) < 1e-3;
+            var isFullCircle = Math.Abs(Math.Abs(Math.Max(axis.EndAngle, axis.StartAngle) - Math.Min(axis.StartAngle, axis.EndAngle)) - 360) < 1e-3;
             var majorTickCount = (int)(axisLength / axis.ActualMajorStep);
             if (!isFullCircle)
             {

--- a/Source/OxyPlot/Axes/Rendering/AngleAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/AngleAxisRenderer.cs
@@ -15,7 +15,7 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Provides functionality to render <see cref="AngleAxis" />.
     /// </summary>
-    public class AngleAxisRenderer : AxisRendererBase
+    public class AngleAxisRenderer : AxisRendererBase<AngleAxis>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AngleAxisRenderer" /> class.
@@ -33,10 +33,8 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="pass">The render pass.</param>
         /// <exception cref="System.InvalidOperationException">Magnitude axis not defined.</exception>
-        public override void Render(Axis axis, int pass)
+        public override void Render(AngleAxis axis, int pass)
         {
-            var angleAxis = (AngleAxis)axis;
-
             base.Render(axis, pass);
 
             var magnitudeAxis = this.Plot.DefaultMagnitudeAxis;
@@ -46,8 +44,8 @@ namespace OxyPlot.Axes
                 throw new InvalidOperationException("Magnitude axis not defined.");
             }
 
-            var scaledStartAngle = angleAxis.StartAngle / angleAxis.Scale;
-            var scaledEndAngle = angleAxis.EndAngle / angleAxis.Scale;
+            var scaledStartAngle = axis.StartAngle / axis.Scale;
+            var scaledEndAngle = axis.EndAngle / axis.Scale;
 
             var axisLength = Math.Abs(scaledEndAngle - scaledStartAngle);
             var eps = axis.MinorStep * 1e-3;
@@ -64,7 +62,7 @@ namespace OxyPlot.Axes
                 }
             }
 
-            var isFullCircle = Math.Abs(Math.Abs(Math.Max(angleAxis.EndAngle, angleAxis.StartAngle) - Math.Min(angleAxis.StartAngle, angleAxis.EndAngle)) - 360) < 1e-3;
+            var isFullCircle = Math.Abs(Math.Abs(Math.Max(axis.EndAngle, axis.StartAngle) - Math.Min(axis.StartAngle, axis.EndAngle)) - 360) < 1e-3;
             var majorTickCount = (int)(axisLength / axis.ActualMajorStep);
             if (!isFullCircle)
             {

--- a/Source/OxyPlot/Axes/Rendering/AxisRendererBase.cs
+++ b/Source/OxyPlot/Axes/Rendering/AxisRendererBase.cs
@@ -14,7 +14,7 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Provides an abstract base class for axis renderers.
     /// </summary>
-    public abstract class AxisRendererBase
+    public abstract class AxisRendererBase<T> where T: Axis
     {
         /// <summary>
         /// The plot.
@@ -42,7 +42,7 @@ namespace OxyPlot.Axes
         private IList<double> minorTickValues;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AxisRendererBase" /> class.
+        /// Initializes a new instance of the <see cref="AxisRendererBase{T}" /> class.
         /// </summary>
         /// <param name="rc">The render context.</param>
         /// <param name="plot">The plot.</param>
@@ -164,7 +164,7 @@ namespace OxyPlot.Axes
         /// </summary>
         /// <param name="axis">The axis.</param>
         /// <param name="pass">The pass.</param>
-        public virtual void Render(Axis axis, int pass)
+        public virtual void Render(T axis, int pass)
         {
             if (axis == null)
             {
@@ -179,7 +179,7 @@ namespace OxyPlot.Axes
         /// Creates the pens.
         /// </summary>
         /// <param name="axis">The axis.</param>
-        protected virtual void CreatePens(Axis axis)
+        protected virtual void CreatePens(T axis)
         {
             var minorTickColor = axis.MinorTicklineColor.IsAutomatic() ? axis.TicklineColor : axis.MinorTicklineColor;
 
@@ -201,7 +201,7 @@ namespace OxyPlot.Axes
         /// <param name="position">The position.</param>
         /// <param name="x0">The x 0.</param>
         /// <param name="x1">The x 1.</param>
-        protected virtual void GetTickPositions(Axis axis, TickStyle tickStyle, double tickSize, AxisPosition position, out double x0, out double x1)
+        protected virtual void GetTickPositions(T axis, TickStyle tickStyle, double tickSize, AxisPosition position, out double x0, out double x1)
         {
             x0 = 0;
             x1 = 0;

--- a/Source/OxyPlot/Axes/Rendering/CategoryColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/CategoryColorAxisRenderer.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes.Rendering
+{
+    /// <summary>
+    /// Provides functionality to render category color axes.
+    /// </summary>
+    public class CategoryColorAxisRenderer : ColorAxisRenderer<CategoryColorAxis>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CategoryColorAxisRenderer" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        public CategoryColorAxisRenderer(IRenderContext rc, PlotModel plot) : base(rc, plot)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void RenderColorBlock(CategoryColorAxis axis)
+        {
+            axis.GetTickValues(out var majorLabelValues, out _, out _);
+
+            for (var i = 0; i < axis.Palette.Colors.Count; i++)
+            {
+                var low = axis.Transform(axis.GetLowValue(i, majorLabelValues));
+                var high = axis.Transform(axis.GetHighValue(i, majorLabelValues));
+                this.DrawColorRect(axis, low, high, axis.Palette.Colors[i]);
+            }
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/Rendering/CategoryColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/CategoryColorAxisRenderer.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+// <copyright file="CategoryColorAxisRenderer.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/OxyPlot/Axes/Rendering/ColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/ColorAxisRenderer.cs
@@ -1,0 +1,128 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes.Rendering
+{
+    using System;
+
+    /// <summary>
+    /// Provides functionality to render color axes.
+    /// </summary>
+    public abstract class ColorAxisRenderer<T> : HorizontalAndVerticalAxisRenderer<T> where T: Axis, IColorAxis
+    {
+        /// <summary>
+        /// Position of the left edge of the color block.
+        /// </summary>
+        protected double left;
+
+        /// <summary>
+        /// Position of the top edge of the color block.
+        /// </summary>
+        protected double top;
+
+        /// <summary>
+        /// 'Size' of the color block; this is the width for vertical axes, or the height for horizontal axes.
+        /// </summary>
+        protected double size;
+
+        /// <summary>
+        /// Screen position of the minimum value of the axis.
+        /// </summary>
+        protected double minScreenPosition;
+
+        /// <summary>
+        /// Screen position of the maximum value of the axis.
+        /// </summary>
+        protected double maxScreenPosition;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorAxisRenderer{T}" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        public ColorAxisRenderer(IRenderContext rc, PlotModel plot) : base(rc, plot)
+        {
+        }
+
+        /// <summary>
+        /// Initializes fields containing information about position and size of the color axis on screen.
+        /// </summary>
+        /// <param name="axis">The color axis.</param>
+        protected virtual void InitPosition(T axis)
+        {
+            this.size = axis.MajorTickSize - 2;
+            var distance = axis.AxisDistance;
+            this.minScreenPosition = axis.Transform(axis.ClipMinimum);
+            this.maxScreenPosition = axis.Transform(axis.ClipMaximum);
+
+            switch (axis.Position)
+            {
+                case AxisPosition.Left:
+                    this.left = axis.PlotModel.PlotArea.Left - axis.PositionTierMinShift - this.size - distance;
+                    this.top = axis.PlotModel.PlotArea.Top;
+                    break;
+                case AxisPosition.Right:
+                    this.left = axis.PlotModel.PlotArea.Right + axis.PositionTierMinShift + distance;
+                    this.top = axis.PlotModel.PlotArea.Top;
+                    break;
+                case AxisPosition.Top:
+                    this.left = axis.PlotModel.PlotArea.Left;
+                    this.top = axis.PlotModel.PlotArea.Top - axis.PositionTierMinShift - this.size - distance;
+                    break;
+                case AxisPosition.Bottom:
+                    this.left = axis.PlotModel.PlotArea.Left;
+                    this.top = axis.PlotModel.PlotArea.Bottom + axis.PositionTierMinShift + distance;
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Render(T axis, int pass)
+        {
+            if (axis.Position is not (AxisPosition.Left or AxisPosition.Right or AxisPosition.Top or AxisPosition.Bottom))
+            {
+                return;
+            }
+
+            if (pass == 0)
+            {
+                this.InitPosition(axis);
+                this.RenderColorBlock(axis);
+            }
+
+            base.Render(axis, pass);
+        }
+
+        /// <summary>
+        /// Renders the color block.
+        /// </summary>
+        /// <param name="axis">The color axis.</param>
+        protected abstract void RenderColorBlock(T axis);
+
+        /// <summary>
+        /// Draws a single colored rectangle at the provided screen position.
+        /// </summary>
+        /// <param name="axis">The color axis.</param>
+        /// <param name="ylow">The screen position of the lower end of the rectangle.</param>
+        /// <param name="yhigh">The screen position of the higher end of the rectangle.</param>
+        /// <param name="color">The color.</param>
+        protected void DrawColorRect(T axis, double ylow, double yhigh, OxyColor color) 
+        {
+            var ymin = Math.Min(ylow, yhigh);
+            var ymax = Math.Max(ylow, yhigh) + 0.5;
+            var rect = axis.IsHorizontal()
+                    ? new OxyRect(ymin, this.top, ymax - ymin, this.size)
+                    : new OxyRect(this.left, ymin, this.size, ymax - ymin);
+
+            this.RenderContext.DrawRectangle(
+                rect,
+                color,
+                OxyColors.Undefined,
+                0,
+                axis.EdgeRenderingMode);
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/Rendering/ColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/ColorAxisRenderer.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+// <copyright file="ColorAxisRenderer.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/HorizontalAndVerticalAxisRenderer.cs
@@ -17,14 +17,29 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Provides functionality to render horizontal and vertical axes.
     /// </summary>
-    public class HorizontalAndVerticalAxisRenderer : AxisRendererBase
+    public class HorizontalAndVerticalAxisRenderer : HorizontalAndVerticalAxisRenderer<Axis>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HorizontalAndVerticalAxisRenderer" /> class.
         /// </summary>
         /// <param name="rc">The render context.</param>
         /// <param name="plot">The plot.</param>
-        public HorizontalAndVerticalAxisRenderer(IRenderContext rc, PlotModel plot)
+        public HorizontalAndVerticalAxisRenderer(IRenderContext rc, PlotModel plot) : base(rc, plot)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides functionality to render horizontal and vertical axes.
+    /// </summary>
+    public abstract class HorizontalAndVerticalAxisRenderer<T> : AxisRendererBase<T> where T : Axis
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HorizontalAndVerticalAxisRenderer{T}" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        protected HorizontalAndVerticalAxisRenderer(IRenderContext rc, PlotModel plot)
             : base(rc, plot)
         {
         }
@@ -34,7 +49,7 @@ namespace OxyPlot.Axes
         /// </summary>
         /// <param name="axis">The axis.</param>
         /// <param name="pass">The pass.</param>
-        public override void Render(Axis axis, int pass)
+        public override void Render(T axis, int pass)
         {
             base.Render(axis, pass);
 
@@ -204,7 +219,7 @@ namespace OxyPlot.Axes
         /// <param name="valign">The vertical alignment.</param>
         /// <returns>The <see cref="ScreenPoint" />.</returns>
         protected virtual ScreenPoint GetAxisTitlePositionAndAlignment(
-            Axis axis,
+            T axis,
             double titlePosition,
             ref double angle,
             ref HorizontalAlignment halign,
@@ -246,7 +261,7 @@ namespace OxyPlot.Axes
         /// </summary>
         /// <param name="axis">The axis.</param>
         /// <param name="titlePosition">The title position.</param>
-        protected virtual void RenderAxisTitle(Axis axis, double titlePosition)
+        protected virtual void RenderAxisTitle(T axis, double titlePosition)
         {
             if (string.IsNullOrEmpty(axis.ActualTitle))
             {
@@ -294,7 +309,7 @@ namespace OxyPlot.Axes
         /// <param name="axisPosition">The axis position.</param>
         /// <param name="titlePosition">The title position.</param>
         /// <param name="drawAxisLine">Draw the axis line if set to <c>true</c>.</param>
-        protected virtual void RenderMajorItems(Axis axis, double axisPosition, double titlePosition, bool drawAxisLine)
+        protected virtual void RenderMajorItems(T axis, double axisPosition, double titlePosition, bool drawAxisLine)
         {
             double eps = axis.ActualMinorStep * 1e-3;
 
@@ -512,7 +527,7 @@ namespace OxyPlot.Axes
         /// </summary>
         /// <param name="axis">The axis.</param>
         /// <param name="axisPosition">The axis position.</param>
-        protected virtual void RenderMinorItems(Axis axis, double axisPosition)
+        protected virtual void RenderMinorItems(T axis, double axisPosition)
         {
             double eps = axis.ActualMinorStep * 1e-3;
             double actualMinimum = axis.ClipMinimum;

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisFullPlotAreaRenderer.cs
@@ -15,7 +15,7 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Provides functionality to render <see cref="MagnitudeAxis" /> using the full plot area.
     /// </summary>
-    public class MagnitudeAxisFullPlotAreaRenderer : AxisRendererBase
+    public class MagnitudeAxisFullPlotAreaRenderer : AxisRendererBase<MagnitudeAxisFullPlotArea>
     {
         /// <summary>
         /// constants to simplify angular calculations
@@ -44,7 +44,7 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="pass">The pass.</param>
         /// <exception cref="System.NullReferenceException">Angle axis should not be <c>null</c>.</exception>
-        public override void Render(Axis axis, int pass)
+        public override void Render(MagnitudeAxisFullPlotArea axis, int pass)
         {
             base.Render(axis, pass);
 
@@ -275,7 +275,7 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="angleAxis">The angle axis.</param>
         /// <returns>The angle (in radians).</returns>
-        private static double GetActualAngle(Axis axis, Axis angleAxis)
+        private static double GetActualAngle(MagnitudeAxisFullPlotArea axis, Axis angleAxis)
         {
             var a = axis.Transform(0, angleAxis.Angle, angleAxis);
             var b = axis.Transform(1, angleAxis.Angle, angleAxis);
@@ -325,7 +325,7 @@ namespace OxyPlot.Axes
         /// <param name="pen">The pen.</param>
         /// <param name="startAngle">The start angle.</param>
         /// <param name="endAngle">The end angle.</param>
-        private void RenderTickArc(Axis axis, AngleAxis angleAxis, double x, OxyPen pen, double startAngle, double endAngle)
+        private void RenderTickArc(MagnitudeAxisFullPlotArea axis, AngleAxis angleAxis, double x, OxyPen pen, double startAngle, double endAngle)
         {
             if(startAngle>endAngle)
             {
@@ -369,7 +369,7 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="x">The x-value.</param>
         /// <param name="angleAxis">The angle axis.</param>
-        private void RenderTickText(Axis axis, double x, Axis angleAxis)
+        private void RenderTickText(MagnitudeAxisFullPlotArea axis, double x, Axis angleAxis)
         {
             var actualAngle = GetActualAngle(axis, angleAxis);
             var dx = axis.AxisTickToLabelDistance * Math.Sin(actualAngle);

--- a/Source/OxyPlot/Axes/Rendering/MagnitudeAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/MagnitudeAxisRenderer.cs
@@ -16,7 +16,7 @@ namespace OxyPlot.Axes
     /// <summary>
     /// Provides functionality to render <see cref="MagnitudeAxis" />.
     /// </summary>
-    public class MagnitudeAxisRenderer : AxisRendererBase
+    public class MagnitudeAxisRenderer : AxisRendererBase<MagnitudeAxis>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MagnitudeAxisRenderer" /> class.
@@ -34,7 +34,7 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="pass">The pass.</param>
         /// <exception cref="System.NullReferenceException">Angle axis should not be <c>null</c>.</exception>
-        public override void Render(Axis axis, int pass)
+        public override void Render(MagnitudeAxis axis, int pass)
         {
             base.Render(axis, pass);
 
@@ -134,7 +134,7 @@ namespace OxyPlot.Axes
         /// <param name="angleAxis">The angle axis.</param>
         /// <param name="x">The x-value.</param>
         /// <param name="pen">The pen.</param>
-        private void RenderTick(Axis axis, AngleAxis angleAxis, double x, OxyPen pen)
+        private void RenderTick(MagnitudeAxis axis, AngleAxis angleAxis, double x, OxyPen pen)
         {
             var isFullCircle = Math.Abs(Math.Abs(angleAxis.EndAngle - angleAxis.StartAngle) - 360) < 1e-6;
 
@@ -155,7 +155,7 @@ namespace OxyPlot.Axes
         /// <param name="angleAxis">The angle axis.</param>
         /// <param name="x">The x-value.</param>
         /// <param name="pen">The pen.</param>
-        private void RenderTickCircle(Axis axis, Axis angleAxis, double x, OxyPen pen)
+        private void RenderTickCircle(MagnitudeAxis axis, Axis angleAxis, double x, OxyPen pen)
         {
             var zero = angleAxis.Offset;
             var center = axis.Transform(axis.ClipMinimum, zero, angleAxis);
@@ -176,7 +176,7 @@ namespace OxyPlot.Axes
         /// <param name="angleAxis">The angle axis.</param>
         /// <param name="x">The x-value.</param>
         /// <param name="pen">The pen.</param>
-        private void RenderTickArc(Axis axis, AngleAxis angleAxis, double x, OxyPen pen)
+        private void RenderTickArc(MagnitudeAxis axis, AngleAxis angleAxis, double x, OxyPen pen)
         {
             // caution: make sure angleAxis.UpdateActualMaxMin(); has been called
             var minAngle = angleAxis.ClipMinimum;
@@ -210,7 +210,7 @@ namespace OxyPlot.Axes
         /// <param name="axis">The axis.</param>
         /// <param name="x">The x-value.</param>
         /// <param name="angleAxis">The angle axis.</param>
-        private void RenderTickText(Axis axis, double x, Axis angleAxis)
+        private void RenderTickText(MagnitudeAxis axis, double x, Axis angleAxis)
         {
             var actualAngle = GetActualAngle(axis, angleAxis);
             var dx = axis.AxisTickToLabelDistance * Math.Sin(actualAngle);

--- a/Source/OxyPlot/Axes/Rendering/NumericColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/NumericColorAxisRenderer.cs
@@ -1,0 +1,116 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes.Rendering
+{
+    using OxyPlot.Utilities;
+    using System;
+
+    /// <summary>
+    /// Provides functionality to render numeric color axes.
+    /// </summary>
+    public class NumericColorAxisRenderer<T> : ColorAxisRenderer<T> where T : Axis, INumericColorAxis
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NumericColorAxisRenderer{T}" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        public NumericColorAxisRenderer(IRenderContext rc, PlotModel plot) : base(rc, plot)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void RenderColorBlock(T axis)
+        {
+            if (axis.Palette == null)
+            {
+                throw new InvalidOperationException("No Palette defined for color axis.");
+            }
+
+            if (axis.RenderAsImage)
+            {
+                var axisLength = axis.Transform(axis.ClipMaximum) - axis.Transform(axis.ClipMinimum);
+                var reverse = axisLength < 0;
+                axisLength = Math.Abs(axisLength);
+
+                if (axis.IsHorizontal())
+                {
+                    var colorAxisImage = this.GenerateColorAxisImage(axis, reverse);
+                    this.RenderContext.DrawImage(colorAxisImage, this.left, this.top, axisLength, this.size, 1, true);
+                }
+                else
+                {
+                    var colorAxisImage = this.GenerateColorAxisImage(axis, reverse);
+                    this.RenderContext.DrawImage(colorAxisImage, this.left, this.top, this.size, axisLength, 1, true);
+                }
+            }
+            else
+            {
+                for (var i = 0; i < axis.Palette.Colors.Count; i++)
+                {
+                    var ylow = this.Transform(axis, axis.GetLowValue(i));
+                    var yhigh = this.Transform(axis, axis.GetHighValue(i));
+                    this.DrawColorRect(axis, ylow, yhigh, axis.Palette.Colors[i]);
+                }
+
+                double highLowLength = 10;
+                if (axis.IsHorizontal())
+                {
+                    highLowLength *= -1;
+                }
+
+                if (!axis.LowColor.IsUndefined())
+                {
+                    this.DrawColorRect(axis, this.minScreenPosition, this.minScreenPosition + highLowLength, axis.LowColor);
+                }
+
+                if (!axis.HighColor.IsUndefined())
+                {
+                    this.DrawColorRect(axis, this.maxScreenPosition, this.maxScreenPosition - highLowLength, axis.HighColor);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates the image used to render the color axis.
+        /// </summary>
+        /// <param name="axis">The color axis.</param>
+        /// <param name="reverse">Reverse the colors if set to <c>true</c>.</param>
+        /// <returns>An <see cref="OxyImage" /> used to render the color axis.</returns>
+        private OxyImage GenerateColorAxisImage(T axis, bool reverse)
+        {
+            var n = axis.Palette.Colors.Count;
+            var buffer = axis.IsHorizontal() ? new OxyColor[n, 1] : new OxyColor[1, n];
+            for (var i = 0; i < n; i++)
+            {
+                var color = axis.Palette.Colors[i];
+                var i2 = reverse ? n - 1 - i : i;
+                if (axis.IsHorizontal())
+                {
+                    buffer[i2, 0] = color;
+                }
+                else
+                {
+                    buffer[0, i2] = color;
+                }
+            }
+
+            return OxyImage.Create(buffer, ImageFormat.Png);
+        }
+
+        /// <summary>
+        /// Transforms a value to a screen position. We don't use the regular Transform functions of the axis here, as the color block should always be drawn with linear scaling.
+        /// </summary>
+        /// <param name="axis">The color axis.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The transformed value.</returns>
+        private double Transform(T axis, double value)
+        {
+            return Helpers.LinearInterpolation(axis.ClipMinimum, this.minScreenPosition, axis.ClipMaximum, this.maxScreenPosition, value);
+        }
+    }
+}

--- a/Source/OxyPlot/Axes/Rendering/RangeColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/RangeColorAxisRenderer.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+// <copyright file="RangeColorAxisRenderer.cs" company="OxyPlot">
 //   Copyright (c) 2014 OxyPlot contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/OxyPlot/Axes/Rendering/RangeColorAxisRenderer.cs
+++ b/Source/OxyPlot/Axes/Rendering/RangeColorAxisRenderer.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericColorAxisRenderer.cs" company="OxyPlot">
+//   Copyright (c) 2014 OxyPlot contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace OxyPlot.Axes.Rendering
+{
+    /// <summary>
+    /// Provides functionality to render range color axes.
+    /// </summary>
+    public class RangeColorAxisRenderer : ColorAxisRenderer<RangeColorAxis>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RangeColorAxisRenderer" /> class.
+        /// </summary>
+        /// <param name="rc">The render context.</param>
+        /// <param name="plot">The plot.</param>
+        public RangeColorAxisRenderer(IRenderContext rc, PlotModel plot) : base(rc, plot)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void RenderColorBlock(RangeColorAxis axis)
+        {
+            var effectiveMaxY = axis.Transform(axis.IsReversed ? axis.ActualMinimum : axis.ActualMaximum);
+            var effectiveMinY = axis.Transform(axis.IsReversed ? axis.ActualMaximum : axis.ActualMinimum);
+
+            foreach (var range in axis.ranges)
+            {
+                var ylow = axis.Transform(range.LowerBound);
+                var yhigh = axis.Transform(range.UpperBound);
+
+                if (axis.IsHorizontal())
+                {
+                    if (ylow < effectiveMinY)
+                    {
+                        ylow = effectiveMinY;
+                    }
+
+                    if (yhigh > effectiveMaxY)
+                    {
+                        yhigh = effectiveMaxY;
+                    }
+                }
+                else
+                {
+                    if (ylow > effectiveMinY)
+                    {
+                        ylow = effectiveMinY;
+                    }
+
+                    if (yhigh < effectiveMaxY)
+                    {
+                        yhigh = effectiveMaxY;
+                    }
+                }
+
+                this.DrawColorRect(axis, ylow, yhigh, range.Color);
+            }
+
+            double highLowLength = 10;
+            if (axis.IsHorizontal())
+            {
+                highLowLength *= -1;
+            }
+
+            if (!axis.LowColor.IsUndefined())
+            {
+                var ylow = axis.Transform(axis.ActualMinimum);
+                this.DrawColorRect(axis, ylow, ylow + highLowLength, axis.LowColor);
+            }
+
+            if (!axis.HighColor.IsUndefined())
+            {
+                var yhigh = axis.Transform(axis.ActualMaximum);
+                this.DrawColorRect(axis, yhigh, yhigh - highLowLength, axis.HighColor);
+            }
+        }
+    }
+}

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -9,7 +9,7 @@
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>OxyPlot.snk</AssemblyOriginatorKeyFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <LangVersion>8</LangVersion>
+        <LangVersion>9</LangVersion>
         <NoWarn>$(NoWarn);CS0618</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/Source/OxyPlot/Utilities/Helpers.cs
+++ b/Source/OxyPlot/Utilities/Helpers.cs
@@ -49,8 +49,8 @@ namespace OxyPlot.Utilities
                 throw new ArgumentNullException(nameof(projection));
             }
 
-            T best = default;
-            TComparable bestComparable = default;
+            T? best = default;
+            TComparable? bestComparable = default;
 
             bool first = true;
             foreach (T t in sequence)
@@ -70,6 +70,20 @@ namespace OxyPlot.Utilities
             }
 
             return best!;
+        }
+
+        /// <summary>
+        /// Performs a linear interpolation between two points.
+        /// </summary>
+        /// <param name="x0">The x coordinate of the first point.</param>
+        /// <param name="y0">The y coordinate of the first point.</param>
+        /// <param name="x1">The x coordinate of the second point.</param>
+        /// <param name="y1">The y coordinate of the second point.</param>
+        /// <param name="value">The x value where the interpolation should be evaluated.</param>
+        /// <returns>The y coordinate of a point with x=<paramref name="value"/> on the line between the first and second point.</returns>
+        public static double LinearInterpolation(double x0, double y0, double x1, double y1, double value)
+        {
+            return (value - x0) / (x1 - x0) * (y1 - y0) + y0;
         }
     }
 }


### PR DESCRIPTION
Fixes #92.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Implement `LogarithmicColorAxis`
- Clean up Color Axis examples and move Palette examples to a separate category
- Make `AxisRendererBase` generic - this is a breaking change for any derived classes, but one that is easily fixed. And really it should always have been generic.
- Bump `LangVersion` where needed

The reason for the slightly more wide-ranging code changes is as follows:
Until now we had 3 `IColorAxis` implementations: `LinearColorAxis`, `CategoryColorAxis` and `RangeColorAxis`, which duplicated a lot of code between them. Adding `LogarithmicColorAxis` would have essentially duplicated most of `LinearColorAxis` yet again. Therefore I decided to move the color axis rendering functionality into a `ColorAxisRenderer`, so it can be shared between the `IColorAxis` implementations.


@oxyplot/admins
