### PR TITLE
Fix documentation for HeatMapRenderMethod

### DIFF
--- a/Source/OxyPlot/Series/HeatMapSeries.cs
+++ b/Source/OxyPlot/Series/HeatMapSeries.cs
@@ -30,7 +30,7 @@ namespace OxyPlot.Series
     }
 
     /// <summary>
-    /// Specifies how the heat map coordinates are defined.
+    /// Specifies how the heat map is rendered.
     /// </summary>
     public enum HeatMapRenderMethod
     {


### PR DESCRIPTION
Fixes a C&P error in the documentation for the `HeatMapRenderMethod` enum.