### PR TITLE
fix #2061

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Expanded `IntervalBarSeries` and `TornadoBarSeries` to allow for varied label positions and angles (#2027)
 - VectorSeries (#107)
 - LogarithmicColorAxis (#92)
+- DateTimeAxis.DateTimePrecision property (related to #2061)
 
 ### Changed
 - Make consistent BaseValue and BaseLine across BarSeries, LinearBarSeries, and HistogramSeries
@@ -26,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Add support for .NET 7.0 (#1937)
 - Update SkiaSharp to Version 2.88.6
 - AxisRendererBase is now generic
+- DateTimeAxis.ToDateTime(double value) is now obsolete, replacements are provided (related to #2061)
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)
@@ -41,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Font weight not being applied in ImageSharp (#2006)
 - SkiaSharp - Fix use of obsolete functions (#1937)
 - Dashed lines are solid when exporting via SkiaSharp.SvgExporter (#1674)
+- DateTimeAxis.ToDateTime doesn't behave as intended in .NET 8 (#2061) 
 
 ## [2.1.2] - 2022-12-03
 

--- a/Source/Examples/ExampleLibrary/Axes/DateTimeAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/DateTimeAxisExamples.cs
@@ -231,7 +231,11 @@ namespace ExampleLibrary
         public static PlotModel LabelFormatter()
         {
             var model = new PlotModel { Title = "Using LabelFormatter to format labels by day of week" };
-            model.Axes.Add(new DateTimeAxis { LabelFormatter = x => DateTimeAxis.ToDateTime(x).DayOfWeek.ToString().Substring(0, 3) });
+
+            var dateTimeAxis = new DateTimeAxis();
+            dateTimeAxis.LabelFormatter = x => dateTimeAxis.ConvertToDateTime(x).DayOfWeek.ToString().Substring(0, 3);
+            model.Axes.Add(dateTimeAxis);
+
             var series = new LineSeries();
             model.Series.Add(series);
             for (int i = 0; i < 7; i++)
@@ -241,6 +245,40 @@ namespace ExampleLibrary
                 double y = Math.Sin(i * i);
                 series.Points.Add(new DataPoint(x, y));
             }
+
+            return model;
+        }
+
+        [Example("DateTimePrecision")]
+        public static PlotModel DateTimePrecision()
+        {
+            var model = new PlotModel 
+            { 
+                Title = "This shows the effect of DateTimePrecision", 
+                Subtitle = "(only apparent under .NET 7 and above)" 
+            };
+
+            var startDate = new DateTime(2014, 07, 20);
+
+            var dateTimeAxis1 = new DateTimeAxis
+            {
+                Minimum = DateTimeAxis.ToDouble(startDate),
+                Maximum = DateTimeAxis.ToDouble(startDate.AddMinutes(50)),
+                Position = AxisPosition.Bottom,
+                DateTimePrecision = new TimeSpan(1),
+                Title = "DateTimePrecision = 1 tick (no rounding)",
+            };
+
+            var dateTimeAxis2 = new DateTimeAxis
+            {
+                Minimum = dateTimeAxis1.Minimum,
+                Maximum = dateTimeAxis1.Maximum,
+                Position = AxisPosition.Top,
+                Title = "DateTimePrecision = 1 ms (default value)",
+            };
+
+            model.Axes.Add(dateTimeAxis1);
+            model.Axes.Add(dateTimeAxis2);
 
             return model;
         }

--- a/Source/Examples/WPF/WpfExamples/Examples/AnimationsDemo/Models/Pnl.cs
+++ b/Source/Examples/WPF/WpfExamples/Examples/AnimationsDemo/Models/Pnl.cs
@@ -22,7 +22,7 @@ namespace AnimationsDemo
 
         public DateTime Time
         {
-            get { return DateTimeAxis.ToDateTime(this.X); }
+            get { return DateTimeAxis.ToDateTime(this.X, DateTimeAxis.DefaultPrecision); }
             set
             {
                 var finalX = DateTimeAxis.ToDouble(value);

--- a/Source/OxyPlot.Tests/Axes/DateTimeAxisTests.cs
+++ b/Source/OxyPlot.Tests/Axes/DateTimeAxisTests.cs
@@ -35,31 +35,31 @@ namespace OxyPlot.Tests
         public void ToDateTime_ValidDate()
         {
             var date = new DateTime(2011, 3, 15);
-            Assert.AreEqual(date, DateTimeAxis.ToDateTime(date.ToOADate()));
+            Assert.AreEqual(date, DateTimeAxis.ToDateTime(date.ToOADate(), DateTimeAxis.DefaultPrecision));
         }
 
         [Test]
         public void ToDateTime_NoDate()
         {
-            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(-693593));
+            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(-693593, DateTimeAxis.DefaultPrecision));
         }
 
         [Test]
         public void ToDateTime_NaN()
         {
-            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(double.NaN));
+            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(double.NaN, DateTimeAxis.DefaultPrecision));
         }
 
         [Test]
         public void ToDateTime_VeryBigValue()
         {
-            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(double.MaxValue));
+            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(double.MaxValue, DateTimeAxis.DefaultPrecision));
         }
 
         [Test]
         public void ToDateTime_VerySmallValue()
         {
-            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(double.MinValue));
+            Assert.AreEqual(new DateTime(), DateTimeAxis.ToDateTime(double.MinValue, DateTimeAxis.DefaultPrecision));
         }
     }
 }

--- a/Source/OxyPlot/Axes/DateTimeAxis.cs
+++ b/Source/OxyPlot/Axes/DateTimeAxis.cs
@@ -185,7 +185,7 @@ namespace OxyPlot.Axes
         }
 
         /// <summary>
-        /// Converts a numeric representation of the date (number of days after the time origin) to a DateTime structure, using the precision specified by DateTimePrecision.
+        /// Converts a numeric representation of the date (number of days after the time origin) to a DateTime structure, using the precision specified by <see cref="DateTimePrecision" />.
         /// </summary>
         /// <param name="value">The number of days after the time origin.</param>
         /// <returns>A <see cref="DateTime" /> structure. Ticks = 0 if the value is invalid.</returns>

--- a/Source/OxyPlot/Axes/DateTimeAxis.cs
+++ b/Source/OxyPlot/Axes/DateTimeAxis.cs
@@ -27,6 +27,11 @@ namespace OxyPlot.Axes
     public class DateTimeAxis : LinearAxis
     {
         /// <summary>
+        /// The default precision that is used for rounding DateTime values. 1ms is used to emulate the behavior of .NET 6 and earlier.
+        /// </summary>
+        public static readonly TimeSpan DefaultPrecision = TimeSpan.FromMilliseconds(1);
+
+        /// <summary>
         /// The time origin.
         /// </summary>
         /// <remarks>This gives the same numeric date values as Excel</remarks>
@@ -61,6 +66,7 @@ namespace OxyPlot.Axes
             this.IntervalType = DateTimeIntervalType.Auto;
             this.FirstDayOfWeek = DayOfWeek.Monday;
             this.CalendarWeekRule = CalendarWeekRule.FirstFourDayWeek;
+            this.DateTimePrecision = DefaultPrecision;
         }
 
         /// <summary>
@@ -82,6 +88,13 @@ namespace OxyPlot.Axes
         /// Gets or sets MinorIntervalType.
         /// </summary>
         public DateTimeIntervalType MinorIntervalType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the precision that is used for DateTime values internally. Limiting the precision avoids 'unexpected' tick labels, e.g.
+        /// '11:59' for a value of 11:59.99999. The default value is 1 Millisecond.
+        /// </summary>
+        /// <remarks>For .NET 6 and below, the minimum precision is 1 ms. Using a DateTimePrecision smaller than 1 ms will not result in increased precision.</remarks>
+        public TimeSpan DateTimePrecision { get; set; }
 
         /// <summary>
         /// Gets or sets the time zone (used when formatting date/time values).
@@ -124,18 +137,40 @@ namespace OxyPlot.Axes
         }
 
         /// <summary>
-        /// Converts a numeric representation of the date (number of days after the time origin) to a DateTime structure.
+        /// Converts a numeric representation of the date (number of days after the time origin) to a DateTime structure, using a precision of 1 Millisecond.
         /// </summary>
         /// <param name="value">The number of days after the time origin.</param>
         /// <returns>A <see cref="DateTime" /> structure. Ticks = 0 if the value is invalid.</returns>
+        [Obsolete("Use ConvertToDateTime(double value) or ToDateTime(double value, TimeSpan precision) instead.")]
         public static DateTime ToDateTime(double value)
+        {
+            return ToDateTime(value, DefaultPrecision);
+        }
+
+        /// <summary>
+        /// Converts a numeric representation of the date (number of days after the time origin) to a DateTime structure.
+        /// </summary>
+        /// <param name="value">The number of days after the time origin.</param>
+        /// <param name="precision">The precision that is used for the conversion. The DateTime value is rounded to the next integer multiple of this value.</param>
+        /// <returns>A <see cref="DateTime" /> structure. Ticks = 0 if the value is invalid.</returns>
+        public static DateTime ToDateTime(double value, TimeSpan precision)
         {
             if (double.IsNaN(value) || value < MinDayValue || value > MaxDayValue)
             {
                 return new DateTime();
             }
 
-            return TimeOrigin.AddDays(value - 1);
+            var preliminaryDateTime = TimeOrigin.AddDays(value - 1);
+
+            var precisionIntervals = preliminaryDateTime.Ticks / precision.Ticks;
+            var remainderTicks = preliminaryDateTime.Ticks % precision.Ticks;
+
+            if (remainderTicks >= precision.Ticks / 2)
+            {
+                precisionIntervals += 1;
+            }
+
+            return new DateTime(precisionIntervals * precision.Ticks);
         }
 
         /// <summary>
@@ -147,6 +182,16 @@ namespace OxyPlot.Axes
         {
             var span = value - TimeOrigin;
             return span.TotalDays + 1;
+        }
+
+        /// <summary>
+        /// Converts a numeric representation of the date (number of days after the time origin) to a DateTime structure, using the precision specified by DateTimePrecision.
+        /// </summary>
+        /// <param name="value">The number of days after the time origin.</param>
+        /// <returns>A <see cref="DateTime" /> structure. Ticks = 0 if the value is invalid.</returns>
+        public DateTime ConvertToDateTime(double value)
+        {
+            return ToDateTime(value, this.DateTimePrecision);
         }
 
         /// <summary>
@@ -175,7 +220,7 @@ namespace OxyPlot.Axes
         /// <returns>The value.</returns>
         public override object GetValue(double x)
         {
-            var time = ToDateTime(x);
+            var time = this.ConvertToDateTime(x);
 
             if (this.TimeZone != null)
             {
@@ -291,7 +336,7 @@ namespace OxyPlot.Axes
         protected override string FormatValueOverride(double x)
         {
             // convert the double value to a DateTime
-            var time = ToDateTime(x);
+            var time = this.ConvertToDateTime(x);
 
             // If a time zone is specified, convert the time
             if (this.TimeZone != null)
@@ -451,7 +496,7 @@ namespace OxyPlot.Axes
             double min, double max, double step, DateTimeIntervalType intervalType)
         {
             var values = new Collection<double>();
-            var start = ToDateTime(min);
+            var start = this.ConvertToDateTime(min);
             if (start.Ticks == 0)
             {
                 // Invalid start time
@@ -478,7 +523,7 @@ namespace OxyPlot.Axes
             }
 
             // Adds a tick to the end time to make sure the end DateTime is included.
-            var end = ToDateTime(max).AddTicks(1);
+            var end = this.ConvertToDateTime(max).AddTicks(1);
             if (end.Ticks == 0)
             {
                 // Invalid end time
@@ -487,8 +532,8 @@ namespace OxyPlot.Axes
 
             var current = start;
             double eps = step * 1e-3;
-            var minDateTime = ToDateTime(min - eps);
-            var maxDateTime = ToDateTime(max + eps);
+            var minDateTime = this.ConvertToDateTime(min - eps);
+            var maxDateTime = this.ConvertToDateTime(max + eps);
 
             if (minDateTime.Ticks == 0 || maxDateTime.Ticks == 0)
             {


### PR DESCRIPTION
Fixes #2061 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add `DateTimeAxis.DateTimePrecision` property, which is used to round `DateTime` values used by the axis. Default value is 1ms, so this should restore the behavior from .NET 6 and before.
- Add an example showcasing the issue
- Mark `DateTimeAxis.ToDateTime` as obsolete to make people aware of the issue

@oxyplot/admins
