### PR TITLE
Replace .NET 7 targets by .NET 8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,8 +35,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: | 
-          3.1.x
           6.0.x
+          8.0.x
 
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: | 
           6.0.x
-          7.0.x
+          8.0.x
     
     - name: Build
       run: dotnet build Source/OxyPlot.CI.sln --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: | 
           6.0.x

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
           6.0.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 - Remove support for .NET Core 3.1, as it is end-of-life soon (#1937)
 - Move example projects to .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Run tests on both .NET Framework 4.6.2 and .NET 6.0 (#1937)
-- Add support for .NET 7.0 (#1937)
+- Add support for .NET 8.0
 - Update SkiaSharp to Version 2.88.6
 - AxisRendererBase is now generic
 

--- a/Source/Examples/Core.Drawing/Example1/Example1.csproj
+++ b/Source/Examples/Core.Drawing/Example1/Example1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Examples/ExampleGenerator/ExampleGenerator.csproj
+++ b/Source/Examples/ExampleGenerator/ExampleGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net7.0-windows</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows;net8.0-windows</TargetFrameworks>
         <!--<UseWindowsForms>true</UseWindowsForms>-->
         <OutputType>Exe</OutputType>
         <ApplicationIcon />

--- a/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
     <PackageId>OxyPlot.ExampleLibrary</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Example models for OxyPlot.</Description>

--- a/Source/Examples/ImageSharp/Example1/Example1.csproj
+++ b/Source/Examples/ImageSharp/Example1/Example1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Examples/PerformanceTest/PerformanceTest.csproj
+++ b/Source/Examples/PerformanceTest/PerformanceTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <ApplicationIcon />
         <StartupObject />

--- a/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.WPF.csproj
+++ b/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <OutputType>WinExe</OutputType>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
+++ b/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+      <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
       <UseWPF>true</UseWPF>
       <UseWindowsForms>true</UseWindowsForms>
       <OutputType>WinExe</OutputType>

--- a/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
+++ b/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
+++ b/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot ImageSharp unit tests</Description>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
+++ b/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>
 </Project>

--- a/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
+++ b/Source/OxyPlot.Pdf.Tests/OxyPlot.Pdf.Tests.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="PDFsharp-MigraDoc-GDI" Version="1.50.5147" />
     </ItemGroup>
     <ItemGroup>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot SkiaSharp unit tests</Description>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>
 </Project>

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Description>OxyPlot is a plotting library for .NET. This package targets WPF applications and uses the SkiaSharp renderer.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -3,7 +3,7 @@
     <LangVersion>8</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright (c) 2020 OxyPlot contributors</Copyright>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Authors>OxyPlot contributors</Authors>
     <Description>OxyPlot is a plotting library for .NET. This package provides rendering based on SkiaSharp.</Description>
     <PackageTags>plotting plot charting chart skiasharp skia pdf</PackageTags>

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot unit tests</Description>
         <LangVersion>9</LangVersion>

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -14,8 +14,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
         <PackageReference Include="NSubstitute" Version="4.2.1" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="Schemas\svg.xsd">

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <Description>OxyPlot is a plotting library for .NET. This package targets Windows Forms applications.</Description>
         <PackageTags>plotting plot charting chart</PackageTags>

--- a/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
+++ b/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>8</LangVersion>
     <Description>OxyPlot is a plotting library for .NET. This package is the base for WPF PlotView implementations.</Description>

--- a/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
+++ b/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
         <PackageReference Include="NSubstitute" Version="4.2.1" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>
 </Project>

--- a/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
+++ b/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <Description>OxyPlot WPF unit tests</Description>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Source/OxyPlot.Wpf.Tests/PlotViewTests.cs
+++ b/Source/OxyPlot.Wpf.Tests/PlotViewTests.cs
@@ -113,7 +113,6 @@ namespace OxyPlot.Wpf.Tests
         /// In this case, the Loaded event is not fired.
         /// </summary>
         [Test]
-        [RequiresThread(System.Threading.ApartmentState.STA)]
         public void PlotInifityPolyline()
         {
             var model = new PlotModel();
@@ -133,7 +132,6 @@ namespace OxyPlot.Wpf.Tests
         /// Make sure the PlotView does not throw an exception if it is invalidated while not in the visual tree.
         /// </summary>
         [Test]
-        [RequiresThread(System.Threading.ApartmentState.STA)]
         public void InvalidateDisconnected()
         {
             var model = new PlotModel();

--- a/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
+++ b/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>OxyPlot.Wpf.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net462;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
         <PackageId>OxyPlot.Core</PackageId>
         <Description>OxyPlot is a plotting library for .NET. This is the core library including the foundation classes and plot model. To display the plots, you also need to add a platform-specific OxyPlot package that contains a PlotView component.</Description>
         <PackageTags>plotting plot charting chart</PackageTags>


### PR DESCRIPTION
.NET 7 is out of support by now, so prior to a potential v2.2 release, we should upgrade all .NET 7 targets to .NET 8. 
.NET 6 is still supported until end of 2024, so this can stay.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Replace all .NET 7 targets by .NET 8
- Add .NET 6 and .NET 8 targets to `OxyPlot.Skiasharp` (not sure why we didn't have these before)

@oxyplot/admins
