### PR TITLE
Modify some of the examples to make them deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Update SkiaSharp to Version 2.88.6
 - AxisRendererBase is now generic
 - DateTimeAxis.ToDateTime(double value) is now obsolete, replacements are provided (related to #2061)
+- Modify some of the examples to make them deterministic
 
 ### Removed
 - Support for .NET Framework 4.0 and 4.5 (#1839)

--- a/Source/Examples/ExampleLibrary/Issues/Issues.cs
+++ b/Source/Examples/ExampleLibrary/Issues/Issues.cs
@@ -741,22 +741,24 @@ namespace ExampleLibrary
 
             plotModel1.Axes.Add(verticalAxis);
 
+            var time = new DateTime(2024, 07, 20, 13, 27, 5);
+
             var line = new LineSeries { Title = "Measurement", XAxisKey = masterAxis.Key, YAxisKey = verticalAxis.Key };
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now), 10));
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(1)), 10));
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(2)), 45));
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(3)), 17));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time), 10));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time.AddSeconds(1)), 10));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time.AddSeconds(2)), 45));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time.AddSeconds(3)), 17));
 
             line.Points.Add(DataPoint.Undefined);
 
             // this point should be visible
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(4)), 10));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time.AddSeconds(4)), 10));
             //// line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(4)), 10));
 
             line.Points.Add(DataPoint.Undefined);
 
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(5)), 45));
-            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(DateTime.Now.AddSeconds(6)), 17));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time.AddSeconds(5)), 45));
+            line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(time.AddSeconds(6)), 17));
 
             plotModel1.Series.Add(line);
 
@@ -1184,7 +1186,7 @@ namespace ExampleLibrary
             var myModel = new PlotModel { Title = "Example 1" };
             myModel.Series.Add(new FunctionSeries(Math.Cos, 0, 10, 0.1, "cos(x)"));
 
-            var rng = new Random();
+            var rng = new Random(0);
             var buf = new byte[100, 100];
             for (int i = 0; i < 100; i++)
             {
@@ -2230,7 +2232,7 @@ namespace ExampleLibrary
                 Palette = myPalette,
             });
 
-            var rand = new Random();
+            var rand = new Random(0);
             var data = new double[yAxisLabels.Count, xAxisLabels.Count];
             for (int x = 0; x < xAxisLabels.Count; ++x)
             {

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickAndVolumeSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickAndVolumeSeriesExamples.cs
@@ -127,7 +127,7 @@ namespace ExampleLibrary
             };
 
             // create bars
-            foreach (var bar in OhlcvItemGenerator.MRProcess(n))
+            foreach (var bar in OhlcvItemGenerator.MRProcess(n, new Random(0)))
             {
                 series.Append(bar);
             }

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/CandleStickSeriesExamples.cs
@@ -26,7 +26,7 @@ namespace ExampleLibrary
             var linearAxis1 = new LinearAxis { Position = AxisPosition.Left };
             pm.Axes.Add(linearAxis1);
             var n = 1000000;
-            var items = HighLowItemGenerator.MRProcess(n).ToArray();
+            var items = HighLowItemGenerator.MRProcess(n, new Random(0)).ToArray();
             var series = new CandleStickSeries
                              {
                                  Color = OxyColors.Black,
@@ -68,7 +68,7 @@ namespace ExampleLibrary
             var linearAxis1 = new LinearAxis { Position = AxisPosition.Left };
             pm.Axes.Add(linearAxis1);
             var n = 1000000;
-            var items = HighLowItemGenerator.MRProcess(n).ToArray();
+            var items = HighLowItemGenerator.MRProcess(n, new Random(1)).ToArray();
             var series = new CandleStickSeries
                              {
                                  Color = OxyColors.Black,
@@ -106,7 +106,7 @@ namespace ExampleLibrary
             var linearAxis1 = new LinearAxis { Position = AxisPosition.Left };
             pm.Axes.Add(linearAxis1);
             var n = 100;
-            var items = HighLowItemGenerator.MRProcess(n).ToArray();
+            var items = HighLowItemGenerator.MRProcess(n, new Random(2)).ToArray();
             var series = new CandleStickSeries
                              {
                                  Color = OxyColors.Black,

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/HighLowItemGenerator.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/HighLowItemGenerator.cs
@@ -21,11 +21,6 @@ namespace ExampleLibrary
     public static class HighLowItemGenerator
     {
         /// <summary>
-        /// The random number generator.
-        /// </summary>
-        private static readonly Random Rand = new Random();
-
-        /// <summary>
         /// Creates bars governed by a MR process
         /// </summary>
         /// <returns>The process.</returns>
@@ -36,6 +31,7 @@ namespace ExampleLibrary
         /// <param name="kappa">Kappa.</param>
         public static IEnumerable<HighLowItem> MRProcess(
             int n,
+            Random rand,
             double x0 = 100.0,
             double csigma = 0.50,
             double esigma = 0.70,
@@ -43,12 +39,12 @@ namespace ExampleLibrary
         {
             double x = x0;
 
-            var baseT = DateTime.UtcNow;
+            var baseT = new DateTime(2024, 07, 20, 14, 26, 06);
             for (int ti = 0; ti < n; ti++)
             {
-                var dx_c = -kappa * (x - x0) + RandomNormal(0, csigma);
-                var dx_1 = -kappa * (x - x0) + RandomNormal(0, esigma);
-                var dx_2 = -kappa * (x - x0) + RandomNormal(0, esigma);
+                var dx_c = -kappa * (x - x0) + RandomNormal(0, csigma, rand);
+                var dx_1 = -kappa * (x - x0) + RandomNormal(0, esigma, rand);
+                var dx_2 = -kappa * (x - x0) + RandomNormal(0, esigma, rand);
 
                 var open = x;
                 var close = x = x + dx_c;
@@ -92,9 +88,9 @@ namespace ExampleLibrary
         /// </summary>
         /// <param name="mu">Mu.</param>
         /// <param name="sigma">Sigma.</param>
-        private static double RandomNormal(double mu, double sigma)
+        private static double RandomNormal(double mu, double sigma, Random rand)
         {
-            return InverseCumNormal(Rand.NextDouble(), mu, sigma);
+            return InverseCumNormal(rand.NextDouble(), mu, sigma);
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/OhlcvItemGenerator.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/OhlcvItemGenerator.cs
@@ -21,11 +21,6 @@ namespace ExampleLibrary
     public static class OhlcvItemGenerator
     {
         /// <summary>
-        /// The random number generator.
-        /// </summary>
-        private static readonly Random Rand = new Random();
-
-        /// <summary>
         /// Creates bars governed by a MR process.
         /// </summary>
         /// <param name="n">N.</param>
@@ -39,6 +34,7 @@ namespace ExampleLibrary
         /// </returns>
         public static IEnumerable<OhlcvItem> MRProcess(
             int n,
+            Random rand,
             double x0 = 100.0,
             double v0 = 500,
             double csigma = 0.50,
@@ -46,12 +42,12 @@ namespace ExampleLibrary
             double kappa = 0.01)
         {
             double x = x0;
-            var baseT = DateTime.UtcNow;
+            var baseT = new DateTime(2024, 07, 20, 14, 26, 06);
             for (int ti = 0; ti < n; ti++)
             {
-                var dx_c = -kappa * (x - x0) + RandomNormal(0, csigma);
-                var dx_1 = -kappa * (x - x0) + RandomNormal(0, esigma);
-                var dx_2 = -kappa * (x - x0) + RandomNormal(0, esigma);
+                var dx_c = -kappa * (x - x0) + RandomNormal(0, csigma, rand);
+                var dx_1 = -kappa * (x - x0) + RandomNormal(0, esigma, rand);
+                var dx_2 = -kappa * (x - x0) + RandomNormal(0, esigma, rand);
 
                 var open = x;
                 var close = x = x + dx_c;
@@ -106,9 +102,9 @@ namespace ExampleLibrary
         /// <param name="mu">Mu.</param>
         /// <param name="sigma">Sigma.</param>
         /// <returns></returns>
-        private static double RandomNormal(double mu, double sigma)
+        private static double RandomNormal(double mu, double sigma, Random rand)
         {
-            return InverseCumNormal(Rand.NextDouble(), mu, sigma);
+            return InverseCumNormal(rand.NextDouble(), mu, sigma);
         }
 
         /// <summary>

--- a/Source/Examples/ExampleLibrary/Series/FinancialSeries/VolumeSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/FinancialSeries/VolumeSeriesExamples.cs
@@ -9,6 +9,7 @@ namespace ExampleLibrary
     using OxyPlot;
     using OxyPlot.Axes;
     using OxyPlot.Series;
+    using System;
 
     [Examples("VolumeSeries")]
     [Tags("Series")]
@@ -78,7 +79,7 @@ namespace ExampleLibrary
             };
 
             // create bars
-            foreach (var bar in OhlcvItemGenerator.MRProcess(n))
+            foreach (var bar in OhlcvItemGenerator.MRProcess(n, new Random(1)))
             {
                 series.Append(bar);
             }


### PR DESCRIPTION
During testing for #2090 I found it quite annoying that some examples give different output each time they are run, as they use either a `Random` without explicit seed or `DateTime.Now`. This leads to failed test on every test run. Therefore I decided to modify the handful of tests where this is the case.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Make all Examples in `ExampleLibrary` deterministic

@oxyplot/admins
