### PR TITLE
Bump SkiaSharp to 2.88.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 - Move example projects to .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Run tests on both .NET Framework 4.6.2 and .NET 6.0 (#1937)
 - Add support for .NET 8.0
-- Update SkiaSharp to Version 2.88.6
+- Update SkiaSharp to Version 2.88.8
 - AxisRendererBase is now generic
 - DateTimeAxis.ToDateTime(double value) is now obsolete, replacements are provided (related to #2061)
 - Modify some of the examples to make them deterministic

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
@@ -11,7 +11,7 @@
     <AssemblyOriginatorKeyFile>OxyPlot.SkiaSharp.Wpf.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.88.8" />
     <None Include="OxyPlot.SkiaSharp.Wpf.snk" />
     <None Include="VisualStudioToolsManifest.xml" Pack="true" PackagePath="tools" />
   </ItemGroup>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -13,8 +13,8 @@
     <AssemblyOriginatorKeyFile>OxyPlot.SkiaSharp.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.6" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
   </ItemGroup>
   <ItemGroup>
     <None Include="OxyPlot.SkiaSharp.snk" />


### PR DESCRIPTION
No special reason, just probably a good idea to stay up-to-date.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Update SkiaSharp dependency from 2.88.6 to 2.88.8.

@oxyplot/admins
