### PR TITLE
Refit ImageSharp again

### DIFF
--- a/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
+++ b/Source/OxyPlot.ImageSharp.Tests/OxyPlot.ImageSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <Description>OxyPlot ImageSharp unit tests</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Source/OxyPlot.ImageSharp/OxyPlot.ImageSharp.csproj
+++ b/Source/OxyPlot.ImageSharp/OxyPlot.ImageSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8</LangVersion>
-        <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <Description>OxyPlot is a plotting library for .NET. This is package is based on SixLabors.ImageSharp.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Copyright>Copyright (c) 2014 OxyPlot contributors</Copyright>
@@ -13,16 +13,16 @@
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <NoWarn>NU5104</NoWarn>
+        <LangVersion>9</LangVersion>
         <WarningsAsErrors />
     </PropertyGroup>
     <ItemGroup>
         <None Include="..\..\Icons\OxyPlot_128.png" Pack="true" PackagePath="\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0007" />
-        <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0009" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
+        <PackageReference Include="SixLabors.Fonts" Version="2.0.4" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />


### PR DESCRIPTION
(I need to rebase against develop and a few other things, so this is very much a WIP: don't bother reviewing it yet)

ImageSharp is out of beta, and the old libraries have listed vulnerabilities, so this bumps everything to the latest versions.

This requires targeting net6.0, so we lose netstandard and netframework support.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

Just done a very quick refit so far, and doesn't look painful.

Outstanding issues:
 - Not tested properly yet, though the tests run and at least some of them produce recognisable figures
 - `DrawImage` doesn't work: may be possible to significantly simplify the method as there are some useful looking `DrawImage` overloads in ImageSharp now (though AFAIKT none that does the job in one)
    - Images render in the wrong place (e.g. PlotBackgroundInterpolated test)
    - I commented out the code that was responsible for nice edges on interpolated plots because the interface for changing individual pixels has gone away, so that's probably broken (maybe PlotBackgroundInterpolated again: dark edge suggests it's interpolating black: may be new graphics options to deal with this)
 - `DrawText` uses a hideous hard-coded path length because the old methods we used doesn't exist; may be that there is a nicer API for drawing text that doesn't involve laying out the glyphs etc. as is probably necessary for proper emoji support

@oxyplot/admins