### PR TITLE
Update changelog for 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [2.2.0] - 2024-08-24
 
 ### Added
 - Example to demonstrate BarSeries HitTest bug (#2038)
@@ -517,6 +517,8 @@ All notable changes to this project will be documented in this file.
 - PngExporter text formatting (#170)
 
 [Unreleased]: https://github.com/oxyplot/oxyplot/compare/v2.1.0...HEAD
+[2.2.0]: https://github.com/oxyplot/oxyplot/compare/v2.1.2...v2.2.0
+[2.1.2]: https://github.com/oxyplot/oxyplot/compare/v2.1.0...v2.1.2
 [2.1.0]: https://github.com/oxyplot/oxyplot/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/oxyplot/oxyplot/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/oxyplot/oxyplot/compare/v0.2014.1.546...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [2.2.0] - 2024-08-24
+## [2.2.0] - 2024-09-03
 
 ### Added
 - Example to demonstrate BarSeries HitTest bug (#2038)


### PR DESCRIPTION
Changes to the changelog for 2.2.0. Went with 2.2.0 rather than 2.1.3 because of all the dependency changes and the couple of breaking changes; nothing too much to be excited about in this release.

Once finalised, will create branch release/v2.2.0 and push to nuget.

Would be nice to include https://github.com/oxyplot/oxyplot/pull/2099 but can always do a point release.

@oxyplot/admins
