### PR TITLE
Add the colorblind friendly Okabe-Ito color palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.3.0]
+
+### Added
+- Colorblind friendly Okabe-Ito color palette
+
 ## [2.2.0] - 2024-09-03
 
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -145,6 +145,7 @@ Udo Liess
 VisualMelon
 vhoehn <veit.hoehn@hte-company.de>
 Vsevolod Kukol <sevo@sevo.org>
+Wim Leflere <wim.leflere@gmail.com>
 Xavier <Xavier@xavier-PC.lsi>
 zur003 <Eric.Zurcher@csiro.au>
 Markus Ebner

--- a/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
@@ -7,6 +7,7 @@
 namespace ExampleLibrary
 {
     using OxyPlot;
+    using OxyPlot.Axes;
 
     [Examples("Palettes")]
     public class PaletteExamples
@@ -146,7 +147,23 @@ namespace ExampleLibrary
         [Example("Okabe-Ito palette")]
         public static PlotModel OkabeIto()
         {
-            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.OkabeIto, false);
+            var model = new PlotModel
+            {
+                Title = "Okabe-Ito palette",
+                DefaultColors = OxyPalettes.OkabeIto8.Colors
+            };
+
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+
+            foreach (var color in model.DefaultColors)
+            {
+                var lineSeries = LineSeriesExamples.CreateExampleLineSeries((int)color.ToUint());
+                lineSeries.Title = color.ToString().ToUpper().Replace("#FF", "#");
+                model.Series.Add(lineSeries);
+            }
+
+            return model;
         }
     }
 }

--- a/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
+++ b/Source/Examples/ExampleLibrary/Misc/PaletteExamples.cs
@@ -142,5 +142,11 @@ namespace ExampleLibrary
         {
             return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.Jet(6), false);
         }
+
+        [Example("Okabe-Ito palette")]
+        public static PlotModel OkabeIto()
+        {
+            return HeatMapSeriesExamples.CreatePeaks(OxyPalettes.OkabeIto, false);
+        }
     }
 }

--- a/Source/Examples/ExampleLibrary/Series/LineSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/LineSeriesExamples.cs
@@ -441,7 +441,7 @@ namespace ExampleLibrary
         /// Creates an example line series.
         /// </summary>
         /// <returns>A line series containing random points.</returns>
-        private static LineSeries CreateExampleLineSeries(int seed = 13)
+        public static LineSeries CreateExampleLineSeries(int seed = 13)
         {
             var lineSeries1 = new LineSeries();
             var r = new Random(seed);

--- a/Source/OxyPlot/Rendering/OxyPalettes.cs
+++ b/Source/OxyPlot/Rendering/OxyPalettes.cs
@@ -22,6 +22,15 @@ namespace OxyPlot
             BlueWhiteRed31 = BlueWhiteRed(31);
             Hot64 = Hot(64);
             Hue64 = Hue(64);
+            OkabeIto = new OxyPalette(
+                OxyColor.FromRgb(0, 0, 0),
+                OxyColor.FromRgb(230, 159, 0),
+                OxyColor.FromRgb(86, 180, 233),
+                OxyColor.FromRgb(0, 158, 115),
+                OxyColor.FromRgb(240, 228, 66),
+                OxyColor.FromRgb(0, 114, 178),
+                OxyColor.FromRgb(213, 94, 0),
+                OxyColor.FromRgb(204, 121, 167));
         }
 
         /// <summary>
@@ -38,6 +47,12 @@ namespace OxyPlot
         /// Gets the hue palette with 64 colors.
         /// </summary>
         public static OxyPalette Hue64 { get; private set; }
+
+        /// <summary>
+        /// Gets the Okabe-Ito colorblind friendly palette.
+        /// https://jfly.uni-koeln.de/color/
+        /// </summary>
+        public static OxyPalette OkabeIto { get; private set; }
 
         /// <summary>
         /// Creates a black/white/red palette with the specified number of colors.

--- a/Source/OxyPlot/Rendering/OxyPalettes.cs
+++ b/Source/OxyPlot/Rendering/OxyPalettes.cs
@@ -22,15 +22,7 @@ namespace OxyPlot
             BlueWhiteRed31 = BlueWhiteRed(31);
             Hot64 = Hot(64);
             Hue64 = Hue(64);
-            OkabeIto = new OxyPalette(
-                OxyColor.FromRgb(0, 0, 0),
-                OxyColor.FromRgb(230, 159, 0),
-                OxyColor.FromRgb(86, 180, 233),
-                OxyColor.FromRgb(0, 158, 115),
-                OxyColor.FromRgb(240, 228, 66),
-                OxyColor.FromRgb(0, 114, 178),
-                OxyColor.FromRgb(213, 94, 0),
-                OxyColor.FromRgb(204, 121, 167));
+            OkabeIto8 = OkabeIto(8);
         }
 
         /// <summary>
@@ -49,10 +41,10 @@ namespace OxyPlot
         public static OxyPalette Hue64 { get; private set; }
 
         /// <summary>
-        /// Gets the Okabe-Ito colorblind friendly palette.
+        /// Gets the Okabe-Ito colorblind friendly palette with 8 colors.
         /// https://jfly.uni-koeln.de/color/
         /// </summary>
-        public static OxyPalette OkabeIto { get; private set; }
+        public static OxyPalette OkabeIto8 { get; private set; }
 
         /// <summary>
         /// Creates a black/white/red palette with the specified number of colors.
@@ -179,6 +171,26 @@ namespace OxyPlot
                 OxyColors.Yellow,
                 OxyColors.Orange,
                 OxyColors.Red);
+        }
+
+        /// <summary>
+        /// Creates the Okabe-Ito colorblind friendly palette with the specified number of colors.
+        /// https://jfly.uni-koeln.de/color/
+        /// </summary>
+        /// <param name="numberOfColors">The number of colors to create for the palette.</param>
+        /// <returns>A palette.</returns>
+        public static OxyPalette OkabeIto(int numberOfColors)
+        {
+            return OxyPalette.Interpolate(
+                numberOfColors,
+                OxyColor.FromRgb(0, 0, 0),
+                OxyColor.FromRgb(230, 159, 0),
+                OxyColor.FromRgb(86, 180, 233),
+                OxyColor.FromRgb(0, 158, 115),
+                OxyColor.FromRgb(240, 228, 66),
+                OxyColor.FromRgb(0, 114, 178),
+                OxyColor.FromRgb(213, 94, 0),
+                OxyColor.FromRgb(204, 121, 167));
         }
     }
 }


### PR DESCRIPTION
### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Add the colorblind friendly Okabe-Ito color palette.

Based on the paper: "How to make figures and presentations that are friendly to Colorblind people"
Masataka Okabe - Kei Ito (2008)
https://jfly.uni-koeln.de/color/

@oxyplot/admins
