### PR TITLE
Add example with vertical bars in BarSeriesExamples.cs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [2.2.1] - 2024-12-11
+## Unreleased
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.2.1] - 2024-12-11
+
+### Added
+
+- Example to demonstrate how to create vertical BarSeries
+
 ## [2.2.0] - 2024-09-03
 
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -96,6 +96,7 @@ Matthew Leibowitz <mattleibow@live.com>
 Memphisch <memphis@machzwo.de>
 Mendel Monteiro-Beckerman
 Menno Deij - van Rijswijk <m.deij@marin.nl>
+Menno van der Woude <mennowo@gmail.com>
 methdotnet
 Michael Fox <16841316+foxmja@users.noreply.github.com>
 Michael Hieke <mghie@gmx.net>

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -63,24 +63,6 @@ namespace ExampleLibrary
             return model;
         }
 
-        [Example("With labels (vertical bars)")]
-        public static PlotModel WithLabelsVerticalBars()
-        {
-            var model = WithLabels();
-
-            foreach (BarSeries s in model.Series)
-            {
-                s.XAxisKey = "values";
-                s.YAxisKey = "categories";
-            }
-            model.Axes[0].Position = AxisPosition.Bottom;
-            model.Axes[0].Key = "categories";
-            model.Axes[1].Position = AxisPosition.Left;
-            model.Axes[1].Key = "values";
-
-            return model;
-        }
-
         [Example("With labels (at an angle)")]
         public static PlotModel WithLabelsAtAnAngle()
         {
@@ -98,6 +80,48 @@ namespace ExampleLibrary
         public static PlotModel WithLabelsXAxisReversed()
         {
             return WithLabels().ReverseXAxis();
+        }
+
+        [Example("With vertical bars")]
+        public static PlotModel WithVerticalBars()
+        {
+            var model = new PlotModel
+            {
+                Title = "With labels",
+            };
+
+            var rnd = new Random(1);
+            var series = new List<BarSeries>
+            {
+                new BarSeries { Title = "Base", XAxisKey = "values", YAxisKey = "categories" },
+                new BarSeries { Title = "Inside", XAxisKey = "values", YAxisKey = "categories" },
+                new BarSeries { Title = "Middle", XAxisKey = "values", YAxisKey = "categories" },
+                new BarSeries { Title = "Outside", XAxisKey = "values", YAxisKey = "categories" }
+            };
+
+            for (int i = 0; i < 4; i++)
+            {
+                foreach (var s in series)
+                {
+                    s.Items.Add(new BarItem() { Value = rnd.Next(-100, 100) });
+                }
+            }
+
+            var categoryAxis = new CategoryAxis { Position = AxisPosition.Bottom, Key = "categories" };
+            categoryAxis.Labels.Add("Category A");
+            categoryAxis.Labels.Add("Category B");
+            categoryAxis.Labels.Add("Category C");
+            categoryAxis.Labels.Add("Category D");
+            var valueAxis = new LinearAxis { Position = AxisPosition.Left, MinimumPadding = 0.06, MaximumPadding = 0.06, ExtraGridlines = new[] { 0d }, Key = "values" };
+
+            foreach (var s in series)
+            {
+                model.Series.Add(s);
+            }
+
+            model.Axes.Add(categoryAxis);
+            model.Axes.Add(valueAxis);
+            return model;
         }
 
         [Example("Stacked")]

--- a/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
+++ b/Source/Examples/ExampleLibrary/Series/BarSeriesExamples.cs
@@ -63,6 +63,24 @@ namespace ExampleLibrary
             return model;
         }
 
+        [Example("With labels (vertical bars)")]
+        public static PlotModel WithLabelsVerticalBars()
+        {
+            var model = WithLabels();
+
+            foreach (BarSeries s in model.Series)
+            {
+                s.XAxisKey = "values";
+                s.YAxisKey = "categories";
+            }
+            model.Axes[0].Position = AxisPosition.Bottom;
+            model.Axes[0].Key = "categories";
+            model.Axes[1].Position = AxisPosition.Left;
+            model.Axes[1].Key = "values";
+
+            return model;
+        }
+
         [Example("With labels (at an angle)")]
         public static PlotModel WithLabelsAtAnAngle()
         {


### PR DESCRIPTION
In the past, there was ColumnSeries, which could have the categories be placed on the X axis. The BarSeries explicitly needs them on the Y axis. The new example show how use `XAxisKey` and `YAxisKey` to have categories on bottom axis in the plot. There is no documentation for this, so it would be good example to have out there.

### Checklist

- [X] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add example for `BarSeries`, showing how to make it plot vertical bars

@oxyplot/admins
