### PR TITLE
Fix DateTimeAxis converting local time rather than UTC to TimeZone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 - Example to demonstrate how to create vertical BarSeries
 
+### Fixed
+- DateTimeAxis converting local time rather than UTC to TimeZone
+
 ## [2.2.0] - 2024-09-03
 
 ### Added

--- a/Source/Examples/ExampleLibrary/Axes/DateTimeAxisExamples.cs
+++ b/Source/Examples/ExampleLibrary/Axes/DateTimeAxisExamples.cs
@@ -80,31 +80,74 @@ namespace ExampleLibrary
             return tmp;
         }
 
-        [Example("TimeZone adjustments")]
+        [Example("TimeZone")]
         public static PlotModel DaylightSavingsBreak()
         {
-            var m = new PlotModel();
+            var timeZone = TimeZoneInfo.CreateCustomTimeZone(
+                id: "Example Time",
+                baseUtcOffset: TimeSpan.FromHours(-1),
+                displayName: "(UTC-01:00) Example Time",
+                standardDisplayName: "Example Standard Time",
+                daylightDisplayName: "Example Daylight Time",
+                new TimeZoneInfo.AdjustmentRule[]
+                {
+                    TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+                        DateTime.MinValue.Date,
+                        DateTime.MaxValue.Date,
+                        daylightDelta: TimeSpan.FromHours(1),
+                        daylightTransitionStart: TimeZoneInfo.TransitionTime.CreateFixedDateRule(
+                            timeOfDay: new DateTime(1, 1, 1, 2, 0, 0),
+                            month: 3,
+                            day: 1),
+                        daylightTransitionEnd: TimeZoneInfo.TransitionTime.CreateFixedDateRule(
+                            timeOfDay: new DateTime(1, 1, 1, 2, 0, 0),
+                            month: 11,
+                            day: 1))
+                });
 
-            var xa = new DateTimeAxis { Position = AxisPosition.Bottom };
-            // TimeZone not available in PCL...
+            var start = TimeZoneInfo.ConvertTimeToUtc(new DateTime(2000, 3, 1, 0, 0, 0), timeZone);
+            var end = TimeZoneInfo.ConvertTimeToUtc(new DateTime(2000, 3, 1, 5, 0, 0), timeZone);
 
-            m.Axes.Add(xa);
-            m.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-            var ls = new LineSeries { MarkerType = MarkerType.Circle };
-            m.Series.Add(ls);
-
-            // set the origin of the curve to 2013-03-31 00:00:00 (UTC)
-            var o = new DateTime(2013, 3, 31, 0, 0, 0, DateTimeKind.Utc);
-
-            // add points at 10min intervals
-            // at 2am the clocks are turned forward 1 hour (W. Europe Standard Time)
-            for (int i = 0; i < 400; i += 10)
+            var items = new List<DataPoint>();
+            var date = start;
+            double y = 0;
+            while (date <= end)
             {
-                var time = o.AddMinutes(i);
-                ls.Points.Add(DateTimeAxis.CreateDataPoint(time, i));
+                items.Add(new DataPoint(DateTimeAxis.ToDouble(date), y));
+                date = date.AddHours(0.25);
+                y += 0.25;
             }
 
-            return m;
+            var plotModel = new PlotModel()
+            {
+                Title = "DateTimeAxis with TimeZone at DST Transition",
+                Subtitle = "Time goes from 0:00 to 5:00 and jumps from 1:59 to 3:00",
+                Axes =
+                {
+                    new LinearAxis
+                    {
+                        Position = AxisPosition.Left,
+                        MajorGridlineStyle = LineStyle.Solid,
+                        Unit = "Hours",
+                    },
+                    new DateTimeAxis
+                    {
+                        Position = AxisPosition.Bottom,
+                        MajorGridlineStyle = LineStyle.Solid,
+                        TimeZone = timeZone,
+                    },
+                },
+                Series =
+                {
+                    new LineSeries
+                    {
+                        MarkerType = MarkerType.Circle,
+                        ItemsSource = items,
+                    },
+                },
+            };
+
+            return plotModel;
         }
 
         public class Item

--- a/Source/OxyPlot/Axes/DateTimeAxis.cs
+++ b/Source/OxyPlot/Axes/DateTimeAxis.cs
@@ -170,7 +170,7 @@ namespace OxyPlot.Axes
                 precisionIntervals += 1;
             }
 
-            return new DateTime(precisionIntervals * precision.Ticks);
+            return new DateTime(precisionIntervals * precision.Ticks, preliminaryDateTime.Kind);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes problem introduced by #2089 which caused the `DateTime` being converted to lose its `Kind`. 

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix regression introduced in v2.2.0

@oxyplot/admins
