### PR TITLE
Perform clean-up tasks for 2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,16 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Target .NET 10, remove target .NET 6 (out of support and incompatible with nuget updates)
-- Various nuget package upgrades
-- Updated DotNet.ReproducibleBuilds and DotNet.ReproducibleBuilds.Isolated to 2.0.5
+- Update ImageSharp to 3.1.11
+- Update ImageSharp.Drawing to 2.1.4
+- Update SkiaSharp.Views.Desktop.Common to 3.119.2
+- Update SkiaSharp to 3.199.2
+- Update SkiaSharp.HarfBuzz to 3.199.2
+- Update Microsoft.NET.Test.Sdk to 17.13.10
+- Update NUnit to 4.5.1
+- Update NUnit3TestAdapter to 6.2.0
+- Update NSubstitute to 5.3.0
+- Update DotNet.ReproducibleBuilds and DotNet.ReproducibleBuilds.Isolated to 2.0.5 and remove redundant package references
 
 ## [2.2.0] - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Target .NET 10, remove target .NET 6 (out of support and incompatible with nuget updates)
 - Various nuget package upgrades
+- Updated DotNet.ReproducibleBuilds and DotNet.ReproducibleBuilds.Isolated to 2.0.5
 
 ## [2.2.0] - 2024-09-03
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
-  <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="1.1.1" />
+  <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="2.0.5" />
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.5" PrivateAssets="All"/>
   </ItemGroup>
   <PropertyGroup>
     <Copyright>Copyright (c) 2014-2022 OxyPlot Contributors</Copyright>

--- a/Source/Examples/ExampleGenerator/ExampleGenerator.csproj
+++ b/Source/Examples/ExampleGenerator/ExampleGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net8.0-windows</TargetFrameworks>
         <!--<UseWindowsForms>true</UseWindowsForms>-->
         <OutputType>Exe</OutputType>
         <ApplicationIcon />

--- a/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
@@ -25,7 +25,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\OxyPlot\OxyPlot.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-  </ItemGroup>
 </Project>

--- a/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
+++ b/Source/Examples/ExampleLibrary/ExampleLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0;net10.0</TargetFrameworks>
     <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
     <PackageId>OxyPlot.ExampleLibrary</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Source/Examples/PerformanceTest/PerformanceTest.csproj
+++ b/Source/Examples/PerformanceTest/PerformanceTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <ApplicationIcon />
         <StartupObject />

--- a/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.WPF.csproj
+++ b/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <OutputType>WinExe</OutputType>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
+++ b/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
+      <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
       <UseWPF>true</UseWPF>
       <UseWindowsForms>true</UseWindowsForms>
       <OutputType>WinExe</OutputType>

--- a/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
+++ b/Source/Examples/WindowsForms/ExampleBrowser/ExampleBrowser.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
+++ b/Source/OxyPlot.SkiaSharp.Tests/OxyPlot.SkiaSharp.Tests.csproj
@@ -27,7 +27,4 @@
         <PackageReference Include="NUnit" Version="4.5.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-    </ItemGroup>
 </Project>

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows7.0;net8.0-windows7.0;net10.0-windows7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows7.0;net10.0-windows7.0</TargetFrameworks>
     <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
     <UseWPF>true</UseWPF>
     <Description>OxyPlot is a plotting library for .NET. This package targets WPF applications and uses the SkiaSharp renderer.</Description>

--- a/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
+++ b/Source/OxyPlot.SkiaSharp.Wpf/OxyPlot.SkiaSharp.Wpf.csproj
@@ -21,7 +21,4 @@
     <ProjectReference Include="..\OxyPlot.Wpf.Shared\OxyPlot.Wpf.Shared.csproj" />
     <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-  </ItemGroup>
 </Project>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -23,7 +23,4 @@
   <ItemGroup>
     <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-  </ItemGroup>
 </Project>

--- a/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
+++ b/Source/OxyPlot.SkiaSharp/OxyPlot.SkiaSharp.csproj
@@ -3,7 +3,7 @@
     <LangVersion>8</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright (c) 2020 OxyPlot contributors</Copyright>
-    <TargetFrameworks>net462;netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
     <Authors>OxyPlot contributors</Authors>
     <Description>OxyPlot is a plotting library for .NET. This package provides rendering based on SkiaSharp.</Description>

--- a/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
+++ b/Source/OxyPlot.Tests/OxyPlot.Tests.csproj
@@ -51,7 +51,4 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-    </ItemGroup>
 </Project>

--- a/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
+++ b/Source/OxyPlot.WindowsForms/OxyPlot.WindowsForms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows7.0;net8.0-windows7.0</TargetFrameworks>
+        <TargetFrameworks>net462;net8.0-windows7.0</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <Description>OxyPlot is a plotting library for .NET. This package targets Windows Forms applications.</Description>
         <PackageTags>plotting plot charting chart</PackageTags>

--- a/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
+++ b/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows7.0;net8.0-windows7.0;net10.0-windows7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows7.0;net10.0-windows7.0</TargetFrameworks>
     <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
     <UseWPF>true</UseWPF>
     <LangVersion>14</LangVersion>

--- a/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
+++ b/Source/OxyPlot.Wpf.Shared/OxyPlot.Wpf.Shared.csproj
@@ -17,7 +17,4 @@
   <ItemGroup>
     <ProjectReference Include="..\OxyPlot\OxyPlot.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-  </ItemGroup>
 </Project>

--- a/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
+++ b/Source/OxyPlot.Wpf.Tests/OxyPlot.Wpf.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <Description>OxyPlot WPF unit tests</Description>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
+++ b/Source/OxyPlot.Wpf/OxyPlot.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows7.0;net8.0-windows7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows7.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>OxyPlot.Wpf.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net462;net8.0;net10.0</TargetFrameworks>
         <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
         <PackageId>OxyPlot.Core</PackageId>
         <Description>OxyPlot is a plotting library for .NET. This is the core library including the foundation classes and plot model. To display the plots, you also need to add a platform-specific OxyPlot package that contains a PlotView component.</Description>

--- a/Source/OxyPlot/OxyPlot.csproj
+++ b/Source/OxyPlot/OxyPlot.csproj
@@ -16,7 +16,4 @@
     <ItemGroup>
         <None Include="OxyPlot.snk" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issues raised in #2.2.1 that do not belong in a release PR

### Checklist

- [/] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove redundant references to Dotnet.Reproducible builds and bump it to 2.0.5 (latest)
- List versions of updated third-party packages in changelog
- Remove remaining references to .NET 6, which is out of support

@oxyplot/admins
